### PR TITLE
Fix typo

### DIFF
--- a/c/mapping/mapper_put_or_filter.c
+++ b/c/mapping/mapper_put_or_filter.c
@@ -161,7 +161,7 @@ static void mapper_filter_usage(FILE* o, char* argv0, char* verb) {
 	fprintf(o, "\n");
 	fprintf(o, "Examples:\n");
 	fprintf(o, "  %s %s 'log10($count) > 4.0'\n", argv0, verb);
-	fprintf(o, "  %s %s 'FNR == 2          (second record in each file)'\n", argv0, verb);
+	fprintf(o, "  %s %s 'FNR == 2'         (second record in each file)\n", argv0, verb);
 	fprintf(o, "  %s %s 'urand() < 0.001'  (subsampling)\n", argv0, verb);
 	fprintf(o, "  %s %s '$color != \"blue\" && $value > 4.2'\n", argv0, verb);
 	fprintf(o, "  %s %s '($x<.5 && $y<.5) || ($x>.5 && $y>.5)'\n", argv0, verb);

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -639,7 +639,7 @@ This is simply a copy of what you should see on running **man mlr** at a command
     
            Examples:
     	 mlr filter 'log10($count) > 4.0'
-    	 mlr filter 'FNR == 2	       (second record in each file)'
+    	 mlr filter 'FNR == 2'	       (second record in each file)
     	 mlr filter 'urand() < 0.001'  (subsampling)
     	 mlr filter '$color != "blue" && $value > 4.2'
     	 mlr filter '($x<.5 && $y<.5) || ($x>.5 && $y>.5)'

--- a/docs/manpage.txt
+++ b/docs/manpage.txt
@@ -629,7 +629,7 @@ VERBS
 
        Examples:
 	 mlr filter 'log10($count) > 4.0'
-	 mlr filter 'FNR == 2	       (second record in each file)'
+	 mlr filter 'FNR == 2'	       (second record in each file)
 	 mlr filter 'urand() < 0.001'  (subsampling)
 	 mlr filter '$color != "blue" && $value > 4.2'
 	 mlr filter '($x<.5 && $y<.5) || ($x>.5 && $y>.5)'

--- a/docs/mlr.1
+++ b/docs/mlr.1
@@ -830,7 +830,7 @@ Use # to comment to end of line.
 
 Examples:
   mlr filter 'log10($count) > 4.0'
-  mlr filter 'FNR == 2          (second record in each file)'
+  mlr filter 'FNR == 2'         (second record in each file)
   mlr filter 'urand() < 0.001'  (subsampling)
   mlr filter '$color != "blue" && $value > 4.2'
   mlr filter '($x<.5 && $y<.5) || ($x>.5 && $y>.5)'

--- a/docs/reference-verbs.rst
+++ b/docs/reference-verbs.rst
@@ -793,7 +793,7 @@ filter
     
     Examples:
       mlr filter 'log10($count) > 4.0'
-      mlr filter 'FNR == 2          (second record in each file)'
+      mlr filter 'FNR == 2'         (second record in each file)
       mlr filter 'urand() < 0.001'  (subsampling)
       mlr filter '$color != "blue" && $value > 4.2'
       mlr filter '($x<.5 && $y<.5) || ($x>.5 && $y>.5)'


### PR DESCRIPTION
The explanation was mistakenly in between the single quotes.