### PR TITLE
Deletion of unnecessary checks before some function calls

### DIFF
--- a/c/containers/header_keeper.c
+++ b/c/containers/header_keeper.c
@@ -11,8 +11,7 @@ header_keeper_t* header_keeper_alloc(char* line, slls_t* pkeys) {
 }
 
 void header_keeper_free(header_keeper_t* pheader_keeper) {
-	if (pheader_keeper->line != NULL)
-		free(pheader_keeper->line);
+	free(pheader_keeper->line);
 	slls_free(pheader_keeper->pkeys);
 	free(pheader_keeper);
 }

--- a/c/containers/lhmsi.c
+++ b/c/containers/lhmsi.c
@@ -82,8 +82,7 @@ void lhmsi_free(lhmsi_t* pmap) {
 	if (pmap == NULL)
 		return;
 	for (lhmsie_t* pe = pmap->phead; pe != NULL; pe = pe->pnext) {
-		if (pe->key != NULL)
-			free(pe->key);
+		free(pe->key);
 	}
 	free(pmap->entries);
 	pmap->entries      = NULL;

--- a/c/containers/lhmss.c
+++ b/c/containers/lhmss.c
@@ -81,10 +81,8 @@ void lhmss_free(lhmss_t* pmap) {
 	if (pmap == NULL)
 		return;
 	for (lhmsse_t* pe = pmap->phead; pe != NULL; pe = pe->pnext) {
-		if (pe->key != NULL)
-			free(pe->key);
-		if (pe->value != NULL)
-			free(pe->value);
+		free(pe->key);
+		free(pe->value);
 	}
 	free(pmap->entries);
 	pmap->entries      = NULL;

--- a/c/containers/lhmsv.c
+++ b/c/containers/lhmsv.c
@@ -74,8 +74,7 @@ void lhmsv_free(lhmsv_t* pmap) {
 	if (pmap == NULL)
 		return;
 	for (lhmsve_t* pe = pmap->phead; pe != NULL; pe = pe->pnext) {
-		if (pe->key != NULL)
-			free(pe->key);
+		free(pe->key);
 	}
 	free(pmap->entries);
 	pmap->entries      = NULL;

--- a/c/containers/lrec.c
+++ b/c/containers/lrec.c
@@ -140,8 +140,7 @@ void lrec_remove(lrec_t* prec, char* key) {
 		free(pe->key);
 	}
 	if (pe->free_flags & LREC_FREE_ENTRY_VALUE) {
-		if (pe->value != NULL)
-			free(pe->value);
+		free(pe->value);
 	}
 
 	free(pe);

--- a/c/containers/percentile_keeper.c
+++ b/c/containers/percentile_keeper.c
@@ -19,10 +19,8 @@ percentile_keeper_t* percentile_keeper_alloc() {
 
 // ----------------------------------------------------------------
 void percentile_keeper_free(percentile_keeper_t* ppercentile_keeper) {
-	if (ppercentile_keeper->data != NULL) {
-		free(ppercentile_keeper->data);
-		ppercentile_keeper->data = NULL;
-	}
+	free(ppercentile_keeper->data);
+	ppercentile_keeper->data = NULL;
 	ppercentile_keeper->size = 0;
 	ppercentile_keeper->capacity = 0;
 	free(ppercentile_keeper);

--- a/c/containers/top_keeper.c
+++ b/c/containers/top_keeper.c
@@ -15,14 +15,10 @@ top_keeper_t* top_keeper_alloc(int capacity) {
 
 // ----------------------------------------------------------------
 void top_keeper_free(top_keeper_t* ptop_keeper) {
-	if (ptop_keeper->top_values != NULL) {
-		free(ptop_keeper->top_values);
-		ptop_keeper->top_values = NULL;
-	}
-	if (ptop_keeper->top_precords != NULL) {
-		free(ptop_keeper->top_precords);
-		ptop_keeper->top_precords = NULL;
-	}
+	free(ptop_keeper->top_values);
+	ptop_keeper->top_values = NULL;
+	free(ptop_keeper->top_precords);
+	ptop_keeper->top_precords = NULL;
 	ptop_keeper->size = 0;
 	ptop_keeper->capacity = 0;
 	free(ptop_keeper);

--- a/c/dsls/lemon.c
+++ b/c/dsls/lemon.c
@@ -2577,7 +2577,7 @@ PRIVATE FILE *file_open(struct lemon *lemp, char *suffix, char *mode)
 {
 	FILE *fp;
 
-	if (lemp->outname)  free(lemp->outname);
+	free(lemp->outname);
 	lemp->outname = file_makename(lemp, suffix);
 	fp = fopen(lemp->outname,mode);
 	if (fp==0 && *mode=='w') {

--- a/c/mapping/mapper_cut.c
+++ b/c/mapping/mapper_cut.c
@@ -56,8 +56,7 @@ static void mapper_cut_free(void* pvstate) {
 	mapper_cut_state_t* pstate = (mapper_cut_state_t*)pvstate;
 	if (pstate->pfield_name_list != NULL)
 		slls_free(pstate->pfield_name_list);
-	if (pstate->pfield_name_set != NULL)
-		hss_free(pstate->pfield_name_set);
+	hss_free(pstate->pfield_name_set);
 }
 
 static mapper_t* mapper_cut_alloc(slls_t* pfield_name_list, int do_arg_order, int do_complement) {

--- a/c/mapping/mapper_group_like.c
+++ b/c/mapping/mapper_group_like.c
@@ -44,11 +44,11 @@ static sllv_t* mapper_group_like_process(lrec_t* pinrec, context_t* pctx, void* 
 // ----------------------------------------------------------------
 static void mapper_group_like_free(void* pvstate) {
 	mapper_group_like_state_t* pstate = (mapper_group_like_state_t*)pvstate;
-	if (pstate->precords_by_key_field_names != NULL)
-		// xxx check for full recursive free
-		// xxx in lhmslv & more general outermost readme, articulate the philosophy that containers
-		// will free contents except for void-stars.
-		lhmslv_free(pstate->precords_by_key_field_names);
+
+	// xxx check for full recursive free
+	// xxx in lhmslv & more general outermost readme, articulate the philosophy that containers
+	// will free contents except for void-stars.
+	lhmslv_free(pstate->precords_by_key_field_names);
 }
 
 static mapper_t* mapper_group_like_alloc() {

--- a/c/mapping/mapper_having_fields.c
+++ b/c/mapping/mapper_having_fields.c
@@ -66,8 +66,7 @@ static void mapper_having_fields_free(void* pvstate) {
 	mapper_having_fields_state_t* pstate = (mapper_having_fields_state_t*)pvstate;
 	if (pstate->pfield_names != NULL)
 		slls_free(pstate->pfield_names);
-	if (pstate->pfield_name_set != NULL)
-		lhmsi_free(pstate->pfield_name_set);
+	lhmsi_free(pstate->pfield_name_set);
 }
 
 static mapper_t* mapper_having_fields_alloc(slls_t* pfield_names, int criterion) {

--- a/c/mapping/mapper_head.c
+++ b/c/mapping/mapper_head.c
@@ -48,9 +48,9 @@ static void mapper_head_free(void* pvstate) {
 	mapper_head_state_t* pstate = (mapper_head_state_t*)pvstate;
 	if (pstate->pgroup_by_field_names != NULL)
 		slls_free(pstate->pgroup_by_field_names);
-	if (pstate->precord_lists_by_group != NULL)
-		// xxx recursively free void-stars ... here & elsewhere.
-		lhmslv_free(pstate->precord_lists_by_group);
+
+	// xxx recursively free void-stars ... here & elsewhere.
+	lhmslv_free(pstate->precord_lists_by_group);
 }
 
 static mapper_t* mapper_head_alloc(slls_t* pgroup_by_field_names, unsigned long long head_count) {

--- a/c/mapping/mapper_histogram.c
+++ b/c/mapping/mapper_histogram.c
@@ -101,8 +101,7 @@ static void mapper_histogram_free(void* pvstate) {
 	mapper_histogram_state_t* pstate = (mapper_histogram_state_t*)pvstate;
 	if (pstate->value_field_names != NULL)
 		slls_free(pstate->value_field_names);
-	if (pstate->pcounts_by_field != NULL)
-		lhmsv_free(pstate->pcounts_by_field);
+	lhmsv_free(pstate->pcounts_by_field);
 }
 
 static mapper_t* mapper_histogram_alloc(slls_t* value_field_names, double lo, int nbins, double hi) {

--- a/c/mapping/mapper_put.c
+++ b/c/mapping/mapper_put.c
@@ -34,11 +34,9 @@ static sllv_t* mapper_put_process(lrec_t* pinrec, context_t* pctx, void* pvstate
 // ----------------------------------------------------------------
 static void mapper_put_free(void* pvstate) {
 	mapper_put_state_t* pstate = (mapper_put_state_t*)pvstate;
-	if (pstate->output_field_names != NULL)
-		free(pstate->output_field_names);
+	free(pstate->output_field_names);
 	// xxx recursively free them.
-	if (pstate->pevaluators != NULL)
-		free(pstate->pevaluators);
+	free(pstate->pevaluators);
 }
 
 // xxx comment me ...

--- a/c/mapping/mapper_regularize.c
+++ b/c/mapping/mapper_regularize.c
@@ -36,8 +36,7 @@ static sllv_t* mapper_regularize_process(lrec_t* pinrec, context_t* pctx, void* 
 // ----------------------------------------------------------------
 static void mapper_regularize_free(void* pvstate) {
 	mapper_regularize_state_t* pstate = (mapper_regularize_state_t*)pvstate;
-	if (pstate->psorted_to_original != NULL)
-		lhmslv_free(pstate->psorted_to_original);
+	lhmslv_free(pstate->psorted_to_original);
 }
 
 static mapper_t* mapper_regularize_alloc() {

--- a/c/mapping/mapper_rename.c
+++ b/c/mapping/mapper_rename.c
@@ -29,8 +29,7 @@ static sllv_t* mapper_rename_process(lrec_t* pinrec, context_t* pctx, void* pvst
 // ----------------------------------------------------------------
 static void mapper_rename_free(void* pvstate) {
 	mapper_rename_state_t* pstate = (mapper_rename_state_t*)pvstate;
-	if (pstate->pold_to_new != NULL)
-		lhmss_free(pstate->pold_to_new);
+	lhmss_free(pstate->pold_to_new);
 }
 
 static mapper_t* mapper_rename_alloc(lhmss_t* pold_to_new) {

--- a/c/mapping/mapper_sort.c
+++ b/c/mapping/mapper_sort.c
@@ -206,9 +206,9 @@ static void mapper_sort_free(void* pvstate) {
 	mapper_sort_state_t* pstate = pvstate;
 	if (pstate->pkey_field_names != NULL)
 		slls_free(pstate->pkey_field_names);
-	if (pstate->pbuckets_by_key_field_names != NULL)
-		// xxx free void-star payloads 1st
-		lhmslv_free(pstate->pbuckets_by_key_field_names);
+
+	// xxx free void-star payloads 1st
+	lhmslv_free(pstate->pbuckets_by_key_field_names);
 	free(pstate->sort_params);
 }
 

--- a/c/mapping/mapper_sort.c
+++ b/c/mapping/mapper_sort.c
@@ -209,8 +209,7 @@ static void mapper_sort_free(void* pvstate) {
 	if (pstate->pbuckets_by_key_field_names != NULL)
 		// xxx free void-star payloads 1st
 		lhmslv_free(pstate->pbuckets_by_key_field_names);
-	if (pstate->sort_params != NULL)
-		free(pstate->sort_params);
+	free(pstate->sort_params);
 }
 
 static mapper_t* mapper_sort_alloc(slls_t* pkey_field_names, int* sort_params, int do_sort) {

--- a/c/mapping/mapper_tail.c
+++ b/c/mapping/mapper_tail.c
@@ -30,8 +30,7 @@ static sllv_t* mapper_tail_process(lrec_t* pinrec, context_t* pctx, void* pvstat
 		}
 		if (precord_list_for_group->length >= pstate->tail_count) {
 			lrec_t* porec = sllv_pop(precord_list_for_group);
-			if (porec != NULL)
-				lrec_free(porec);
+			lrec_free(porec);
 		}
 		sllv_add(precord_list_for_group, pinrec);
 
@@ -56,9 +55,9 @@ static void mapper_tail_free(void* pvstate) {
 	mapper_tail_state_t* pstate = pvstate;
 	if (pstate->pgroup_by_field_names != NULL)
 		slls_free(pstate->pgroup_by_field_names);
-	if (pstate->precord_lists_by_group != NULL)
-		// xxx free the void-star payloads 1st
-		lhmslv_free(pstate->precord_lists_by_group);
+
+	// xxx free the void-star payloads 1st
+	lhmslv_free(pstate->precord_lists_by_group);
 }
 
 static mapper_t* mapper_tail_alloc(slls_t* pgroup_by_field_names, unsigned long long tail_count) {


### PR DESCRIPTION
* [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer. Redundant safety checks can be avoided.
* The following functions perform also input parameter validation.
  * hss_free
  * lhmsi_free
  * lhmslv_free
  * lhmsv_free
  * lrec_free

  It is therefore not needed that a function caller repeats a corresponding check.