### PR TITLE
More typemasks

### DIFF
--- a/go/gg
+++ b/go/gg
@@ -52,16 +52,8 @@ mention() {
 
 # ================================================================
 
-run_mlr put '$foo=sub($name, "abc.*"i, "XXX")' <<EOF
-name=ABC12
-name=abc12
-name=AxC12
-EOF
+run_mlr --from r put -q 'for (k in $*) { print k }; print'
 
-run_mlr put '$foo=sub($name, "abc.*", "XXX")' <<EOF
-name=ABC12
-name=abc12
-name=AxC12
-EOF
+run_mlr --from r put -q 'for (k,v in $*) { print k; print v }; print'
 
 # ================================================================

--- a/go/src/dsl/cst/for.go
+++ b/go/src/dsl/cst/for.go
@@ -128,7 +128,7 @@ func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 		for pe := mapval.Head; pe != nil; pe = pe.Next {
 			mapkey := types.MlrvalFromString(pe.Key)
 
-			state.Stack.SetAtScope(this.variableName, "any", &mapkey)
+			state.Stack.SetAtScope(this.variableName, &mapkey)
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)
 			if err != nil {
@@ -160,7 +160,7 @@ func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 		state.Stack.PushStackFrame()
 		defer state.Stack.PopStackFrame()
 		for _, element := range arrayval {
-			state.Stack.SetAtScope(this.variableName, "any", &element)
+			state.Stack.SetAtScope(this.variableName, &element)
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)
 			if err != nil {
@@ -305,8 +305,8 @@ func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 		for pe := mapval.Head; pe != nil; pe = pe.Next {
 			mapkey := types.MlrvalFromString(pe.Key)
 
-			state.Stack.SetAtScope(this.keyVariableName, "any", &mapkey)
-			state.Stack.SetAtScope(this.valueVariableName, "any", pe.Value)
+			state.Stack.SetAtScope(this.keyVariableName, &mapkey)
+			state.Stack.SetAtScope(this.valueVariableName, pe.Value)
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)
 			if err != nil {
@@ -340,8 +340,8 @@ func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 		for zindex, element := range arrayval {
 			mindex := types.MlrvalFromInt(int(zindex + 1))
 
-			state.Stack.SetAtScope(this.keyVariableName, "any", &mindex)
-			state.Stack.SetAtScope(this.valueVariableName, "any", &element)
+			state.Stack.SetAtScope(this.keyVariableName, &mindex)
+			state.Stack.SetAtScope(this.valueVariableName, &element)
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)
 			if err != nil {
@@ -517,7 +517,7 @@ func (this *ForLoopMultivariableNode) executeOuter(
 		for pe := mapval.Head; pe != nil; pe = pe.Next {
 			mapkey := types.MlrvalFromString(pe.Key)
 
-			state.Stack.SetAtScope(keyVariableNames[0], "any", &mapkey)
+			state.Stack.SetAtScope(keyVariableNames[0], &mapkey)
 
 			blockExitPayload, err := this.executeOuter(pe.Value, keyVariableNames[1:], state)
 			if err != nil {
@@ -547,7 +547,7 @@ func (this *ForLoopMultivariableNode) executeOuter(
 		for zindex, element := range arrayval {
 			mindex := types.MlrvalFromInt(int(zindex + 1))
 
-			state.Stack.SetAtScope(keyVariableNames[0], "any", &mindex)
+			state.Stack.SetAtScope(keyVariableNames[0], &mindex)
 
 			blockExitPayload, err := this.executeOuter(&element, keyVariableNames[1:], state)
 			if err != nil {
@@ -599,8 +599,8 @@ func (this *ForLoopMultivariableNode) executeInner(
 		for pe := mapval.Head; pe != nil; pe = pe.Next {
 			mapkey := types.MlrvalFromString(pe.Key)
 
-			state.Stack.SetAtScope(keyVariableName, "any", &mapkey)
-			state.Stack.SetAtScope(this.valueVariableName, "any", pe.Value)
+			state.Stack.SetAtScope(keyVariableName, &mapkey)
+			state.Stack.SetAtScope(this.valueVariableName, pe.Value)
 
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)
@@ -631,8 +631,8 @@ func (this *ForLoopMultivariableNode) executeInner(
 		for zindex, element := range arrayval {
 			mindex := types.MlrvalFromInt(int(zindex + 1))
 
-			state.Stack.SetAtScope(keyVariableName, "any", &mindex)
-			state.Stack.SetAtScope(this.valueVariableName, "any", &element)
+			state.Stack.SetAtScope(keyVariableName, &mindex)
+			state.Stack.SetAtScope(this.valueVariableName, &element)
 
 			// The loop body will push its own frame
 			blockExitPayload, err := this.statementBlockNode.Execute(state)

--- a/go/src/dsl/cst/udf.go
+++ b/go/src/dsl/cst/udf.go
@@ -104,7 +104,7 @@ func (this *UDFCallsite) Evaluate(state *runtime.State) types.Mlrval {
 	//
 	// That's why we have two loops here: the first evaluates the arguments
 	// using the caller's frameset, stashing them in the arguments array.  Then
-	// we push a new frameset and SetAtScope using the callee's frameset.
+	// we push a new frameset and DefineTypedAtScope using the callee's frameset.
 
 	// Evaluate the arguments
 	numArguments := len(this.udf.signature.typeGatedParameterNames)
@@ -131,7 +131,7 @@ func (this *UDFCallsite) Evaluate(state *runtime.State) types.Mlrval {
 	defer state.Stack.PopStackFrameSet()
 
 	for i, argument := range arguments {
-		state.Stack.SetAtScope(
+		state.Stack.DefineTypedAtScope(
 			this.udf.signature.typeGatedParameterNames[i].Name,
 			this.udf.signature.typeGatedParameterNames[i].TypeName,
 			&argument,

--- a/go/src/dsl/cst/uds.go
+++ b/go/src/dsl/cst/uds.go
@@ -103,7 +103,7 @@ func (this *UDSCallsite) Execute(state *runtime.State) (*BlockExitPayload, error
 	//
 	// That's why we have two loops here: the first evaluates the arguments
 	// using the caller's frameset, stashing them in the arguments array.  Then
-	// we push a new frameset and SetAtScope using the callee's frameset.
+	// we push a new frameset and DefineTypedAtScope using the callee's frameset.
 
 	// Evaluate the arguments
 	numArguments := len(this.uds.signature.typeGatedParameterNames)
@@ -125,7 +125,7 @@ func (this *UDSCallsite) Execute(state *runtime.State) (*BlockExitPayload, error
 	defer state.Stack.PopStackFrameSet()
 
 	for i, argument := range arguments {
-		state.Stack.SetAtScope(
+		state.Stack.DefineTypedAtScope(
 			this.uds.signature.typeGatedParameterNames[i].Name,
 			this.uds.signature.typeGatedParameterNames[i].TypeName,
 			&argument,

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -4,9 +4,11 @@ TOP OF LIST:
 ! GC ./parser-experiments/two/src/github.com/goccmack/gocc/
 
 * typemask:
-  - clearly separate set-typed and re-set
-    int x = 3
-    str x = 4 <-- should say 'has already been defined in the same scope'
+  o clearly separate set-typed and re-set
+    - int x = 3
+      str x = 4 <-- should say 'has already been defined in the same scope'
+    - SetAtScope -> DefineTypedAtScope
+    - what does DefinedTypedAtScopeIndexed really mean?!?
 
 * regexes
   o finish stats1 -r

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -3,6 +3,11 @@ TOP OF LIST:
 
 ! GC ./parser-experiments/two/src/github.com/goccmack/gocc/
 
+* typemask:
+  - clearly separate set-typed and re-set
+    int x = 3
+    str x = 4 <-- should say 'has already been defined in the same scope'
+
 * regexes
   o finish stats1 -r
   o regex captures ...


### PR DESCRIPTION
Previous PR was still allowing

```
int x = 3;
int x = 3;
```

Also:

```
int x = 3;
str x = "abc";
```

was triggering an error but only on the fact that `x` wasn't an `int` on the second line -- it should have triggered on the redeclare with `str`.

Both are fixed now.

Tests passing with `build` in `go/` dir.

Context: https://github.com/johnkerl/miller/blob/master/go/README.md