### PR TITLE
Fix whatis info in manpage

### DIFF
--- a/doc/mkman.rb
+++ b/doc/mkman.rb
@@ -17,7 +17,7 @@ def main
   print make_top
 
   print make_section('NAME', [
-    "Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV and tabular JSON."
+    "miller \\\- like awk, sed, cut, join, and sort for name-indexed data such as CSV and tabular JSON."
   ])
 
   print make_section('SYNOPSIS', [
@@ -224,7 +224,7 @@ def groff_encode(line)
   #line = line.gsub(/"/, '\(dq')
   #line = line.gsub(/\./, '\&')
   #line = line.gsub(/-/, '\-')
-  line = line.gsub(/\\/, '\e')
+  line = line.gsub(/\\([^-])/, '\e\1')
   line = line.gsub(/^\./){'\&.'}
   line
 end

--- a/doc/mlr.1
+++ b/doc/mlr.1
@@ -26,7 +26,7 @@
 .\" -----------------------------------------------------------------
 .SH "NAME"
 .sp
-Miller is like awk, sed, cut, join, and sort for name-indexed data such as CSV and tabular JSON.
+miller \- like awk, sed, cut, join, and sort for name-indexed data such as CSV and tabular JSON.
 .SH "SYNOPSIS"
 .sp
 Usage: mlr [I/O options] {verb} [verb-dependent options ...] {zero or more file names}


### PR DESCRIPTION
whatis relies on a specific format in the NAME section: command name,
hyphen, description. This fixes the generator so that it produces a
valid NAME section.

Signed-off-by: Stephen Kitt <steve@sk2.org>