### PR TITLE
no -v on openbsd

### DIFF
--- a/c/reg_test/run
+++ b/c/reg_test/run
@@ -52,7 +52,7 @@ outfile=$outdir/out
 expfile=$expdir/out
 mkdir -p $outdir
 
-rm -rvf $outdir
+rm -rf $outdir
 mkdir -p $outdir
 touch $outfile
 echo


### PR DESCRIPTION
Like commit https://github.com/johnkerl/miller/commit/9dcb6f2c8f4f6f2faa24f5350b188d5baa7a6200, openbsd doesn't have a verbose rm flag.
http://man.openbsd.org/OpenBSD-current/man1/rm.1