### PR TITLE
Replace timegm

### DIFF
--- a/c/lib/mlrutil.c
+++ b/c/lib/mlrutil.c
@@ -241,3 +241,24 @@ char* mlr_get_line(FILE* input_stream, char rs) {
 
 	return line;
 }
+
+time_t mlr_timegm (struct tm* tm) {
+	time_t ret;
+	char* tz;
+
+	tz = getenv("TZ");
+	if (tz) {
+		tz = strdup(tz);
+	}
+	setenv("TZ", "GMT0", 1);
+	tzset();
+	ret = mktime(tm);
+	if (tz) {
+		setenv("TZ", tz, 1);
+		free(tz);
+	} else {
+		unsetenv("TZ");
+	}
+	tzset();
+	return ret;
+}

--- a/c/lib/mlrutil.h
+++ b/c/lib/mlrutil.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define TRUE  1
 #define FALSE 0
@@ -55,5 +56,8 @@ int mlr_string_pair_hash_func(char* str1, char* str2);
 
 // xxx cmt mem mgt
 char* mlr_get_line(FILE* input_stream, char rs);
+
+// portable timegm replacement
+time_t mlr_timegm (struct tm *tm);
 
 #endif // MLRUTIL_H

--- a/c/mapping/mlr_val.c
+++ b/c/mapping/mlr_val.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "lib/mlr_globals.h"
+#include "lib/mlrutil.h"
 #include "mapping/mlr_val.h"
 
 // For some Linux distros, in spite of including time.h:
@@ -246,7 +247,7 @@ mv_t i_s_gmt2sec_func(mv_t* pval1) {
 		return MV_NULL;
 	} else {
 		strptime(pval1->u.strv, "%Y-%m-%dT%H:%M:%SZ", &tm);
-		time_t t = timegm(&tm);
+		time_t t = mlr_timegm(&tm);
 
 		mv_t rv = {.type = MT_INT, .u.intv = (long long)t};
 		return rv;


### PR DESCRIPTION
This PR adds mlr_timegm function and replace timegm with mlr_timegm. (Issue #20)