### PR TITLE
typo in the Full_field_renames_and_reassigns sample

### DIFF
--- a/doc/data/full-reorg.sh
+++ b/doc/data/full-reorg.sh
@@ -7,7 +7,7 @@ mlr put '
   $* = {
     "z": $x + y,
     "KEYFIELD": $a,
-    "i": $i_cumu,
+    "i": @i_cumu,
     "b": $b,
     "y": $x,
     "x": $y,


### PR DESCRIPTION
readable on http://johnkerl.org/miller/doc/cookbook.html#Full_field_renames_and_reassigns

result before:
```
z=0.346790,KEYFIELD=pan,i=,b=pan,y=0.346790,x=0.726803
z=0.758680,KEYFIELD=eks,i=,b=pan,y=0.758680,x=0.522151
z=0.204603,KEYFIELD=wye,i=,b=wye,y=0.204603,x=0.338319
z=0.381399,KEYFIELD=eks,i=,b=wye,y=0.381399,x=0.134189
z=0.573289,KEYFIELD=wye,i=,b=pan,y=0.573289,x=0.863624
```

result after:
```
z=0.346790,KEYFIELD=pan,i=1,b=pan,y=0.346790,x=0.726803
z=0.758680,KEYFIELD=eks,i=3,b=pan,y=0.758680,x=0.522151
z=0.204603,KEYFIELD=wye,i=6,b=wye,y=0.204603,x=0.338319
z=0.381399,KEYFIELD=eks,i=10,b=wye,y=0.381399,x=0.134189
z=0.573289,KEYFIELD=wye,i=15,b=pan,y=0.573289,x=0.863624
```

now there are values for `i`.