### PR TITLE
Cast is*/to* arguments to proper type.

### DIFF
--- a/c/input/peek_file_reader.c
+++ b/c/input/peek_file_reader.c
@@ -84,7 +84,7 @@ void pfr_dump(peek_file_reader_t* pfr) {
 	printf("  npeeked    = %d\n", pfr->npeeked);
 	for (int i = 0; i < pfr->npeeked; i++) {
 		char c = pfr->peekbuf[i];
-		printf("  i=%d c=%c [%02x]\n", i, isprint(c) ? c : ' ', c);
+		printf("  i=%d c=%c [%02x]\n", i, isprint((unsigned char)c) ? c : ' ', c);
 	}
 	printf("------------------------\n");
 }

--- a/c/mapping/mlr_val.c
+++ b/c/mapping/mlr_val.c
@@ -200,7 +200,7 @@ mv_t s_sss_sub_func(mv_t* pval1, mv_t* pval2, mv_t* pval3) {
 mv_t s_s_tolower_func(mv_t* pval1) {
 	char* string = strdup(pval1->u.strv);
 	for (char* c = string; *c; c++)
-		*c = tolower(*c);
+		*c = tolower((unsigned char)*c);
 	// xxx encapsulate this:
 	free(pval1->u.strv);
 	pval1->u.strv = NULL;
@@ -213,7 +213,7 @@ mv_t s_s_tolower_func(mv_t* pval1) {
 mv_t s_s_toupper_func(mv_t* pval1) {
 	char* string = strdup(pval1->u.strv);
 	for (char* c = string; *c; c++)
-		*c = toupper(*c);
+		*c = toupper((unsigned char)*c);
 	// xxx encapsulate this:
 	free(pval1->u.strv);
 	pval1->u.strv = NULL;


### PR DESCRIPTION
Fixes
error: array subscript has type ‘char’ [-Werror=char-subscripts]
on NetBSD, which is picky about its ctype(3) function arguments.