### PR TITLE
reg_test: always print mlr stderr after stdout

### DIFF
--- a/c/reg_test/run
+++ b/c/reg_test/run
@@ -128,8 +128,9 @@ mlr_expect_fail() {
   echo mlr "$@" >> $outfile
   # Use path to mlr for invoking the command
   set +e
-  $path_to_mlr "$@" >> $outfile 2>&1
+  stderr_capture=$( $path_to_mlr "$@" 3>&1 1>&2 2>&3 >>$outfile )
   status=$?
+  echo "${stderr_capture}" >> $outfile
   if [ $status -ne 1 ]; then
     echo "Exit status was $status; expected 1."
     echo "Exit status was $status; expected 1." >> $outfile


### PR DESCRIPTION
This PR fixes the first two diff sections in the `reg_test` of the Alpine integration: https://github.com/johnkerl/miller/issues/293#issuecomment-609207268

It makes the reg_test less platform dependent by eliminating a racy `2>&1` merge that gets later used in diff.
It appends stdout to the test log first, and simulatenously juggles around stderr via a third file descriptor until it gets captured in a variable.
Finally, that variable is printed after stdout has been fully flushed through.

I'm not sure if that's the best way to do it, but I figured since stderr output is fairly small usually it's fine to buffer it up in a variable.