### PR TITLE
Minor typo in reference

### DIFF
--- a/doc/content-for-reference.html
+++ b/doc/content-for-reference.html
@@ -96,7 +96,7 @@ POKI_RUN_COMMAND{{mlr sort --help}}HERE
   --nidx    --inidx    --onidx
   --csv     --icsv     --ocsv
   --csvlite --icsvlite --ocsvlite
-  --pprint  --ipprint  --ppprint  --right
+  --pprint  --ipprint  --opprint  --right
   --xtab    --ixtab    --oxtab
   --json    --ijson    --ojson
 </pre>

--- a/doc/reference.html
+++ b/doc/reference.html
@@ -652,7 +652,7 @@ which is the same as:
   --nidx    --inidx    --onidx
   --csv     --icsv     --ocsv
   --csvlite --icsvlite --ocsvlite
-  --pprint  --ipprint  --ppprint  --right
+  --pprint  --ipprint  --opprint  --right
   --xtab    --ixtab    --oxtab
   --json    --ijson    --ojson
 </pre>


### PR DESCRIPTION
`ppprint` ➡️ `opprint`