### PR TITLE
use generic shell

### DIFF
--- a/c/test/run
+++ b/c/test/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # NEEDING COVERAGE:
 # group-like


### PR DESCRIPTION
not everyone has bash installed and if they do, this path may not be correct.
I think it's better to use the more universal shell, sh. Not as exciting but more
deployed.