### PR TITLE
Remove unused variable eol

### DIFF
--- a/c/input/lrec_reader_mmap_csv.c
+++ b/c/input/lrec_reader_mmap_csv.c
@@ -56,12 +56,10 @@ static slls_t* lrec_reader_mmap_csv_get_header(file_reader_mmap_state_t* phandle
 	}
 
 	char* header_name = phandle->sol;
-	char* eol         = NULL;
 
 	for (char* p = phandle->sol; p < phandle->eof && *p; ) {
 		if (*p == irs) {
 			*p = 0;
-			eol = p;
 			phandle->sol = p+1;
 			pstate->ilno++;
 			break;
@@ -100,7 +98,6 @@ static lrec_t* lrec_reader_mmap_csv_get_record(file_reader_mmap_state_t* phandle
 	char* line  = phandle->sol;
 	char* key   = NULL;
 	char* value = line;
-	char* eol   = NULL;
 
 	sllse_t* pe = pheader_keeper->pkeys->phead;
 	for (char* p = line; p < phandle->eof && *p; ) {
@@ -110,7 +107,6 @@ static lrec_t* lrec_reader_mmap_csv_get_record(file_reader_mmap_state_t* phandle
 				return NULL;
 			}
 			*p = 0;
-			eol = p;
 			phandle->sol = p+1;
 			break;
 		} else if (*p == ifs) {

--- a/c/input/lrec_reader_mmap_dkvp.c
+++ b/c/input/lrec_reader_mmap_dkvp.c
@@ -50,13 +50,11 @@ lrec_t* lrec_parse_mmap_dkvp(file_reader_mmap_state_t *phandle, char irs, char i
 	char* line  = phandle->sol;
 	char* key   = line;
 	char* value = line;
-	char* eol   = NULL;
 
 	int idx = 0;
 	for (char* p = line; p < phandle->eof && *p; ) {
 		if (*p == irs) {
 			*p = 0;
-			eol = p;
 			phandle->sol = p+1;
 			break;
 		} else if (*p == ifs) {

--- a/c/input/lrec_reader_mmap_nidx.c
+++ b/c/input/lrec_reader_mmap_nidx.c
@@ -48,13 +48,11 @@ lrec_t* lrec_parse_mmap_nidx(file_reader_mmap_state_t *phandle, char irs, char i
 	int idx = 0;
 	char* key   = NULL;
 	char* value = line;
-	char* eol   = NULL;
 	char free_flags = 0;
 
 	for (char* p = line; p < phandle->eof && *p; ) {
 		if (*p == irs) {
 			*p = 0;
-			eol = p;
 			phandle->sol = p+1;
 			break;
 		} else if (*p == ifs) {

--- a/c/input/lrec_reader_mmap_xtab.c
+++ b/c/input/lrec_reader_mmap_xtab.c
@@ -60,14 +60,12 @@ lrec_t* lrec_parse_mmap_xtab(file_reader_mmap_state_t* phandle, char irs, char i
 		char* line  = phandle->sol;
 		char* key   = line;
 		char* value = "";
-		char* eol   = NULL;
 		char* p;
 
 		// Construct one field
 		for (p = line; p < phandle->eof && *p; ) {
 			if (*p == irs) {
 				*p = 0;
-				eol = p;
 				phandle->sol = p+1;
 				break;
 			} else if (*p == ips) {


### PR DESCRIPTION
This removes the unused eol variable.

In my case the warnings due to the eol variable resulted in a build error:
```
input/lrec_reader_mmap_csv.c: In function ‘lrec_reader_mmap_csv_get_header’:
input/lrec_reader_mmap_csv.c:59:8: error: variable ‘eol’ set but not used [-Werror=unused-but-set-variable]
  char* eol         = NULL;
        ^
input/lrec_reader_mmap_csv.c: In function ‘lrec_reader_mmap_csv_get_record’:
input/lrec_reader_mmap_csv.c:103:8: error: variable ‘eol’ set but not used [-Werror=unused-but-set-variable]
  char* eol   = NULL;
        ^
cc1: all warnings being treated as errors
input/lrec_reader_mmap_dkvp.c: In function ‘lrec_parse_mmap_dkvp’:
input/lrec_reader_mmap_dkvp.c:53:8: error: variable ‘eol’ set but not used [-Werror=unused-but-set-variable]
  char* eol   = NULL;
        ^
cc1: all warnings being treated as errors
input/lrec_reader_mmap_nidx.c: In function ‘lrec_parse_mmap_nidx’:
input/lrec_reader_mmap_nidx.c:51:8: error: variable ‘eol’ set but not used [-Werror=unused-but-set-variable]
  char* eol   = NULL;
        ^
cc1: all warnings being treated as errors
input/lrec_reader_mmap_xtab.c: In function ‘lrec_parse_mmap_xtab’:
input/lrec_reader_mmap_xtab.c:63:9: error: variable ‘eol’ set but not used [-Werror=unused-but-set-variable]
   char* eol   = NULL;
         ^
cc1: all warnings being treated as errors
make[1]: *** [mlr] Error 1
make[1]: Leaving directory `/path/to/miller/c'
```