### PR TITLE
Add documentation on installing via MacPorts

### DIFF
--- a/doc/build.html
+++ b/doc/build.html
@@ -236,6 +236,16 @@ brew update &amp;&amp; brew install miller
 </div>
 <p/>
 
+<p/>...and also via MacPorts:
+
+<p/>
+<div class="pokipanel">
+<pre>
+sudo port selfupdate &amp;&amp; sudo port install miller
+</pre>
+</div>
+<p/>
+
 <p/> You may already have the <code>mlr</code> executable available in your platform&rsquo;s
 package manager on NetBSD, Debian Linux, Ubuntu Xenial and upward, Arch Linux, or perhaps other distributions.
 For example, on various Linux distributions you might do one of the following:


### PR DESCRIPTION
Miller can now be installed via MacPorts.