### PR TITLE
update install path

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -10,7 +10,7 @@ LFLAGS=-lm
 #   make -e INSTALLDIR=/usr/local/bin
 #
 # pending https://github.com/johnkerl/miller/issues/9
-INSTALLDIR=$(HOME)/bin
+INSTALLDIR=/usr/local/bin
 
 CC=$(CCOMP) $(CFLAGS) $(IFLAGS) $(WFLAGS) -O3
 #CCDEBUG=$(CCOMP) -g -O1 $(CFLAGS) $(IFLAGS) $(WFLAGS)


### PR DESCRIPTION
Hello,

I see that one can specify the install path with
`make -e INSTALLDIR=/usr/local/bin` but I think it's far better if
`/usr/local/bin/` is the default and anything else can be specified.
If one were to  `sudo make install`, the file will end up in /root/ and you
certainly don't want root priv to execute the file.

Thanks for the consideration!