### PR TITLE
Miller available for freeBSD!

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Distros](https://img.shields.io/badge/distros-ubuntu-db4923.svg)](https://launchpad.net/ubuntu/xenial/+package/miller)
 [![Distros](https://img.shields.io/badge/distros-debian-c70036.svg)](https://buildd.debian.org/status/package.php?p=miller)
 [![Distros](https://img.shields.io/badge/distros-netbsd-f26711.svg)](http://pkgsrc.se/textproc/miller)
-[![Distros](https://img.shields.io/badge/distros-freebsd-a0a0a0.svg)](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206785)
+[![Distros](https://img.shields.io/badge/distros-freebsd-a0a0a0.svg)](https://www.freshports.org/textproc/miller/)
 [![Distros](https://img.shields.io/badge/distros-prolinux-3a679d.svg)](http://www.pro-linux.de/cgi-bin/DBApp/check.cgi?ShowApp..20427.100)
 [![Distros](https://img.shields.io/badge/distros-archlinux-1792d0.svg)](https://aur.archlinux.org/packages/miller-git)
 [![Distros](https://img.shields.io/badge/distros-macosxbrew-ba832b.svg)](https://github.com/Homebrew/homebrew/search?utf8=%E2%9C%93&q=miller)


### PR DESCRIPTION
Update link to direct to freshports.org, a site well known for port/package information. Even though this site is not an official freeBSD.org or freebsd foundation managed site, it's well used by many to search for ports/packages.