### PR TITLE
Reduce GC in DSL

### DIFF
--- a/go/README-profiling.md
+++ b/go/README-profiling.md
@@ -38,11 +38,12 @@ mkdir -p $HOME/go
 ```
 go get -u github.com/google/pprof
 ll ~/go/bin/pprof
-go get github.com/uber/go-torch
+go get -u github.com/uber/go-torch
 ```
 
 ```
-cd ~/git
+mkdir -p ~/git/brendangregg
+cd ~/git/brendangregg
 git clone https://github.com/brendangregg/FlameGraph
 ```
 
@@ -50,7 +51,7 @@ Per run:
 
 ```
 cd /path/to/mlr/go
-export PATH=${PATH}:~/git/FlameGraph/
+export PATH=${PATH}:~/git/brendangregg/FlameGraph/
 go-torch cpu.pprof
 mv torch.svg ~/Desktop/
 ```

--- a/go/reg-test/input/ff.mlr
+++ b/go/reg-test/input/ff.mlr
@@ -1,6 +1,6 @@
-func f(x) {
-  if (x > 1) {
-    return x*f(x-1)
+func f(n) {
+  if (n > 1) {
+    return n*f(n-1)
   } else {
     return 1
   }

--- a/go/src/dsl/cst/assignments.go
+++ b/go/src/dsl/cst/assignments.go
@@ -8,6 +8,7 @@ import (
 	"miller/src/dsl"
 	"miller/src/lib"
 	"miller/src/runtime"
+	"miller/src/types"
 )
 
 // ================================================================
@@ -56,8 +57,11 @@ func NewAssignmentNode(
 	}
 }
 
-func (this *AssignmentNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	rvalue := this.rvalueNode.Evaluate(state)
+func (this *AssignmentNode) Execute(
+	state *runtime.State,
+) (*BlockExitPayload, error) {
+	var rvalue types.Mlrval
+	this.rvalueNode.Evaluate(&rvalue, state)
 	if !rvalue.IsAbsent() {
 		err := this.lvalueNode.Assign(&rvalue, state)
 		if err != nil {

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -321,7 +321,10 @@ func (this *TernaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Ml
 	arg1 := this.evaluable1.Evaluate(state)
 	arg2 := this.evaluable2.Evaluate(state)
 	arg3 := this.evaluable3.Evaluate(state)
-	return this.ternaryFunc(&arg1, &arg2, &arg3)
+	// xxx temp
+	output := types.MlrvalFromAbsent()
+	this.ternaryFunc(&output, &arg1, &arg2, &arg3)
+	return output
 }
 
 // ----------------------------------------------------------------
@@ -565,7 +568,7 @@ func BinaryShortCircuitPlaceholder(a, b *types.Mlrval) types.Mlrval {
 	return types.MlrvalFromError() // not reached
 }
 
-func TernaryShortCircuitPlaceholder(a, b, c *types.Mlrval) types.Mlrval {
+func TernaryShortCircuitPlaceholder(output, input1, input2, input3 *types.Mlrval) {
 	lib.InternalCodingErrorPanic("Short-circuting was not correctly implemented")
-	return types.MlrvalFromError() // not reached
+	output.SetFromError() // not reached
 }

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -265,9 +265,12 @@ func (this *RootNode) BuildBinaryFunctionCallsiteNode(
 }
 
 func (this *BinaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
+	// xxx temp
+	output := types.MlrvalFromError()
 	arg1 := this.evaluable1.Evaluate(state)
 	arg2 := this.evaluable2.Evaluate(state)
-	return this.binaryFunc(&arg1, &arg2)
+	this.binaryFunc(&output, &arg1, &arg2)
+	return output
 }
 
 // ----------------------------------------------------------------
@@ -379,7 +382,10 @@ func (this *VariadicFunctionCallsiteNode) Evaluate(state *runtime.State) types.M
 		arg := evaluable.Evaluate(state)
 		args[i] = &arg
 	}
-	return this.variadicFunc(args)
+	// xxx temp
+	output := types.MlrvalFromError()
+	this.variadicFunc(&output, args)
+	return output
 }
 
 // ================================================================
@@ -450,7 +456,10 @@ func (this *LogicalANDOperatorNode) Evaluate(state *runtime.State) types.Mlrval 
 	if btype == types.MT_ABSENT {
 		return bout
 	}
-	return types.MlrvalLogicalAND(&aout, &bout)
+	// xxx temp
+	output := types.MlrvalFromError()
+	types.MlrvalLogicalAND(&output, &aout, &bout)
+	return output
 }
 
 // ================================================================
@@ -490,7 +499,10 @@ func (this *LogicalOROperatorNode) Evaluate(state *runtime.State) types.Mlrval {
 	if btype == types.MT_ABSENT {
 		return bout
 	}
-	return types.MlrvalLogicalOR(&aout, &bout)
+	// xxx temp
+	output := types.MlrvalFromError()
+	types.MlrvalLogicalOR(&output, &aout, &bout)
+	return output
 }
 
 // ================================================================
@@ -572,9 +584,9 @@ func (this *StandardTernaryOperatorNode) Evaluate(state *runtime.State) types.Ml
 // for the function-manager lookup table to indicate the arity of the function,
 // even though at runtime these functions should not get invoked.
 
-func BinaryShortCircuitPlaceholder(a, b *types.Mlrval) types.Mlrval {
+func BinaryShortCircuitPlaceholder(output, input1, input2 *types.Mlrval) {
 	lib.InternalCodingErrorPanic("Short-circuting was not correctly implemented")
-	return types.MlrvalFromError() // not reached
+	output.SetFromError() // not reached
 }
 
 func TernaryShortCircuitPlaceholder(output, input1, input2, input3 *types.Mlrval) {

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -101,14 +101,16 @@ func (this *RootNode) BuildZaryFunctionCallsiteNode(
 		)
 	}
 
-	return &ZaryFunctionCallsiteNode{zaryFunc: builtinFunctionInfo.zaryFunc}, nil
+	return &ZaryFunctionCallsiteNode{
+		zaryFunc: builtinFunctionInfo.zaryFunc,
+	}, nil
 }
 
-func (this *ZaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	// xxx temp
-	output := types.MlrvalFromAbsent()
-	this.zaryFunc(&output)
-	return output
+func (this *ZaryFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	this.zaryFunc(output)
 }
 
 // ----------------------------------------------------------------
@@ -146,12 +148,13 @@ func (this *RootNode) BuildUnaryFunctionCallsiteNode(
 	}, nil
 }
 
-func (this *UnaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	arg1 := this.evaluable1.Evaluate(state)
-	// xxx temp
-	output := types.MlrvalFromAbsent()
-	this.unaryFunc(&output, &arg1)
-	return output
+func (this *UnaryFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var arg1 types.Mlrval
+	this.evaluable1.Evaluate(&arg1, state)
+	this.unaryFunc(output, &arg1)
 }
 
 // ----------------------------------------------------------------
@@ -189,12 +192,13 @@ func (this *RootNode) BuildContextualUnaryFunctionCallsiteNode(
 	}, nil
 }
 
-func (this *ContextualUnaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	arg1 := this.evaluable1.Evaluate(state)
-	// xxx temp
-	output := types.MlrvalFromAbsent()
-	this.contextualUnaryFunc(&output, &arg1, state.Context)
-	return output
+func (this *ContextualUnaryFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var arg1 types.Mlrval
+	this.evaluable1.Evaluate(&arg1, state)
+	this.contextualUnaryFunc(output, &arg1, state.Context)
 }
 
 // ----------------------------------------------------------------
@@ -264,13 +268,14 @@ func (this *RootNode) BuildBinaryFunctionCallsiteNode(
 	}, nil
 }
 
-func (this *BinaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	// xxx temp
-	output := types.MlrvalFromError()
-	arg1 := this.evaluable1.Evaluate(state)
-	arg2 := this.evaluable2.Evaluate(state)
-	this.binaryFunc(&output, &arg1, &arg2)
-	return output
+func (this *BinaryFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var arg1, arg2 types.Mlrval
+	this.evaluable1.Evaluate(&arg1, state)
+	this.evaluable2.Evaluate(&arg2, state)
+	this.binaryFunc(output, &arg1, &arg2)
 }
 
 // ----------------------------------------------------------------
@@ -329,20 +334,22 @@ func (this *RootNode) BuildTernaryFunctionCallsiteNode(
 	}, nil
 }
 
-func (this *TernaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	arg1 := this.evaluable1.Evaluate(state)
-	arg2 := this.evaluable2.Evaluate(state)
-	arg3 := this.evaluable3.Evaluate(state)
-	// xxx temp
-	output := types.MlrvalFromAbsent()
-	this.ternaryFunc(&output, &arg1, &arg2, &arg3)
-	return output
+func (this *TernaryFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var arg1, arg2, arg3 types.Mlrval
+	this.evaluable1.Evaluate(&arg1, state)
+	this.evaluable2.Evaluate(&arg2, state)
+	this.evaluable3.Evaluate(&arg3, state)
+	this.ternaryFunc(output, &arg1, &arg2, &arg3)
 }
 
 // ----------------------------------------------------------------
 type VariadicFunctionCallsiteNode struct {
 	variadicFunc types.VariadicFunc
 	evaluables   []IEvaluable
+	args         []*types.Mlrval
 }
 
 func (this *RootNode) BuildVariadicFunctionCallsiteNode(
@@ -351,6 +358,7 @@ func (this *RootNode) BuildVariadicFunctionCallsiteNode(
 ) (IEvaluable, error) {
 	lib.InternalCodingErrorIf(astNode.Children == nil)
 	evaluables := make([]IEvaluable, len(astNode.Children))
+	args := make([]*types.Mlrval, len(astNode.Children))
 
 	callsiteArity := len(astNode.Children)
 	if callsiteArity < builtinFunctionInfo.minimumVariadicArity {
@@ -369,30 +377,35 @@ func (this *RootNode) BuildVariadicFunctionCallsiteNode(
 		if err != nil {
 			return nil, err
 		}
+		args[i] = types.MlrvalPointerFromError()
 	}
 	return &VariadicFunctionCallsiteNode{
 		variadicFunc: builtinFunctionInfo.variadicFunc,
 		evaluables:   evaluables,
+		args:         args,
 	}, nil
 }
 
-func (this *VariadicFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	args := make([]*types.Mlrval, len(this.evaluables))
-	for i, evaluable := range this.evaluables {
-		arg := evaluable.Evaluate(state)
-		args[i] = &arg
+func (this *VariadicFunctionCallsiteNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	for i, _ := range this.evaluables {
+		this.evaluables[i].Evaluate(this.args[i], state)
 	}
-	// xxx temp
-	output := types.MlrvalFromError()
-	this.variadicFunc(&output, args)
-	return output
+	this.variadicFunc(output, this.args)
 }
 
 // ================================================================
-type LogicalANDOperatorNode struct{ a, b IEvaluable }
+type LogicalANDOperatorNode struct {
+	a, b IEvaluable
+}
 
 func (this *RootNode) BuildLogicalANDOperatorNode(a, b IEvaluable) *LogicalANDOperatorNode {
-	return &LogicalANDOperatorNode{a: a, b: b}
+	return &LogicalANDOperatorNode{
+		a: a,
+		b: b,
+	}
 }
 
 // This is different from most of the evaluator functions in that it does
@@ -431,42 +444,53 @@ func (this *RootNode) BuildLogicalANDOperatorNode(a, b IEvaluable) *LogicalANDOp
 // * If b is absent: return absent
 // * Return a && b
 
-func (this *LogicalANDOperatorNode) Evaluate(state *runtime.State) types.Mlrval {
-	aout := this.a.Evaluate(state)
+func (this *LogicalANDOperatorNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var aout, bout types.Mlrval
+	this.a.Evaluate(&aout, state)
 	atype := aout.GetType()
 	if !(atype == types.MT_ABSENT || atype == types.MT_BOOL) {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if atype == types.MT_ABSENT {
-		return aout
+		output.SetFromAbsent()
+		return
 	}
 	if aout.IsFalse() {
 		// This means false && bogus type evaluates to true, which is sad but
 		// which we MUST do in order to not violate the short-circuiting
 		// property.  We would have to evaluate b to know if it were error or
 		// not.
-		return aout
+		output.CopyFrom(&aout)
+		return
 	}
 
-	bout := this.b.Evaluate(state)
+	this.b.Evaluate(&bout, state)
 	btype := bout.GetType()
 	if !(btype == types.MT_ABSENT || btype == types.MT_BOOL) {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if btype == types.MT_ABSENT {
-		return bout
+		output.SetFromAbsent()
+		return
 	}
-	// xxx temp
-	output := types.MlrvalFromError()
-	types.MlrvalLogicalAND(&output, &aout, &bout)
-	return output
+	types.MlrvalLogicalAND(output, &aout, &bout)
 }
 
 // ================================================================
-type LogicalOROperatorNode struct{ a, b IEvaluable }
+type LogicalOROperatorNode struct {
+	a, b IEvaluable
+}
 
 func (this *RootNode) BuildLogicalOROperatorNode(a, b IEvaluable) *LogicalOROperatorNode {
-	return &LogicalOROperatorNode{a: a, b: b}
+	return &LogicalOROperatorNode{
+		a: a,
+		b: b,
+	}
 }
 
 // This is different from most of the evaluator functions in that it does
@@ -474,35 +498,41 @@ func (this *RootNode) BuildLogicalOROperatorNode(a, b IEvaluable) *LogicalOROper
 // if the first argument is false.
 //
 // See the disposition-matrix discussion for LogicalANDOperator.
-func (this *LogicalOROperatorNode) Evaluate(state *runtime.State) types.Mlrval {
-	aout := this.a.Evaluate(state)
+func (this *LogicalOROperatorNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var aout, bout types.Mlrval
+	this.a.Evaluate(&aout, state)
 	atype := aout.GetType()
 	if !(atype == types.MT_ABSENT || atype == types.MT_BOOL) {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if atype == types.MT_ABSENT {
-		return aout
+		output.SetFromAbsent()
+		return
 	}
 	if aout.IsTrue() {
 		// This means true || bogus type evaluates to true, which is sad but
 		// which we MUST do in order to not violate the short-circuiting
 		// property.  We would have to evaluate b to know if it were error or
 		// not.
-		return aout
+		output.CopyFrom(&aout)
+		return
 	}
 
-	bout := this.b.Evaluate(state)
+	this.b.Evaluate(&bout, state)
 	btype := bout.GetType()
 	if !(btype == types.MT_ABSENT || btype == types.MT_BOOL) {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if btype == types.MT_ABSENT {
-		return bout
+		output.SetFromAbsent()
+		return
 	}
-	// xxx temp
-	output := types.MlrvalFromError()
-	types.MlrvalLogicalOR(&output, &aout, &bout)
-	return output
+	types.MlrvalLogicalOR(output, &aout, &bout)
 }
 
 // ================================================================
@@ -517,15 +547,16 @@ func (this *RootNode) BuildAbsentCoalesceOperatorNode(a, b IEvaluable) *AbsentCo
 // This is different from most of the evaluator functions in that it does
 // short-circuiting: the second argument is not evaluated if the first
 // argument is not absent.
-func (this *AbsentCoalesceOperatorNode) Evaluate(state *runtime.State) types.Mlrval {
-	aout := this.a.Evaluate(state)
-	atype := aout.GetType()
-	if atype != types.MT_ABSENT {
-		return aout
+func (this *AbsentCoalesceOperatorNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	this.a.Evaluate(output, state)
+	if output.GetType() != types.MT_ABSENT {
+		return
 	}
 
-	bout := this.b.Evaluate(state)
-	return bout
+	this.b.Evaluate(output, state)
 }
 
 // ================================================================
@@ -540,14 +571,14 @@ func (this *RootNode) BuildEmptyCoalesceOperatorNode(a, b IEvaluable) *EmptyCoal
 // This is different from most of the evaluator functions in that it does
 // short-circuiting: the second argument is not evaluated if the first
 // argument is not absent.
-func (this *EmptyCoalesceOperatorNode) Evaluate(state *runtime.State) types.Mlrval {
-	aout := this.a.Evaluate(state)
-	atype := aout.GetType()
-	if atype == types.MT_ABSENT || atype == types.MT_VOID || (atype == types.MT_STRING && aout.String() == "") {
-		bout := this.b.Evaluate(state)
-		return bout
-	} else {
-		return aout
+func (this *EmptyCoalesceOperatorNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	this.a.Evaluate(output, state)
+	atype := output.GetType()
+	if atype == types.MT_ABSENT || atype == types.MT_VOID || (atype == types.MT_STRING && output.String() == "") {
+		this.b.Evaluate(output, state)
 	}
 }
 
@@ -557,19 +588,23 @@ type StandardTernaryOperatorNode struct{ a, b, c IEvaluable }
 func (this *RootNode) BuildStandardTernaryOperatorNode(a, b, c IEvaluable) *StandardTernaryOperatorNode {
 	return &StandardTernaryOperatorNode{a: a, b: b, c: c}
 }
-func (this *StandardTernaryOperatorNode) Evaluate(state *runtime.State) types.Mlrval {
-	aout := this.a.Evaluate(state)
+func (this *StandardTernaryOperatorNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	this.a.Evaluate(output, state)
 
-	boolValue, isBool := aout.GetBoolValue()
+	boolValue, isBool := output.GetBoolValue()
 	if !isBool {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	// Short-circuit: defer evaluation unless needed
 	if boolValue == true {
-		return this.b.Evaluate(state)
+		this.b.Evaluate(output, state)
 	} else {
-		return this.c.Evaluate(state)
+		this.c.Evaluate(output, state)
 	}
 }
 

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -191,7 +191,10 @@ func (this *RootNode) BuildContextualUnaryFunctionCallsiteNode(
 
 func (this *ContextualUnaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
 	arg1 := this.evaluable1.Evaluate(state)
-	return this.contextualUnaryFunc(&arg1, state.Context)
+	// xxx temp
+	output := types.MlrvalFromAbsent()
+	this.contextualUnaryFunc(&output, &arg1, state.Context)
+	return output
 }
 
 // ----------------------------------------------------------------

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -148,7 +148,10 @@ func (this *RootNode) BuildUnaryFunctionCallsiteNode(
 
 func (this *UnaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
 	arg1 := this.evaluable1.Evaluate(state)
-	return this.unaryFunc(&arg1)
+	// xxx temp
+	output := types.MlrvalFromAbsent()
+	this.unaryFunc(&output, &arg1)
+	return output
 }
 
 // ----------------------------------------------------------------

--- a/go/src/dsl/cst/builtin_functions.go
+++ b/go/src/dsl/cst/builtin_functions.go
@@ -105,7 +105,10 @@ func (this *RootNode) BuildZaryFunctionCallsiteNode(
 }
 
 func (this *ZaryFunctionCallsiteNode) Evaluate(state *runtime.State) types.Mlrval {
-	return this.zaryFunc()
+	// xxx temp
+	output := types.MlrvalFromAbsent()
+	this.zaryFunc(&output)
+	return output
 }
 
 // ----------------------------------------------------------------

--- a/go/src/dsl/cst/collections.go
+++ b/go/src/dsl/cst/collections.go
@@ -141,7 +141,10 @@ func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
 		return types.MlrvalFromAbsent()
 	}
 	if baseMlrval.IsString() {
-		return types.MlrvalSubstr(&baseMlrval, &lowerIndexMlrval, &upperIndexMlrval)
+		// xxx temp
+		output := types.MlrvalFromAbsent()
+		types.MlrvalSubstr(&output, &baseMlrval, &lowerIndexMlrval, &upperIndexMlrval)
+		return output
 	}
 	array := baseMlrval.GetArray()
 	if array == nil {

--- a/go/src/dsl/cst/collections.go
+++ b/go/src/dsl/cst/collections.go
@@ -15,6 +15,7 @@ import (
 // ----------------------------------------------------------------
 type ArrayLiteralNode struct {
 	evaluables []IEvaluable
+	mlrvals    []types.Mlrval
 }
 
 func (this *RootNode) BuildArrayLiteralNode(
@@ -25,26 +26,32 @@ func (this *RootNode) BuildArrayLiteralNode(
 	// children
 	lib.InternalCodingErrorIf(astNode.Children == nil)
 
-	evaluables := make([]IEvaluable, 0)
+	evaluables := make([]IEvaluable, len(astNode.Children))
+	mlrvals := make([]types.Mlrval, len(astNode.Children))
 
-	for _, astChild := range astNode.Children {
+	for i, astChild := range astNode.Children {
 		element, err := this.BuildEvaluableNode(astChild)
 		if err != nil {
 			return nil, err
 		}
-		evaluables = append(evaluables, element)
+		evaluables[i] = element
+		mlrvals[i] = types.MlrvalFromError()
 	}
 
-	return &ArrayLiteralNode{evaluables: evaluables}, nil
+	return &ArrayLiteralNode{
+		evaluables: evaluables,
+		mlrvals:    mlrvals,
+	}, nil
 }
 
-func (this *ArrayLiteralNode) Evaluate(state *runtime.State) types.Mlrval {
-	mlrvals := make([]types.Mlrval, 0)
-	for _, evaluable := range this.evaluables {
-		mlrval := evaluable.Evaluate(state)
-		mlrvals = append(mlrvals, mlrval)
+func (this *ArrayLiteralNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	for i, _ := range this.evaluables {
+		this.evaluables[i].Evaluate(&this.mlrvals[i], state)
 	}
-	return types.MlrvalFromArrayLiteralReference(mlrvals)
+	output.SetFromArrayLiteralReference(this.mlrvals)
 }
 
 // ----------------------------------------------------------------
@@ -77,19 +84,23 @@ func (this *RootNode) BuildArrayOrMapIndexAccessNode(
 	}, nil
 }
 
-func (this *ArrayOrMapIndexAccessNode) Evaluate(state *runtime.State) types.Mlrval {
-	baseMlrval := this.baseEvaluable.Evaluate(state)
-	indexMlrval := this.indexEvaluable.Evaluate(state)
+func (this *ArrayOrMapIndexAccessNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var baseMlrval, indexMlrval types.Mlrval
+	this.baseEvaluable.Evaluate(&baseMlrval, state)
+	this.indexEvaluable.Evaluate(&indexMlrval, state)
 
 	// Base-is-array and index-is-int will be checked there
 	if baseMlrval.IsArray() {
-		return baseMlrval.ArrayGet(&indexMlrval)
+		*output = baseMlrval.ArrayGet(&indexMlrval)
 	} else if baseMlrval.IsMap() {
-		return baseMlrval.MapGet(&indexMlrval)
+		*output = baseMlrval.MapGet(&indexMlrval)
 	} else if baseMlrval.IsAbsent() {
-		return baseMlrval
+		output.SetFromAbsent()
 	} else {
-		return types.MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
@@ -132,31 +143,36 @@ func (this *RootNode) BuildArraySliceAccessNode(
 	}, nil
 }
 
-func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
-	baseMlrval := this.baseEvaluable.Evaluate(state)
-	lowerIndexMlrval := this.lowerIndexEvaluable.Evaluate(state)
-	upperIndexMlrval := this.upperIndexEvaluable.Evaluate(state)
+func (this *ArraySliceAccessNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var baseMlrval, lowerIndexMlrval, upperIndexMlrval types.Mlrval
+	this.baseEvaluable.Evaluate(&baseMlrval, state)
+	this.lowerIndexEvaluable.Evaluate(&lowerIndexMlrval, state)
+	this.upperIndexEvaluable.Evaluate(&upperIndexMlrval, state)
 
 	if baseMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
 	}
 	if baseMlrval.IsString() {
-		// xxx temp
-		output := types.MlrvalFromAbsent()
-		types.MlrvalSubstr(&output, &baseMlrval, &lowerIndexMlrval, &upperIndexMlrval)
-		return output
+		types.MlrvalSubstr(output, &baseMlrval, &lowerIndexMlrval, &upperIndexMlrval)
+		return
 	}
 	array := baseMlrval.GetArray()
 	if array == nil {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	n := len(array)
 
 	if lowerIndexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 	if upperIndexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	lowerIndex, ok := lowerIndexMlrval.GetIntValue()
@@ -164,7 +180,8 @@ func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
 		if lowerIndexMlrval.IsEmpty() {
 			lowerIndex = 1
 		} else {
-			return types.MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 	}
 	upperIndex, ok := upperIndexMlrval.GetIntValue()
@@ -172,7 +189,8 @@ func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
 		if upperIndexMlrval.IsEmpty() {
 			upperIndex = n
 		} else {
-			return types.MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 	}
 
@@ -183,7 +201,8 @@ func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
 	upperZindex, _ := types.UnaliasArrayIndex(&array, upperIndex)
 
 	if lowerZindex > upperZindex {
-		return types.MlrvalFromArrayLiteralReference(make([]types.Mlrval, 0))
+		output.SetFromArrayLiteralReference(make([]types.Mlrval, 0))
+		return
 	}
 
 	// Say x=[1,2,3,4,5]. Then x[3:10] is [3,4,5].
@@ -204,7 +223,7 @@ func (this *ArraySliceAccessNode) Evaluate(state *runtime.State) types.Mlrval {
 		di++
 	}
 
-	return types.MlrvalFromArrayLiteralReference(retval)
+	output.SetFromArrayLiteralReference(retval)
 }
 
 // ================================================================
@@ -233,23 +252,30 @@ func (this *RootNode) BuildPositionalFieldNameNode(
 }
 
 // TODO: code-dedupe these next four Evaluate methods
-func (this *PositionalFieldNameNode) Evaluate(state *runtime.State) types.Mlrval {
-	indexMlrval := this.indexEvaluable.Evaluate(state)
+func (this *PositionalFieldNameNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var indexMlrval types.Mlrval
+	this.indexEvaluable.Evaluate(&indexMlrval, state)
 	if indexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	index, ok := indexMlrval.GetIntValue()
 	if !ok {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	name, ok := state.Inrec.GetNameAtPositionalIndex(index)
 	if !ok {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
-	return types.MlrvalFromString(name)
+	output.SetFromString(name)
 }
 
 // ================================================================
@@ -277,23 +303,30 @@ func (this *RootNode) BuildPositionalFieldValueNode(
 	}, nil
 }
 
-func (this *PositionalFieldValueNode) Evaluate(state *runtime.State) types.Mlrval {
-	indexMlrval := this.indexEvaluable.Evaluate(state)
+func (this *PositionalFieldValueNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var indexMlrval types.Mlrval
+	this.indexEvaluable.Evaluate(&indexMlrval, state)
 	if indexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	index, ok := indexMlrval.GetIntValue()
 	if !ok {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	retval := state.Inrec.GetWithPositionalIndex(index)
 	if retval == nil {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
-	return *retval
+	output.CopyFrom(retval)
 }
 
 // ================================================================
@@ -328,41 +361,53 @@ func (this *RootNode) BuildArrayOrMapPositionalNameAccessNode(
 	}, nil
 }
 
-func (this *ArrayOrMapPositionalNameAccessNode) Evaluate(state *runtime.State) types.Mlrval {
-	baseMlrval := this.baseEvaluable.Evaluate(state)
-	indexMlrval := this.indexEvaluable.Evaluate(state)
+func (this *ArrayOrMapPositionalNameAccessNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var baseMlrval, indexMlrval types.Mlrval
+	this.baseEvaluable.Evaluate(&baseMlrval, state)
+	this.indexEvaluable.Evaluate(&indexMlrval, state)
 
 	if indexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	index, ok := indexMlrval.GetIntValue()
 	if !ok {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	if baseMlrval.IsArray() {
 		n, _ := baseMlrval.GetArrayLength()
 		zindex, ok := types.UnaliasArrayLengthIndex(int(n), index)
 		if ok {
-			return types.MlrvalFromInt(zindex + 1) // Miller user-space indices are 1-up
+			output.SetFromInt(zindex + 1) // Miller user-space indices are 1-up
+			return
 		} else {
-			return types.MlrvalFromAbsent()
+			output.SetFromAbsent()
+			return
 		}
 
 	} else if baseMlrval.IsMap() {
 		name, ok := baseMlrval.GetMap().GetNameAtPositionalIndex(index)
 		if !ok {
-			return types.MlrvalFromAbsent()
+			output.SetFromAbsent()
+			return
 		} else {
-			return types.MlrvalFromString(name)
+			output.SetFromString(name)
+			return
 		}
 
 	} else if baseMlrval.IsAbsent() {
-		return baseMlrval
+		output.SetFromAbsent()
+		return
 
 	} else {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 }
 
@@ -398,36 +443,47 @@ func (this *RootNode) BuildArrayOrMapPositionalValueAccessNode(
 	}, nil
 }
 
-func (this *ArrayOrMapPositionalValueAccessNode) Evaluate(state *runtime.State) types.Mlrval {
-	baseMlrval := this.baseEvaluable.Evaluate(state)
-	indexMlrval := this.indexEvaluable.Evaluate(state)
+func (this *ArrayOrMapPositionalValueAccessNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var baseMlrval, indexMlrval types.Mlrval
+	this.baseEvaluable.Evaluate(&baseMlrval, state)
+	this.indexEvaluable.Evaluate(&indexMlrval, state)
 
 	if indexMlrval.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	index, ok := indexMlrval.GetIntValue()
 	if !ok {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	if baseMlrval.IsArray() {
-		return baseMlrval.ArrayGet(&indexMlrval)
+		// xxx pending pointer-output refactor
+		element := baseMlrval.ArrayGet(&indexMlrval)
+		output.CopyFrom(&element)
 
 	} else if baseMlrval.IsMap() {
 		value := baseMlrval.GetMap().GetWithPositionalIndex(index)
 		if value == nil {
-			return types.MlrvalFromAbsent()
+			output.SetFromAbsent()
+			return
 		}
 
-		retval := value.Copy()
-		return *retval
+		output.CopyFrom(value)
+		return
 
 	} else if baseMlrval.IsAbsent() {
-		return baseMlrval
+		output.CopyFrom(&baseMlrval)
+		return
 
 	} else {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 }
 
@@ -453,8 +509,7 @@ func NewEvaluablePair(key IEvaluable, value IEvaluable) *EvaluablePair {
 
 // ----------------------------------------------------------------
 type MapLiteralNode struct {
-	evaluablePairs []EvaluablePair
-	// needs array of key/value Mlrval pairs
+	evaluablePairs []*EvaluablePair
 }
 
 func (this *RootNode) BuildMapLiteralNode(
@@ -465,8 +520,8 @@ func (this *RootNode) BuildMapLiteralNode(
 	// children
 	lib.InternalCodingErrorIf(astNode.Children == nil)
 
-	evaluablePairs := make([]EvaluablePair, 0)
-	for _, astChild := range astNode.Children {
+	evaluablePairs := make([]*EvaluablePair, len(astNode.Children))
+	for i, astChild := range astNode.Children {
 		lib.InternalCodingErrorIf(astChild.Children == nil)
 		lib.InternalCodingErrorIf(len(astChild.Children) != 2)
 		astKey := astChild.Children[0]
@@ -481,23 +536,26 @@ func (this *RootNode) BuildMapLiteralNode(
 			return nil, err
 		}
 
-		evaluablePair := NewEvaluablePair(cstKey, cstValue)
-		evaluablePairs = append(evaluablePairs, *evaluablePair)
+		evaluablePairs[i] = NewEvaluablePair(cstKey, cstValue)
 	}
-	return &MapLiteralNode{evaluablePairs: evaluablePairs}, nil
+	return &MapLiteralNode{
+		evaluablePairs: evaluablePairs,
+	}, nil
 }
 
-func (this *MapLiteralNode) Evaluate(state *runtime.State) types.Mlrval {
-	mlrval := types.MlrvalEmptyMap()
+func (this *MapLiteralNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	output.SetFromEmptyMap()
 
-	for _, evaluablePair := range this.evaluablePairs {
-		mkey := evaluablePair.Key.Evaluate(state)
-		mvalue := evaluablePair.Value.Evaluate(state)
+	for i, _ := range this.evaluablePairs {
+		var key, value types.Mlrval
+		this.evaluablePairs[i].Key.Evaluate(&key, state)
+		this.evaluablePairs[i].Value.Evaluate(&value, state)
 
-		if !mvalue.IsAbsent() {
-			mlrval.MapPut(&mkey, &mvalue)
+		if !value.IsAbsent() {
+			output.MapPut(&key, &value)
 		}
 	}
-
-	return mlrval
 }

--- a/go/src/dsl/cst/cond.go
+++ b/go/src/dsl/cst/cond.go
@@ -43,10 +43,13 @@ func (this *RootNode) BuildCondBlockNode(astNode *dsl.ASTNode) (*CondBlockNode, 
 }
 
 // ----------------------------------------------------------------
-func (this *CondBlockNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	condition := types.MlrvalFromTrue()
+func (this *CondBlockNode) Execute(
+	state *runtime.State,
+) (*BlockExitPayload, error) {
+	var condition types.Mlrval
+	condition.SetFromTrue()
 	if this.conditionNode != nil {
-		condition = this.conditionNode.Evaluate(state)
+		this.conditionNode.Evaluate(&condition, state)
 	}
 	boolValue, isBool := condition.GetBoolValue()
 

--- a/go/src/dsl/cst/dump.go
+++ b/go/src/dsl/cst/dump.go
@@ -166,9 +166,10 @@ func (this *DumpStatementNode) Execute(state *runtime.State) (*BlockExitPayload,
 	//
 	// Plus: we never have to worry about forgetting to do fflush(). :)
 	var buffer bytes.Buffer
+	var evaluation types.Mlrval
 
 	for _, expressionEvaluable := range this.expressionEvaluables {
-		evaluation := expressionEvaluable.Evaluate(state)
+		expressionEvaluable.Evaluate(&evaluation, state)
 		if !evaluation.IsAbsent() {
 			s := evaluation.String()
 			buffer.WriteString(s)
@@ -214,7 +215,8 @@ func (this *DumpStatementNode) dumpToFileOrPipe(
 	outputString string,
 	state *runtime.State,
 ) error {
-	redirectorTarget := this.redirectorTargetEvaluable.Evaluate(state)
+	var redirectorTarget types.Mlrval
+	this.redirectorTargetEvaluable.Evaluate(&redirectorTarget, state)
 	if !redirectorTarget.IsString() {
 		return errors.New(
 			fmt.Sprintf(

--- a/go/src/dsl/cst/emitf.go
+++ b/go/src/dsl/cst/emitf.go
@@ -140,9 +140,10 @@ func (this *RootNode) BuildEmitFStatementNode(astNode *dsl.ASTNode) (IExecutable
 
 func (this *EmitFStatementNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
 	newrec := types.NewMlrmapAsRecord()
+	var emitfValue types.Mlrval
 	for i, emitfEvaluable := range this.emitfEvaluables {
 		emitfName := this.emitfNames[i]
-		emitfValue := emitfEvaluable.Evaluate(state)
+		emitfEvaluable.Evaluate(&emitfValue, state)
 
 		if !emitfValue.IsAbsent() {
 			newrec.PutCopy(emitfName, &emitfValue)
@@ -195,7 +196,8 @@ func (this *EmitFStatementNode) emitfToFileOrPipe(
 	outrec *types.Mlrmap,
 	state *runtime.State,
 ) error {
-	redirectorTarget := this.redirectorTargetEvaluable.Evaluate(state)
+	var redirectorTarget types.Mlrval
+	this.redirectorTargetEvaluable.Evaluate(&redirectorTarget, state)
 	if !redirectorTarget.IsString() {
 		return errors.New(
 			fmt.Sprintf(

--- a/go/src/dsl/cst/env.go
+++ b/go/src/dsl/cst/env.go
@@ -33,14 +33,20 @@ func (this *RootNode) BuildEnvironmentVariableNode(astNode *dsl.ASTNode) (*Envir
 	}, nil
 }
 
-func (this *EnvironmentVariableNode) Evaluate(state *runtime.State) types.Mlrval {
-	name := this.nameEvaluable.Evaluate(state)
+func (this *EnvironmentVariableNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) {
+	var name types.Mlrval
+	this.nameEvaluable.Evaluate(&name, state)
 	if name.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 	if !name.IsString() {
-		return types.MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	return types.MlrvalFromString(os.Getenv(name.String()))
+	output.SetFromString(os.Getenv(name.String()))
 }

--- a/go/src/dsl/cst/evaluable.go
+++ b/go/src/dsl/cst/evaluable.go
@@ -93,10 +93,15 @@ func (this *RootNode) BuildIndirectFieldValueNode(
 		fieldNameEvaluable: fieldNameEvaluable,
 	}, nil
 }
-func (this *IndirectFieldValueNode) Evaluate(state *runtime.State) types.Mlrval { // xxx err
-	fieldName := this.fieldNameEvaluable.Evaluate(state)
+func (this *IndirectFieldValueNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) { // TODO: err
+	var fieldName types.Mlrval
+	this.fieldNameEvaluable.Evaluate(&fieldName, state)
 	if fieldName.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	// For normal DSL use the CST validator will prohibit this from being
@@ -105,7 +110,8 @@ func (this *IndirectFieldValueNode) Evaluate(state *runtime.State) types.Mlrval 
 	// print inrec attributes. Also, a UDF/UDS invoked from begin/end could try
 	// to access the inrec, and that would get past the validator.
 	if state.Inrec == nil {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	value, err := state.Inrec.GetWithMlrvalIndex(&fieldName)
@@ -116,9 +122,10 @@ func (this *IndirectFieldValueNode) Evaluate(state *runtime.State) types.Mlrval 
 		os.Exit(1)
 	}
 	if value == nil {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
-	return *value
+	output.CopyFrom(value)
 }
 
 // ----------------------------------------------------------------
@@ -141,15 +148,21 @@ func (this *RootNode) BuildIndirectOosvarValueNode(
 	}, nil
 }
 
-func (this *IndirectOosvarValueNode) Evaluate(state *runtime.State) types.Mlrval { // xxx err
-	oosvarName := this.oosvarNameEvaluable.Evaluate(state)
+func (this *IndirectOosvarValueNode) Evaluate(
+	output *types.Mlrval,
+	state *runtime.State,
+) { // TODO: err
+	var oosvarName types.Mlrval
+	this.oosvarNameEvaluable.Evaluate(&oosvarName, state)
 	if oosvarName.IsAbsent() {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
 
 	value := state.Oosvars.Get(oosvarName.String())
 	if value == nil {
-		return types.MlrvalFromAbsent()
+		output.SetFromAbsent()
+		return
 	}
-	return *value
+	output.CopyFrom(value)
 }

--- a/go/src/dsl/cst/filter.go
+++ b/go/src/dsl/cst/filter.go
@@ -32,6 +32,6 @@ func (this *RootNode) BuildFilterStatementNode(astNode *dsl.ASTNode) (IExecutabl
 }
 
 func (this *FilterStatementNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	state.FilterExpression = this.filterEvaluable.Evaluate(state)
+	this.filterEvaluable.Evaluate(&state.FilterExpression, state)
 	return nil, nil
 }

--- a/go/src/dsl/cst/for.go
+++ b/go/src/dsl/cst/for.go
@@ -116,11 +116,12 @@ func (this *RootNode) BuildForLoopOneVariableNode(astNode *dsl.ASTNode) (*ForLoo
 //
 
 func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	mlrval := this.indexableNode.Evaluate(state)
+	var indexMlrval types.Mlrval
+	this.indexableNode.Evaluate(&indexMlrval, state)
 
-	if mlrval.IsMap() {
+	if indexMlrval.IsMap() {
 
-		mapval := mlrval.GetMap()
+		mapval := indexMlrval.GetMap()
 
 		// Make a frame for the loop variable(s)
 		state.Stack.PushStackFrame()
@@ -152,9 +153,9 @@ func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 			}
 		}
 
-	} else if mlrval.IsArray() {
+	} else if indexMlrval.IsArray() {
 
-		arrayval := mlrval.GetArray()
+		arrayval := indexMlrval.GetArray()
 
 		// Note: Miller user-space array indices ("mindex") are 1-up. Internal
 		// Go storage ("zindex") is 0-up.
@@ -187,7 +188,7 @@ func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 			}
 		}
 
-	} else if mlrval.IsAbsent() {
+	} else if indexMlrval.IsAbsent() {
 		// Data-heterogeneity no-op
 	}
 
@@ -198,7 +199,7 @@ func (this *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 	//		return nil, errors.New(
 	//			fmt.Sprintf(
 	//				"Miller: looped-over item is not a map or array; got %s",
-	//				mlrval.GetTypeName(),
+	//				indexMlrval.GetTypeName(),
 	//			),
 	//		)
 
@@ -299,11 +300,12 @@ func (this *RootNode) BuildForLoopTwoVariableNode(astNode *dsl.ASTNode) (*ForLoo
 //
 
 func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	mlrval := this.indexableNode.Evaluate(state)
+	var indexMlrval types.Mlrval
+	this.indexableNode.Evaluate(&indexMlrval, state)
 
-	if mlrval.IsMap() {
+	if indexMlrval.IsMap() {
 
-		mapval := mlrval.GetMap()
+		mapval := indexMlrval.GetMap()
 
 		// Make a frame for the loop variable(s)
 		state.Stack.PushStackFrame()
@@ -339,9 +341,9 @@ func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 			}
 		}
 
-	} else if mlrval.IsArray() {
+	} else if indexMlrval.IsArray() {
 
-		arrayval := mlrval.GetArray()
+		arrayval := indexMlrval.GetArray()
 
 		// Note: Miller user-space array indices ("mindex") are 1-up. Internal
 		// Go storage ("zindex") is 0-up.
@@ -380,7 +382,7 @@ func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 			}
 		}
 
-	} else if mlrval.IsAbsent() {
+	} else if indexMlrval.IsAbsent() {
 		// Data-heterogeneity no-op
 	}
 
@@ -391,7 +393,7 @@ func (this *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 	//		return nil, errors.New(
 	//			fmt.Sprintf(
 	//				"Miller: looped-over item is not a map or array; got %s",
-	//				mlrval.GetTypeName(),
+	//				indexMlrval.GetTypeName(),
 	//			),
 	//		)
 
@@ -495,7 +497,8 @@ func (this *RootNode) BuildForLoopMultivariableNode(
 //
 
 func (this *ForLoopMultivariableNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	mlrval := this.indexableNode.Evaluate(state)
+	var indexMlrval types.Mlrval
+	this.indexableNode.Evaluate(&indexMlrval, state)
 
 	// Make a frame for the loop variables
 	state.Stack.PushStackFrame()
@@ -506,7 +509,7 @@ func (this *ForLoopMultivariableNode) Execute(state *runtime.State) (*BlockExitP
 	// from any of the latter is a break from all.  However, at this point, the
 	// break has been "broken" and should not be returned to the caller.
 	// Return-statements should, though.
-	blockExitPayload, err := this.executeOuter(&mlrval, this.keyVariableNames, state)
+	blockExitPayload, err := this.executeOuter(&indexMlrval, this.keyVariableNames, state)
 	if blockExitPayload == nil {
 		return nil, err
 	} else {
@@ -854,11 +857,13 @@ func (this *TripleForLoopNode) Execute(state *runtime.State) (*BlockExitPayload,
 		return nil, err
 	}
 
+	var continuationValue types.Mlrval
+
 	for {
 		// state.Stack.Dump()
 		// empty is true
 		if this.continuationExpressionNode != nil {
-			continuationValue := this.continuationExpressionNode.Evaluate(state)
+			this.continuationExpressionNode.Evaluate(&continuationValue, state)
 			boolValue, isBool := continuationValue.GetBoolValue()
 			if !isBool {
 				// TODO: propagate line-number context

--- a/go/src/dsl/cst/if.go
+++ b/go/src/dsl/cst/if.go
@@ -119,10 +119,11 @@ func (this *RootNode) BuildIfChainNode(astNode *dsl.ASTNode) (*IfChainNode, erro
 
 // ----------------------------------------------------------------
 func (this *IfChainNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
+	var condition types.Mlrval
 	for _, ifItem := range this.ifItems {
-		condition := types.MlrvalFromTrue()
+		condition.SetFromTrue()
 		if ifItem.conditionNode != nil {
-			condition = ifItem.conditionNode.Evaluate(state)
+			ifItem.conditionNode.Evaluate(&condition, state)
 		}
 		boolValue, isBool := condition.GetBoolValue()
 		if !isBool {

--- a/go/src/dsl/cst/leaves.go
+++ b/go/src/dsl/cst/leaves.go
@@ -191,7 +191,6 @@ func (this *LocalVariableNode) Evaluate(
 	state *runtime.State,
 ) {
 	value := state.Stack.Get(this.variableName)
-	//state.Stack.Dump()
 	if value == nil {
 		output.SetFromAbsent()
 	} else {

--- a/go/src/dsl/cst/lvalues.go
+++ b/go/src/dsl/cst/lvalues.go
@@ -206,6 +206,7 @@ func (this *IndirectFieldValueLvalueNode) AssignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) error {
+	var lhsFieldName types.Mlrval
 	// AssignmentNode checks for absentness of the rvalue, so we just assign
 	// whatever we get
 	lib.InternalCodingErrorIf(rvalue.IsAbsent())
@@ -219,7 +220,7 @@ func (this *IndirectFieldValueLvalueNode) AssignIndexed(
 		return errors.New("There is no current record to assign to.")
 	}
 
-	lhsFieldName := this.lhsFieldNameExpression.Evaluate(state)
+	this.lhsFieldNameExpression.Evaluate(&lhsFieldName, state)
 
 	if indices == nil {
 		err := state.Inrec.PutCopyWithMlrvalIndex(&lhsFieldName, rvalue)
@@ -229,7 +230,7 @@ func (this *IndirectFieldValueLvalueNode) AssignIndexed(
 		return nil
 	} else {
 		return state.Inrec.PutIndexed(
-			append([]*types.Mlrval{&lhsFieldName}, indices...),
+			append([]*types.Mlrval{lhsFieldName.Copy()}, indices...),
 			rvalue,
 		)
 	}
@@ -245,6 +246,7 @@ func (this *IndirectFieldValueLvalueNode) UnassignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) {
+	var lhsFieldName types.Mlrval
 	// For normal DSL use the CST validator will prohibit this from being
 	// called in places the current record is undefined (begin and end blocks).
 	// However in the REPL people can read past end of stream and still try to
@@ -254,13 +256,13 @@ func (this *IndirectFieldValueLvalueNode) UnassignIndexed(
 		return
 	}
 
-	lhsFieldName := this.lhsFieldNameExpression.Evaluate(state)
+	this.lhsFieldNameExpression.Evaluate(&lhsFieldName, state)
 	if indices == nil {
 		name := lhsFieldName.String()
 		state.Inrec.Remove(name)
 	} else {
 		state.Inrec.RemoveIndexed(
-			append([]*types.Mlrval{&lhsFieldName}, indices...),
+			append([]*types.Mlrval{lhsFieldName.Copy()}, indices...),
 		)
 	}
 }
@@ -299,6 +301,7 @@ func (this *PositionalFieldNameLvalueNode) Assign(
 	rvalue *types.Mlrval,
 	state *runtime.State,
 ) error {
+	var lhsFieldIndex types.Mlrval
 	// AssignmentNode checks for absentness of the rvalue, so we just assign
 	// whatever we get
 	lib.InternalCodingErrorIf(rvalue.IsAbsent())
@@ -312,7 +315,7 @@ func (this *PositionalFieldNameLvalueNode) Assign(
 		return errors.New("There is no current record to assign to.")
 	}
 
-	lhsFieldIndex := this.lhsFieldIndexExpression.Evaluate(state)
+	this.lhsFieldIndexExpression.Evaluate(&lhsFieldIndex, state)
 
 	index, ok := lhsFieldIndex.GetIntValue()
 	if ok {
@@ -351,7 +354,8 @@ func (this *PositionalFieldNameLvalueNode) UnassignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) {
-	lhsFieldIndex := this.lhsFieldIndexExpression.Evaluate(state)
+	var lhsFieldIndex types.Mlrval
+	this.lhsFieldIndexExpression.Evaluate(&lhsFieldIndex, state)
 
 	// For normal DSL use the CST validator will prohibit this from being
 	// called in places the current record is undefined (begin and end blocks).
@@ -419,6 +423,7 @@ func (this *PositionalFieldValueLvalueNode) AssignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) error {
+	var lhsFieldIndex types.Mlrval
 	// AssignmentNode checks for absentness of the rvalue, so we just assign
 	// whatever we get
 	lib.InternalCodingErrorIf(rvalue.IsAbsent())
@@ -432,7 +437,7 @@ func (this *PositionalFieldValueLvalueNode) AssignIndexed(
 		return errors.New("There is no current record to assign to.")
 	}
 
-	lhsFieldIndex := this.lhsFieldIndexExpression.Evaluate(state)
+	this.lhsFieldIndexExpression.Evaluate(&lhsFieldIndex, state)
 
 	if indices == nil {
 		index, ok := lhsFieldIndex.GetIntValue()
@@ -482,8 +487,9 @@ func (this *PositionalFieldValueLvalueNode) UnassignIndexed(
 	if state.Inrec == nil {
 		return
 	}
+	var lhsFieldIndex types.Mlrval
 
-	lhsFieldIndex := this.lhsFieldIndexExpression.Evaluate(state)
+	this.lhsFieldIndexExpression.Evaluate(&lhsFieldIndex, state)
 	if indices == nil {
 		index, ok := lhsFieldIndex.GetIntValue()
 		if ok {
@@ -679,11 +685,12 @@ func (this *IndirectOosvarValueLvalueNode) AssignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) error {
+	var lhsOosvarName types.Mlrval
 	// AssignmentNode checks for absentness of the rvalue, so we just assign
 	// whatever we get
 	lib.InternalCodingErrorIf(rvalue.IsAbsent())
 
-	lhsOosvarName := this.lhsOosvarNameExpression.Evaluate(state)
+	this.lhsOosvarNameExpression.Evaluate(&lhsOosvarName, state)
 
 	if indices == nil {
 		err := state.Oosvars.PutCopyWithMlrvalIndex(&lhsOosvarName, rvalue)
@@ -693,7 +700,7 @@ func (this *IndirectOosvarValueLvalueNode) AssignIndexed(
 		return nil
 	} else {
 		return state.Oosvars.PutIndexed(
-			append([]*types.Mlrval{&lhsOosvarName}, indices...),
+			append([]*types.Mlrval{lhsOosvarName.Copy()}, indices...),
 			rvalue,
 		)
 	}
@@ -709,14 +716,15 @@ func (this *IndirectOosvarValueLvalueNode) UnassignIndexed(
 	indices []*types.Mlrval,
 	state *runtime.State,
 ) {
-	name := this.lhsOosvarNameExpression.Evaluate(state)
+	var lhsOosvarName types.Mlrval
+	this.lhsOosvarNameExpression.Evaluate(&lhsOosvarName, state)
 
 	if indices == nil {
-		sname := name.String()
+		sname := lhsOosvarName.String()
 		state.Oosvars.Remove(sname)
 	} else {
 		state.Oosvars.RemoveIndexed(
-			append([]*types.Mlrval{&name}, indices...),
+			append([]*types.Mlrval{&lhsOosvarName}, indices...),
 		)
 	}
 }
@@ -883,6 +891,7 @@ func (this *LocalVariableLvalueNode) UnassignIndexed(
 type IndexedLvalueNode struct {
 	baseLvalue      IAssignable
 	indexEvaluables []IEvaluable
+	indices         []*types.Mlrval // malloc-avoidance
 }
 
 func (this *RootNode) BuildIndexedLvalueNode(astNode *dsl.ASTNode) (IAssignable, error) {
@@ -891,6 +900,7 @@ func (this *RootNode) BuildIndexedLvalueNode(astNode *dsl.ASTNode) (IAssignable,
 
 	var baseLvalue IAssignable = nil
 	indexEvaluables := make([]IEvaluable, 0)
+	indices := make([]*types.Mlrval, 0)
 	var err error = nil
 
 	// $ mlr -n put -v '$x[1][2]=3'
@@ -917,7 +927,9 @@ func (this *RootNode) BuildIndexedLvalueNode(astNode *dsl.ASTNode) (IAssignable,
 			if err != nil {
 				return nil, err
 			}
+			index := types.MlrvalFromError()
 			indexEvaluables = append([]IEvaluable{indexEvaluable}, indexEvaluables...)
+			indices = append([]*types.Mlrval{&index}, indices...)
 			walkerNode = walkerNode.Children[0]
 		} else {
 			baseLvalue, err = this.BuildAssignableNode(walkerNode)
@@ -927,16 +939,18 @@ func (this *RootNode) BuildIndexedLvalueNode(astNode *dsl.ASTNode) (IAssignable,
 			break
 		}
 	}
-	return NewIndexedLvalueNode(baseLvalue, indexEvaluables), nil
+	return NewIndexedLvalueNode(baseLvalue, indexEvaluables, indices), nil
 }
 
 func NewIndexedLvalueNode(
 	baseLvalue IAssignable,
 	indexEvaluables []IEvaluable,
+	indices []*types.Mlrval,
 ) *IndexedLvalueNode {
 	return &IndexedLvalueNode{
 		baseLvalue:      baseLvalue,
 		indexEvaluables: indexEvaluables,
+		indices:         indices,
 	}
 }
 
@@ -947,23 +961,21 @@ func (this *IndexedLvalueNode) Assign(
 	rvalue *types.Mlrval,
 	state *runtime.State,
 ) error {
-	indices := make([]*types.Mlrval, len(this.indexEvaluables))
 
 	for i, indexEvaluable := range this.indexEvaluables {
-		index := indexEvaluable.Evaluate(state)
-		indices[i] = &index
-		if index.IsAbsent() {
+		indexEvaluable.Evaluate(this.indices[i], state)
+		if this.indices[i].IsAbsent() {
 			return nil
 		}
 	}
 
 	// This lets the user do '$y[ ["a", "b", "c"] ] = $x' in lieu of
 	// '$y["a"]["b"]["c"] = $x'.
-	if len(indices) == 1 && indices[0].IsArray() {
-		indices = types.MakePointerArray(indices[0].GetArray())
+	if len(this.indices) == 1 && this.indices[0].IsArray() {
+		this.indices = types.MakePointerArray(this.indices[0].GetArray())
 	}
 
-	return this.baseLvalue.AssignIndexed(rvalue, indices, state)
+	return this.baseLvalue.AssignIndexed(rvalue, this.indices, state)
 }
 
 func (this *IndexedLvalueNode) AssignIndexed(
@@ -979,14 +991,11 @@ func (this *IndexedLvalueNode) AssignIndexed(
 func (this *IndexedLvalueNode) Unassign(
 	state *runtime.State,
 ) {
-	indices := make([]*types.Mlrval, len(this.indexEvaluables))
-
 	for i, indexEvaluable := range this.indexEvaluables {
-		index := indexEvaluable.Evaluate(state)
-		indices[i] = &index
+		indexEvaluable.Evaluate(this.indices[i], state)
 	}
 
-	this.baseLvalue.UnassignIndexed(indices, state)
+	this.baseLvalue.UnassignIndexed(this.indices, state)
 }
 
 func (this *IndexedLvalueNode) UnassignIndexed(
@@ -1026,11 +1035,12 @@ func (this *EnvironmentVariableLvalueNode) Assign(
 	rvalue *types.Mlrval,
 	state *runtime.State,
 ) error {
+	var name types.Mlrval
 	// AssignmentNode checks for absentness of the rvalue, so we just assign
 	// whatever we get
 	lib.InternalCodingErrorIf(rvalue.IsAbsent())
 
-	name := this.nameExpression.Evaluate(state)
+	this.nameExpression.Evaluate(&name, state)
 	if name.IsAbsent() {
 		return nil
 	}
@@ -1060,7 +1070,8 @@ func (this *EnvironmentVariableLvalueNode) AssignIndexed(
 func (this *EnvironmentVariableLvalueNode) Unassign(
 	state *runtime.State,
 ) {
-	name := this.nameExpression.Evaluate(state)
+	var name types.Mlrval
+	this.nameExpression.Evaluate(&name, state)
 	if name.IsAbsent() {
 		return
 	}

--- a/go/src/dsl/cst/print.go
+++ b/go/src/dsl/cst/print.go
@@ -312,12 +312,13 @@ func (this *PrintStatementNode) Execute(state *runtime.State) (*BlockExitPayload
 		//
 		// Plus: we never have to worry about forgetting to do fflush(). :)
 		var buffer bytes.Buffer
+		var evaluation types.Mlrval
 
 		for i, expressionEvaluable := range this.expressionEvaluables {
 			if i > 0 {
 				buffer.WriteString(" ")
 			}
-			evaluation := expressionEvaluable.Evaluate(state)
+			expressionEvaluable.Evaluate(&evaluation, state)
 			if !evaluation.IsAbsent() {
 				buffer.WriteString(evaluation.String())
 			}
@@ -360,7 +361,8 @@ func (this *PrintStatementNode) printToFileOrPipe(
 	outputString string,
 	state *runtime.State,
 ) error {
-	redirectorTarget := this.redirectorTargetEvaluable.Evaluate(state)
+	var redirectorTarget types.Mlrval // malloc-avoidance
+	this.redirectorTargetEvaluable.Evaluate(&redirectorTarget, state)
 	if !redirectorTarget.IsString() {
 		return errors.New(
 			fmt.Sprintf(

--- a/go/src/dsl/cst/subroutines.go
+++ b/go/src/dsl/cst/subroutines.go
@@ -11,6 +11,7 @@ package cst
 import (
 	"miller/src/dsl"
 	"miller/src/lib"
+	"miller/src/types"
 )
 
 // ----------------------------------------------------------------
@@ -54,12 +55,14 @@ func (this *RootNode) BuildSubroutineCallsiteNode(astNode *dsl.ASTNode) (IExecut
 	// Here we need to make an array of our arguments at the callsite, to be
 	// paired up with the parameters within he subroutine definition at runtime.
 	argumentNodes := make([]IEvaluable, callsiteArity)
+	arguments := make([]types.Mlrval, callsiteArity)
 	for i, argumentASTNode := range astNode.Children {
 		argumentNode, err := this.BuildEvaluableNode(argumentASTNode)
 		if err != nil {
 			return nil, err
 		}
 		argumentNodes[i] = argumentNode
+		arguments[i] = types.MlrvalFromError()
 	}
 
 	if uds == nil {
@@ -68,11 +71,11 @@ func (this *RootNode) BuildSubroutineCallsiteNode(astNode *dsl.ASTNode) (IExecut
 		// this callsite. This happens example when a subroutine is called before
 		// it's defined.
 		uds = NewUnresolvedUDS(subroutineName, callsiteArity)
-		udsCallsiteNode := NewUDSCallsite(argumentNodes, uds)
+		udsCallsiteNode := NewUDSCallsite(argumentNodes, arguments, uds)
 		this.rememberUnresolvedSubroutineCallsite(udsCallsiteNode)
 		return udsCallsiteNode, nil
 	} else {
-		udsCallsiteNode := NewUDSCallsite(argumentNodes, uds)
+		udsCallsiteNode := NewUDSCallsite(argumentNodes, arguments, uds)
 		return udsCallsiteNode, nil
 	}
 }

--- a/go/src/dsl/cst/tee.go
+++ b/go/src/dsl/cst/tee.go
@@ -141,16 +141,17 @@ func (this *RootNode) BuildTeeStatementNode(astNode *dsl.ASTNode) (IExecutable, 
 
 // ----------------------------------------------------------------
 func (this *TeeStatementNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
-	evaluation := this.expressionEvaluable.Evaluate(state)
-	if !evaluation.IsMap() {
+	var expression types.Mlrval
+	this.expressionEvaluable.Evaluate(&expression, state)
+	if !expression.IsMap() {
 		return nil, errors.New(
 			fmt.Sprintf(
 				"%s: tee-evaluaiton yielded %s, not map.",
-				lib.MlrExeName(), evaluation.GetTypeName(),
+				lib.MlrExeName(), expression.GetTypeName(),
 			),
 		)
 	}
-	err := this.teeToRedirectFunc(evaluation.GetMap(), state)
+	err := this.teeToRedirectFunc(expression.GetMap(), state)
 	return nil, err
 }
 
@@ -159,7 +160,8 @@ func (this *TeeStatementNode) teeToFileOrPipe(
 	outrec *types.Mlrmap,
 	state *runtime.State,
 ) error {
-	redirectorTarget := this.redirectorTargetEvaluable.Evaluate(state)
+	var redirectorTarget types.Mlrval // malloc-avoidance
+	this.redirectorTargetEvaluable.Evaluate(&redirectorTarget, state)
 	if !redirectorTarget.IsString() {
 		return errors.New(
 			fmt.Sprintf(

--- a/go/src/dsl/cst/types.go
+++ b/go/src/dsl/cst/types.go
@@ -62,7 +62,7 @@ type IAssignable interface {
 // Also, for computed field names on the left-hand side, like '$a . $b' in mlr
 // put '$[$a . $b]' = $x + $y'.
 type IEvaluable interface {
-	Evaluate(state *runtime.State) types.Mlrval
+	Evaluate(output *types.Mlrval, state *runtime.State)
 }
 
 // ================================================================

--- a/go/src/dsl/cst/while.go
+++ b/go/src/dsl/cst/while.go
@@ -10,6 +10,7 @@ import (
 	"miller/src/dsl"
 	"miller/src/lib"
 	"miller/src/runtime"
+	"miller/src/types"
 )
 
 // ================================================================
@@ -49,8 +50,9 @@ func (this *RootNode) BuildWhileLoopNode(astNode *dsl.ASTNode) (*WhileLoopNode, 
 
 // ----------------------------------------------------------------
 func (this *WhileLoopNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
+	var condition types.Mlrval
 	for {
-		condition := this.conditionNode.Evaluate(state)
+		this.conditionNode.Evaluate(&condition, state)
 		boolValue, isBool := condition.GetBoolValue()
 		if !isBool {
 			// TODO: line-number/token info for the DSL expression.
@@ -119,6 +121,7 @@ func (this *RootNode) BuildDoWhileLoopNode(astNode *dsl.ASTNode) (*DoWhileLoopNo
 
 // ----------------------------------------------------------------
 func (this *DoWhileLoopNode) Execute(state *runtime.State) (*BlockExitPayload, error) {
+	var condition types.Mlrval
 	for {
 		blockExitPayload, err := this.statementBlockNode.Execute(state)
 		if err != nil {
@@ -140,7 +143,7 @@ func (this *DoWhileLoopNode) Execute(state *runtime.State) (*BlockExitPayload, e
 		// TODO: handle return statements
 		// TODO: runtime errors for any other types
 
-		condition := this.conditionNode.Evaluate(state)
+		this.conditionNode.Evaluate(&condition, state)
 		boolValue, isBool := condition.GetBoolValue()
 		if !isBool {
 			// TODO: line-number/token info for the DSL expression.

--- a/go/src/runtime/stack.go
+++ b/go/src/runtime/stack.go
@@ -322,7 +322,7 @@ func (this *StackFrame) set(
 		this.vars[variableName] = slot
 		return nil
 	} else {
-		return slot.Assign(mlrval.Copy())
+		return slot.Assign(mlrval)
 	}
 }
 

--- a/go/src/transformers/clean-whitespace.go
+++ b/go/src/transformers/clean-whitespace.go
@@ -137,8 +137,11 @@ func (this *TransformerCleanWhitespace) cleanWhitespaceInKeysAndValues(
 
 		for pe := inrecAndContext.Record.Head; pe != nil; pe = pe.Next {
 			oldKey := types.MlrvalFromString(pe.Key)
-			newKey := types.MlrvalCleanWhitespace(&oldKey)
-			newValue := types.MlrvalCleanWhitespace(pe.Value)
+			// xxx temp
+			newKey := types.MlrvalFromAbsent()
+			newValue := types.MlrvalFromAbsent()
+			types.MlrvalCleanWhitespace(&newKey, &oldKey)
+			types.MlrvalCleanWhitespace(&newValue, pe.Value)
 			// Transferring ownership from old record to new record; no copy needed
 			newrec.PutReference(newKey.String(), &newValue)
 		}
@@ -159,7 +162,9 @@ func (this *TransformerCleanWhitespace) cleanWhitespaceInKeys(
 
 		for pe := inrecAndContext.Record.Head; pe != nil; pe = pe.Next {
 			oldKey := types.MlrvalFromString(pe.Key)
-			newKey := types.MlrvalCleanWhitespace(&oldKey)
+			// xxx temp
+			newKey := types.MlrvalFromAbsent()
+			types.MlrvalCleanWhitespace(&newKey, &oldKey)
 			// Transferring ownership from old record to new record; no copy needed
 			newrec.PutReference(newKey.String(), pe.Value)
 		}
@@ -177,8 +182,7 @@ func (this *TransformerCleanWhitespace) cleanWhitespaceInValues(
 ) {
 	if !inrecAndContext.EndOfStream {
 		for pe := inrecAndContext.Record.Head; pe != nil; pe = pe.Next {
-			newValue := types.MlrvalCleanWhitespace(pe.Value)
-			pe.Value = &newValue
+			types.MlrvalCleanWhitespace(pe.Value, pe.Value)
 		}
 		outputChannel <- inrecAndContext
 	} else {

--- a/go/src/transformers/percentile-keeper.go
+++ b/go/src/transformers/percentile-keeper.go
@@ -229,6 +229,7 @@ func computeIndexNoninterpolated(n int, p float64) int {
 	return index
 }
 
+// xxx pending pointer-output refactor
 func getPercentileLinearlyInterpolated(array []*types.Mlrval, n int, p float64) types.Mlrval {
 	findex := (p / 100.0) * (float64(n) - 1)
 	if findex < 0.0 {
@@ -240,10 +241,16 @@ func getPercentileLinearlyInterpolated(array []*types.Mlrval, n int, p float64) 
 	} else {
 		// array[iindex] + frac * (array[iindex+1] - array[iindex])
 		// TODO: just do this in float64.
-		frac := types.MlrvalFromFloat64(findex - float64(iindex))
-		diff := types.MlrvalBinaryMinus(array[iindex+1], array[iindex])
-		prod := types.MlrvalTimes(&frac, &diff)
-		return types.MlrvalBinaryPlus(array[iindex], &prod)
+		frac := types.MlrvalFromError()
+		diff := types.MlrvalFromError()
+		prod := types.MlrvalFromError()
+		output := types.MlrvalFromError()
+
+		frac.SetFromFloat64(findex - float64(iindex))
+		types.MlrvalBinaryMinus(&diff, array[iindex+1], array[iindex])
+		types.MlrvalTimes(&prod, &frac, &diff)
+		types.MlrvalBinaryPlus(&output, array[iindex], &prod)
+		return output
 	}
 }
 

--- a/go/src/transformers/seqgen.go
+++ b/go/src/transformers/seqgen.go
@@ -116,6 +116,7 @@ type TransformerSeqgen struct {
 	stop           types.Mlrval
 	step           types.Mlrval
 	doneComparator types.BinaryFunc
+	mdone          types.Mlrval
 }
 
 // ----------------------------------------------------------------
@@ -180,6 +181,7 @@ func NewTransformerSeqgen(
 		stop:           stop,
 		step:           step,
 		doneComparator: doneComparator,
+		mdone:          types.MlrvalFromBool(false),
 	}, nil
 }
 
@@ -193,8 +195,8 @@ func (this *TransformerSeqgen) Transform(
 	context.UpdateForStartOfFile("seqgen")
 
 	for {
-		mdone := this.doneComparator(&counter, &this.stop)
-		done, _ := mdone.GetBoolValue()
+		this.doneComparator(&this.mdone, &counter, &this.stop)
+		done, _ := this.mdone.GetBoolValue()
 		if done {
 			break
 		}
@@ -207,7 +209,7 @@ func (this *TransformerSeqgen) Transform(
 		outrecAndContext := types.NewRecordAndContext(outrec, context)
 		outputChannel <- outrecAndContext
 
-		counter = types.MlrvalBinaryPlus(&counter, &this.step)
+		types.MlrvalBinaryPlus(&counter, &counter, &this.step)
 	}
 
 	outputChannel <- types.NewEndOfStreamMarker(context)

--- a/go/src/transformers/step.go
+++ b/go/src/transformers/step.go
@@ -370,9 +370,9 @@ func (this *tStepperDelta) process(
 ) {
 	var delta types.Mlrval
 	if this.previous == nil {
-		delta = types.MlrvalFromInt(0)
+		delta.SetFromInt(0)
 	} else {
-		delta = types.MlrvalBinaryMinus(valueFieldValue, this.previous)
+		types.MlrvalBinaryMinus(&delta, valueFieldValue, this.previous)
 	}
 	inrec.PutCopy(this.outputFieldName, &delta)
 
@@ -434,14 +434,14 @@ func (this *tStepperFromFirst) process(
 	valueFieldValue *types.Mlrval,
 	inrec *types.Mlrmap,
 ) {
-	var from_first types.Mlrval
+	var fromFirst types.Mlrval
 	if this.first == nil {
-		from_first = types.MlrvalFromInt(0)
+		fromFirst.SetFromInt(0)
 		this.first = valueFieldValue.Copy()
 	} else {
-		from_first = types.MlrvalBinaryMinus(valueFieldValue, this.first)
+		types.MlrvalBinaryMinus(&fromFirst, valueFieldValue, this.first)
 	}
-	inrec.PutCopy(this.outputFieldName, &from_first)
+	inrec.PutCopy(this.outputFieldName, &fromFirst)
 }
 
 // ================================================================
@@ -467,9 +467,9 @@ func (this *tStepperRatio) process(
 ) {
 	var ratio types.Mlrval
 	if this.previous == nil {
-		ratio = types.MlrvalFromInt(1)
+		ratio.SetFromInt(1)
 	} else {
-		ratio = types.MlrvalDivide(valueFieldValue, this.previous)
+		types.MlrvalDivide(&ratio, valueFieldValue, this.previous)
 	}
 	inrec.PutCopy(this.outputFieldName, &ratio)
 
@@ -497,7 +497,7 @@ func (this *tStepperRsum) process(
 	valueFieldValue *types.Mlrval,
 	inrec *types.Mlrmap,
 ) {
-	this.rsum = types.MlrvalBinaryPlus(valueFieldValue, &this.rsum)
+	types.MlrvalBinaryPlus(&this.rsum, valueFieldValue, &this.rsum)
 	inrec.PutCopy(this.outputFieldName, &this.rsum)
 }
 
@@ -524,7 +524,7 @@ func (this *tStepperCounter) process(
 	valueFieldValue *types.Mlrval,
 	inrec *types.Mlrmap,
 ) {
-	this.counter = types.MlrvalBinaryPlus(&this.counter, &this.one)
+	types.MlrvalBinaryPlus(&this.counter, &this.counter, &this.one)
 	inrec.PutCopy(this.outputFieldName, &this.counter)
 }
 
@@ -600,9 +600,13 @@ func (this *tStepperEWMA) process(
 	} else {
 		for i, _ := range this.alphas {
 			curr := valueFieldValue.Copy()
-			product1 := types.MlrvalTimes(curr, &this.alphas[i])
-			product2 := types.MlrvalTimes(&this.prevs[i], &this.oneMinusAlphas[i])
-			next := types.MlrvalBinaryPlus(&product1, &product2)
+			// xxx pending pointer-output refactor
+			var product1 types.Mlrval
+			var product2 types.Mlrval
+			var next types.Mlrval
+			types.MlrvalTimes(&product1, curr, &this.alphas[i])
+			types.MlrvalTimes(&product2, &this.prevs[i], &this.oneMinusAlphas[i])
+			types.MlrvalBinaryPlus(&next, &product1, &product2)
 			inrec.PutCopy(this.outputFieldNames[i], &next)
 			this.prevs[i] = next
 		}

--- a/go/src/types/mlrmap_accessors.go
+++ b/go/src/types/mlrmap_accessors.go
@@ -294,8 +294,10 @@ func (this *Mlrmap) Contains(that *Mlrmap) bool {
 		}
 		thisval := this.Get(pe.Key)
 		thatval := pe.Value
-		meq := MlrvalEquals(thisval, thatval)
-		eq, _ := meq.GetBoolValue()
+		meq := MlrvalFromError()
+		MlrvalEquals(&meq, thisval, thatval)
+		eq, ok := meq.GetBoolValue()
+		lib.InternalCodingErrorIf(!ok)
 		if !eq {
 			return false
 		}

--- a/go/src/types/mlrmap_flatten_unflatten.go
+++ b/go/src/types/mlrmap_flatten_unflatten.go
@@ -102,7 +102,8 @@ func (this *Mlrmap) Unflatten(separator string) {
 
 	for pe := this.Head; pe != nil; pe = pe.Next {
 		if strings.Contains(pe.Key, separator) {
-			arrayOfIndices := mlrvalSplitAXHelper(pe.Key, separator)
+			arrayOfIndices := MlrvalFromError()
+			mlrvalSplitAXHelper(&arrayOfIndices, pe.Key, separator)
 			that.PutIndexed(
 				MakePointerArray(arrayOfIndices.arrayval),
 				unflattenTerminal(pe.Value).Copy(),
@@ -125,7 +126,8 @@ func (this *Mlrmap) UnflattenFields(
 
 	for pe := this.Head; pe != nil; pe = pe.Next {
 		if strings.Contains(pe.Key, separator) {
-			arrayOfIndices := mlrvalSplitAXHelper(pe.Key, separator)
+			arrayOfIndices := MlrvalFromError()
+			mlrvalSplitAXHelper(&arrayOfIndices, pe.Key, separator)
 			lib.InternalCodingErrorIf(len(arrayOfIndices.arrayval) < 1)
 			baseIndex := arrayOfIndices.arrayval[0].String()
 			if fieldNameSet[baseIndex] {

--- a/go/src/types/mlrval_function_hashing.go
+++ b/go/src/types/mlrval_function_hashing.go
@@ -8,50 +8,50 @@ import (
 	"fmt"
 )
 
-func MlrvalMD5(ma *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
+func MlrvalMD5(input1 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	return MlrvalFromString(
 		fmt.Sprintf(
 			"%x",
-			md5.Sum([]byte(ma.printrep)),
+			md5.Sum([]byte(input1.printrep)),
 		),
 	)
 }
 
-func MlrvalSHA1(ma *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
+func MlrvalSHA1(input1 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	return MlrvalFromString(
 		fmt.Sprintf(
 			"%x",
-			sha1.Sum([]byte(ma.printrep)),
+			sha1.Sum([]byte(input1.printrep)),
 		),
 	)
 }
 
-func MlrvalSHA256(ma *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
+func MlrvalSHA256(input1 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	return MlrvalFromString(
 		fmt.Sprintf(
 			"%x",
-			sha256.Sum256([]byte(ma.printrep)),
+			sha256.Sum256([]byte(input1.printrep)),
 		),
 	)
 }
 
-func MlrvalSHA512(ma *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
+func MlrvalSHA512(input1 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	return MlrvalFromString(
 		fmt.Sprintf(
 			"%x",
-			sha512.Sum512([]byte(ma.printrep)),
+			sha512.Sum512([]byte(input1.printrep)),
 		),
 	)
 }

--- a/go/src/types/mlrval_function_hashing.go
+++ b/go/src/types/mlrval_function_hashing.go
@@ -8,50 +8,54 @@ import (
 	"fmt"
 )
 
-func MlrvalMD5(input1 *Mlrval) Mlrval {
+func MlrvalMD5(output, input1 *Mlrval) {
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+	} else {
+		output.SetFromString(
+			fmt.Sprintf(
+				"%x",
+				md5.Sum([]byte(input1.printrep)),
+			),
+		)
 	}
-	return MlrvalFromString(
-		fmt.Sprintf(
-			"%x",
-			md5.Sum([]byte(input1.printrep)),
-		),
-	)
 }
 
-func MlrvalSHA1(input1 *Mlrval) Mlrval {
+func MlrvalSHA1(output, input1 *Mlrval) {
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+	} else {
+		output.SetFromString(
+			fmt.Sprintf(
+				"%x",
+				sha1.Sum([]byte(input1.printrep)),
+			),
+		)
 	}
-	return MlrvalFromString(
-		fmt.Sprintf(
-			"%x",
-			sha1.Sum([]byte(input1.printrep)),
-		),
-	)
 }
 
-func MlrvalSHA256(input1 *Mlrval) Mlrval {
+func MlrvalSHA256(output, input1 *Mlrval) {
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+	} else {
+		output.SetFromString(
+			fmt.Sprintf(
+				"%x",
+				sha256.Sum256([]byte(input1.printrep)),
+			),
+		)
 	}
-	return MlrvalFromString(
-		fmt.Sprintf(
-			"%x",
-			sha256.Sum256([]byte(input1.printrep)),
-		),
-	)
 }
 
-func MlrvalSHA512(input1 *Mlrval) Mlrval {
+func MlrvalSHA512(output, input1 *Mlrval) {
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+	} else {
+		output.SetFromString(
+			fmt.Sprintf(
+				"%x",
+				sha512.Sum512([]byte(input1.printrep)),
+			),
+		)
 	}
-	return MlrvalFromString(
-		fmt.Sprintf(
-			"%x",
-			sha512.Sum512([]byte(input1.printrep)),
-		),
-	)
 }

--- a/go/src/types/mlrval_functions_arithmetic.go
+++ b/go/src/types/mlrval_functions_arithmetic.go
@@ -67,7 +67,7 @@ func MlrvalLogicalNOT(output, input1 *Mlrval) {
 
 // Auto-overflows up to float.  Additions & subtractions overflow by at most
 // one bit so it suffices to check sign-changes.
-func plus_n_ii(input1, input2 *Mlrval) Mlrval {
+func plus_n_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 	c := a + b
@@ -84,20 +84,20 @@ func plus_n_ii(input1, input2 *Mlrval) Mlrval {
 	}
 
 	if overflowed {
-		return MlrvalFromFloat64(float64(a) + float64(b))
+		output.SetFromFloat64(float64(a) + float64(b))
 	} else {
-		return MlrvalFromInt(c)
+		output.SetFromInt(c)
 	}
 }
 
-func plus_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) + input2.floatval)
+func plus_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) + input2.floatval)
 }
-func plus_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval + float64(input2.intval))
+func plus_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval + float64(input2.intval))
 }
-func plus_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval + input2.floatval)
+func plus_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval + input2.floatval)
 }
 
 var plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -113,8 +113,8 @@ var plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryPlus(input1, input2 *Mlrval) Mlrval {
-	return plus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalBinaryPlus(output, input1, input2 *Mlrval) {
+	plus_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -123,7 +123,7 @@ func MlrvalBinaryPlus(input1, input2 *Mlrval) Mlrval {
 
 // Adds & subtracts overflow by at most one bit so it suffices to check
 // sign-changes.
-func minus_n_ii(input1, input2 *Mlrval) Mlrval {
+func minus_n_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 	c := a - b
@@ -140,20 +140,20 @@ func minus_n_ii(input1, input2 *Mlrval) Mlrval {
 	}
 
 	if overflowed {
-		return MlrvalFromFloat64(float64(a) - float64(b))
+		output.SetFromFloat64(float64(a) - float64(b))
 	} else {
-		return MlrvalFromInt(c)
+		output.SetFromInt(c)
 	}
 }
 
-func minus_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) - input2.floatval)
+func minus_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) - input2.floatval)
 }
-func minus_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval - float64(input2.intval))
+func minus_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval - float64(input2.intval))
 }
-func minus_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval - input2.floatval)
+func minus_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval - input2.floatval)
 }
 
 var minus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -169,8 +169,8 @@ var minus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMinus(input1, input2 *Mlrval) Mlrval {
-	return minus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalBinaryMinus(output, input1, input2 *Mlrval) {
+	minus_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -206,26 +206,26 @@ func MlrvalBinaryMinus(input1, input2 *Mlrval) Mlrval {
 // double less than 2**63. (An alterative would be to do all integer multiplies
 // using handcrafted multi-word 128-bit arithmetic).
 
-func times_n_ii(input1, input2 *Mlrval) Mlrval {
+func times_n_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 	c := float64(a) * float64(b)
 
 	if math.Abs(c) > 9223372036854774784.0 {
-		return MlrvalFromFloat64(c)
+		output.SetFromFloat64(c)
 	} else {
-		return MlrvalFromInt(a * b)
+		output.SetFromInt(a * b)
 	}
 }
 
-func times_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) * input2.floatval)
+func times_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) * input2.floatval)
 }
-func times_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval * float64(input2.intval))
+func times_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval * float64(input2.intval))
 }
-func times_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval * input2.floatval)
+func times_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval * input2.floatval)
 }
 
 var times_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -241,8 +241,8 @@ var times_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalTimes(input1, input2 *Mlrval) Mlrval {
-	return times_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalTimes(output, input1, input2 *Mlrval) {
+	times_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -262,39 +262,42 @@ func MlrvalTimes(input1, input2 *Mlrval) Mlrval {
 //   $ echo 'x=1e-300,y=1e300' | mlr put '$z=$y/$x'
 //   x=1e-300,y=1e300,z=+Inf
 
-func divide_n_ii(input1, input2 *Mlrval) Mlrval {
+func divide_n_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
-		return MlrvalFromFloat64(float64(a) / float64(b))
+		output.SetFromFloat64(float64(a) / float64(b))
+		return
 	}
 
 	// Pythonic division, not C division.
 	if a%b == 0 {
-		return MlrvalFromInt(a / b)
+		output.SetFromInt(a / b)
+		return
 	} else {
-		return MlrvalFromFloat64(float64(a) / float64(b))
+		output.SetFromFloat64(float64(a) / float64(b))
+		return
 	}
 
 	c := float64(a) * float64(b)
 
 	if math.Abs(c) > 9223372036854774784.0 {
-		return MlrvalFromFloat64(c)
+		output.SetFromFloat64(c)
 	} else {
-		return MlrvalFromInt(a * b)
+		output.SetFromInt(a * b)
 	}
 }
 
-func divide_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) / input2.floatval)
+func divide_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) / input2.floatval)
 }
-func divide_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval / float64(input2.intval))
+func divide_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval / float64(input2.intval))
 }
-func divide_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval / input2.floatval)
+func divide_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval / input2.floatval)
 }
 
 var divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -310,21 +313,22 @@ var divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDivide(input1, input2 *Mlrval) Mlrval {
-	return divide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDivide(output, input1, input2 *Mlrval) {
+	divide_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
 // Integer division: DSL operator '//' as in Python.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func int_divide_n_ii(input1, input2 *Mlrval) Mlrval {
+func int_divide_n_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
-		return MlrvalFromFloat64(float64(a) / float64(b))
+		output.SetFromFloat64(float64(a) / float64(b))
+		return
 	}
 
 	// Pythonic division, not C division.
@@ -343,17 +347,17 @@ func int_divide_n_ii(input1, input2 *Mlrval) Mlrval {
 			}
 		}
 	}
-	return MlrvalFromInt(q)
+	output.SetFromInt(q)
 }
 
-func int_divide_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
+func int_divide_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
 }
-func int_divide_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
+func int_divide_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
 }
-func int_divide_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(input1.floatval / input2.floatval))
+func int_divide_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(input1.floatval / input2.floatval))
 }
 
 var int_divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -369,25 +373,25 @@ var int_divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalIntDivide(input1, input2 *Mlrval) Mlrval {
-	return int_divide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalIntDivide(output, input1, input2 *Mlrval) {
+	int_divide_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
 // Non-auto-overflowing addition: DSL operator '.+'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotplus_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval + input2.intval)
+func dotplus_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval + input2.intval)
 }
-func dotplus_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) + input2.floatval)
+func dotplus_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) + input2.floatval)
 }
-func dotplus_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval + float64(input2.intval))
+func dotplus_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval + float64(input2.intval))
 }
-func dotplus_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval + input2.floatval)
+func dotplus_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval + input2.floatval)
 }
 
 var dot_plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -403,25 +407,25 @@ var dot_plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotPlus(input1, input2 *Mlrval) Mlrval {
-	return dot_plus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDotPlus(output, input1, input2 *Mlrval) {
+	dot_plus_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
 // Non-auto-overflowing subtraction: DSL operator '.-'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotminus_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval - input2.intval)
+func dotminus_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval - input2.intval)
 }
-func dotminus_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) - input2.floatval)
+func dotminus_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) - input2.floatval)
 }
-func dotminus_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval - float64(input2.intval))
+func dotminus_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval - float64(input2.intval))
 }
-func dotminus_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval - input2.floatval)
+func dotminus_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval - input2.floatval)
 }
 
 var dotminus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -437,25 +441,25 @@ var dotminus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotMinus(input1, input2 *Mlrval) Mlrval {
-	return dotminus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDotMinus(output, input1, input2 *Mlrval) {
+	dotminus_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Non-auto-overflowing multiplication: DSL operator '.*'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dottimes_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval * input2.intval)
+func dottimes_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval * input2.intval)
 }
-func dottimes_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) * input2.floatval)
+func dottimes_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) * input2.floatval)
 }
-func dottimes_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval * float64(input2.intval))
+func dottimes_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval * float64(input2.intval))
 }
-func dottimes_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval * input2.floatval)
+func dottimes_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval * input2.floatval)
 }
 
 var dottimes_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -471,25 +475,25 @@ var dottimes_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotTimes(input1, input2 *Mlrval) Mlrval {
-	return dottimes_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDotTimes(output, input1, input2 *Mlrval) {
+	dottimes_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // 64-bit integer division: DSL operator './'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotdivide_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval / input2.intval)
+func dotdivide_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval / input2.intval)
 }
-func dotdivide_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval) / input2.floatval)
+func dotdivide_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval) / input2.floatval)
 }
-func dotdivide_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval / float64(input2.intval))
+func dotdivide_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval / float64(input2.intval))
 }
-func dotdivide_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(input1.floatval / input2.floatval)
+func dotdivide_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(input1.floatval / input2.floatval)
 }
 
 var dotdivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -505,21 +509,22 @@ var dotdivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotDivide(input1, input2 *Mlrval) Mlrval {
-	return dotdivide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDotDivide(output, input1, input2 *Mlrval) {
+	dotdivide_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // 64-bit integer division: DSL operator './/'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotidivide_i_ii(input1, input2 *Mlrval) Mlrval {
+func dotidivide_i_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
-		return MlrvalFromFloat64(float64(a) / float64(b))
+		output.SetFromFloat64(float64(a) / float64(b))
+		return
 	}
 
 	// Pythonic division, not C division.
@@ -538,17 +543,17 @@ func dotidivide_i_ii(input1, input2 *Mlrval) Mlrval {
 			}
 		}
 	}
-	return MlrvalFromInt(q)
+	output.SetFromInt(q)
 }
 
-func dotidivide_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
+func dotidivide_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
 }
-func dotidivide_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
+func dotidivide_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
 }
-func dotidivide_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(input1.floatval / input2.floatval))
+func dotidivide_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Floor(input1.floatval / input2.floatval))
 }
 
 var dotidivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -564,20 +569,21 @@ var dotidivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotIntDivide(input1, input2 *Mlrval) Mlrval {
-	return dotidivide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDotIntDivide(output, input1, input2 *Mlrval) {
+	dotidivide_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Modulus
 
-func modulus_i_ii(input1, input2 *Mlrval) Mlrval {
+func modulus_i_ii(output, input1, input2 *Mlrval) {
 	a := input1.intval
 	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
-		return MlrvalFromFloat64(float64(a) / float64(b))
+		output.SetFromFloat64(float64(a) / float64(b))
+		return
 	}
 
 	// Pythonic division, not C division.
@@ -592,25 +598,25 @@ func modulus_i_ii(input1, input2 *Mlrval) Mlrval {
 		}
 	}
 
-	return MlrvalFromInt(m)
+	output.SetFromInt(m)
 }
 
-func modulus_f_fi(input1, input2 *Mlrval) Mlrval {
+func modulus_f_fi(output, input1, input2 *Mlrval) {
 	a := input1.floatval
 	b := float64(input2.intval)
-	return MlrvalFromFloat64(a - b*math.Floor(a/b))
+	output.SetFromFloat64(a - b*math.Floor(a/b))
 }
 
-func modulus_f_if(input1, input2 *Mlrval) Mlrval {
+func modulus_f_if(output, input1, input2 *Mlrval) {
 	a := float64(input1.intval)
 	b := input2.floatval
-	return MlrvalFromFloat64(a - b*math.Floor(a/b))
+	output.SetFromFloat64(a - b*math.Floor(a/b))
 }
 
-func modulus_f_ff(input1, input2 *Mlrval) Mlrval {
+func modulus_f_ff(output, input1, input2 *Mlrval) {
 	a := input1.floatval
 	b := input2.floatval
-	return MlrvalFromFloat64(a - b*math.Floor(a/b))
+	output.SetFromFloat64(a - b*math.Floor(a/b))
 }
 
 var modulus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -626,8 +632,8 @@ var modulus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalModulus(input1, input2 *Mlrval) Mlrval {
-	return modulus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalModulus(output, input1, input2 *Mlrval) {
+	modulus_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -740,31 +746,31 @@ func MlrvalModExp(output, input1, input2, input3 *Mlrval) {
 // * empty-null always loses against numbers
 
 // ----------------------------------------------------------------
-func min_f_ff(input1, input2 *Mlrval) Mlrval {
+func min_f_ff(output, input1, input2 *Mlrval) {
 	var a float64 = input1.floatval
 	var b float64 = input2.floatval
-	return MlrvalFromFloat64(math.Min(a, b))
+	output.SetFromFloat64(math.Min(a, b))
 }
 
-func min_f_fi(input1, input2 *Mlrval) Mlrval {
+func min_f_fi(output, input1, input2 *Mlrval) {
 	var a float64 = input1.floatval
 	var b float64 = float64(input2.intval)
-	return MlrvalFromFloat64(math.Min(a, b))
+	output.SetFromFloat64(math.Min(a, b))
 }
 
-func min_f_if(input1, input2 *Mlrval) Mlrval {
+func min_f_if(output, input1, input2 *Mlrval) {
 	var a float64 = float64(input1.intval)
 	var b float64 = input2.floatval
-	return MlrvalFromFloat64(math.Min(a, b))
+	output.SetFromFloat64(math.Min(a, b))
 }
 
-func min_i_ii(input1, input2 *Mlrval) Mlrval {
+func min_i_ii(output, input1, input2 *Mlrval) {
 	var a int = input1.intval
 	var b int = input2.intval
 	if a < b {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
@@ -772,21 +778,21 @@ func min_i_ii(input1, input2 *Mlrval) Mlrval {
 // --- + ----- -----
 // a=F | min=a min=a
 // a=T | min=b min=b
-func min_b_bb(input1, input2 *Mlrval) Mlrval {
+func min_b_bb(output, input1, input2 *Mlrval) {
 	if input1.boolval == false {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
-func min_s_ss(input1, input2 *Mlrval) Mlrval {
+func min_s_ss(output, input1, input2 *Mlrval) {
 	var a string = input1.printrep
 	var b string = input2.printrep
 	if a < b {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
@@ -803,48 +809,48 @@ var min_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMin(input1, input2 *Mlrval) Mlrval {
-	return (min_dispositions[input1.mvtype][input2.mvtype])(input1, input2)
+func MlrvalBinaryMin(output, input1, input2 *Mlrval) {
+	(min_dispositions[input1.mvtype][input2.mvtype])(output, input1, input2)
 }
 
-func MlrvalVariadicMin(mlrvals []*Mlrval) Mlrval {
+func MlrvalVariadicMin(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) == 0 {
-		return MlrvalFromVoid()
+		output.SetFromVoid()
 	} else {
 		retval := *mlrvals[0]
 		for _, mlrval := range mlrvals[1:] {
-			retval = MlrvalBinaryMin(&retval, mlrval)
+			MlrvalBinaryMin(&retval, &retval, mlrval)
 		}
-		return retval
+		output.CopyFrom(&retval)
 	}
 }
 
 // ----------------------------------------------------------------
-func max_f_ff(input1, input2 *Mlrval) Mlrval {
+func max_f_ff(output, input1, input2 *Mlrval) {
 	var a float64 = input1.floatval
 	var b float64 = input2.floatval
-	return MlrvalFromFloat64(math.Max(a, b))
+	output.SetFromFloat64(math.Max(a, b))
 }
 
-func max_f_fi(input1, input2 *Mlrval) Mlrval {
+func max_f_fi(output, input1, input2 *Mlrval) {
 	var a float64 = input1.floatval
 	var b float64 = float64(input2.intval)
-	return MlrvalFromFloat64(math.Max(a, b))
+	output.SetFromFloat64(math.Max(a, b))
 }
 
-func max_f_if(input1, input2 *Mlrval) Mlrval {
+func max_f_if(output, input1, input2 *Mlrval) {
 	var a float64 = float64(input1.intval)
 	var b float64 = input2.floatval
-	return MlrvalFromFloat64(math.Max(a, b))
+	output.SetFromFloat64(math.Max(a, b))
 }
 
-func max_i_ii(input1, input2 *Mlrval) Mlrval {
+func max_i_ii(output, input1, input2 *Mlrval) {
 	var a int = input1.intval
 	var b int = input2.intval
 	if a > b {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
@@ -852,21 +858,21 @@ func max_i_ii(input1, input2 *Mlrval) Mlrval {
 // --- + ----- -----
 // a=F | max=a max=b
 // a=T | max=a max=b
-func max_b_bb(input1, input2 *Mlrval) Mlrval {
+func max_b_bb(output, input1, input2 *Mlrval) {
 	if input2.boolval == false {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
-func max_s_ss(input1, input2 *Mlrval) Mlrval {
+func max_s_ss(output, input1, input2 *Mlrval) {
 	var a string = input1.printrep
 	var b string = input2.printrep
 	if a > b {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input2
+		output.CopyFrom(input2)
 	}
 }
 
@@ -883,18 +889,18 @@ var max_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMax(input1, input2 *Mlrval) Mlrval {
-	return (max_dispositions[input1.mvtype][input2.mvtype])(input1, input2)
+func MlrvalBinaryMax(output, input1, input2 *Mlrval) {
+	(max_dispositions[input1.mvtype][input2.mvtype])(output, input1, input2)
 }
 
-func MlrvalVariadicMax(mlrvals []*Mlrval) Mlrval {
+func MlrvalVariadicMax(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) == 0 {
-		return MlrvalFromVoid()
+		output.SetFromVoid()
 	} else {
 		retval := *mlrvals[0]
 		for _, mlrval := range mlrvals[1:] {
-			retval = MlrvalBinaryMax(&retval, mlrval)
+			MlrvalBinaryMax(&retval, &retval, mlrval)
 		}
-		return retval
+		output.CopyFrom(&retval)
 	}
 }

--- a/go/src/types/mlrval_functions_arithmetic.go
+++ b/go/src/types/mlrval_functions_arithmetic.go
@@ -19,19 +19,19 @@ var upos_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalUnaryPlus(ma *Mlrval) Mlrval {
-	return upos_dispositions[ma.mvtype](ma)
+func MlrvalUnaryPlus(input1 *Mlrval) Mlrval {
+	return upos_dispositions[input1.mvtype](input1)
 }
 
 // ================================================================
 // Unary minus operator
 
-func uneg_i_i(ma *Mlrval) Mlrval {
-	return MlrvalFromInt(-ma.intval)
+func uneg_i_i(input1 *Mlrval) Mlrval {
+	return MlrvalFromInt(-input1.intval)
 }
 
-func uneg_f_f(ma *Mlrval) Mlrval {
-	return MlrvalFromFloat64(-ma.floatval)
+func uneg_f_f(input1 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(-input1.floatval)
 }
 
 var uneg_dispositions = [MT_DIM]UnaryFunc{
@@ -46,16 +46,16 @@ var uneg_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalUnaryMinus(ma *Mlrval) Mlrval {
-	return uneg_dispositions[ma.mvtype](ma)
+func MlrvalUnaryMinus(input1 *Mlrval) Mlrval {
+	return uneg_dispositions[input1.mvtype](input1)
 }
 
 // ================================================================
 // Logical NOT operator
 
-func MlrvalLogicalNOT(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_BOOL {
-		return MlrvalFromBool(!ma.boolval)
+func MlrvalLogicalNOT(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_BOOL {
+		return MlrvalFromBool(!input1.boolval)
 	} else {
 		return MlrvalFromError()
 	}
@@ -67,9 +67,9 @@ func MlrvalLogicalNOT(ma *Mlrval) Mlrval {
 
 // Auto-overflows up to float.  Additions & subtractions overflow by at most
 // one bit so it suffices to check sign-changes.
-func plus_n_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func plus_n_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 	c := a + b
 
 	overflowed := false
@@ -90,14 +90,14 @@ func plus_n_ii(ma, mb *Mlrval) Mlrval {
 	}
 }
 
-func plus_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) + mb.floatval)
+func plus_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) + input2.floatval)
 }
-func plus_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval + float64(mb.intval))
+func plus_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval + float64(input2.intval))
 }
-func plus_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval + mb.floatval)
+func plus_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval + input2.floatval)
 }
 
 var plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -113,8 +113,8 @@ var plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryPlus(ma, mb *Mlrval) Mlrval {
-	return plus_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalBinaryPlus(input1, input2 *Mlrval) Mlrval {
+	return plus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
@@ -123,9 +123,9 @@ func MlrvalBinaryPlus(ma, mb *Mlrval) Mlrval {
 
 // Adds & subtracts overflow by at most one bit so it suffices to check
 // sign-changes.
-func minus_n_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func minus_n_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 	c := a - b
 
 	overflowed := false
@@ -146,14 +146,14 @@ func minus_n_ii(ma, mb *Mlrval) Mlrval {
 	}
 }
 
-func minus_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) - mb.floatval)
+func minus_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) - input2.floatval)
 }
-func minus_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval - float64(mb.intval))
+func minus_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval - float64(input2.intval))
 }
-func minus_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval - mb.floatval)
+func minus_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval - input2.floatval)
 }
 
 var minus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -169,8 +169,8 @@ var minus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMinus(ma, mb *Mlrval) Mlrval {
-	return minus_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalBinaryMinus(input1, input2 *Mlrval) Mlrval {
+	return minus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
@@ -206,9 +206,9 @@ func MlrvalBinaryMinus(ma, mb *Mlrval) Mlrval {
 // double less than 2**63. (An alterative would be to do all integer multiplies
 // using handcrafted multi-word 128-bit arithmetic).
 
-func times_n_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func times_n_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 	c := float64(a) * float64(b)
 
 	if math.Abs(c) > 9223372036854774784.0 {
@@ -218,14 +218,14 @@ func times_n_ii(ma, mb *Mlrval) Mlrval {
 	}
 }
 
-func times_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) * mb.floatval)
+func times_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) * input2.floatval)
 }
-func times_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval * float64(mb.intval))
+func times_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval * float64(input2.intval))
 }
-func times_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval * mb.floatval)
+func times_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval * input2.floatval)
 }
 
 var times_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -241,8 +241,8 @@ var times_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalTimes(ma, mb *Mlrval) Mlrval {
-	return times_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalTimes(input1, input2 *Mlrval) Mlrval {
+	return times_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
@@ -262,9 +262,9 @@ func MlrvalTimes(ma, mb *Mlrval) Mlrval {
 //   $ echo 'x=1e-300,y=1e300' | mlr put '$z=$y/$x'
 //   x=1e-300,y=1e300,z=+Inf
 
-func divide_n_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func divide_n_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
@@ -287,14 +287,14 @@ func divide_n_ii(ma, mb *Mlrval) Mlrval {
 	}
 }
 
-func divide_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) / mb.floatval)
+func divide_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) / input2.floatval)
 }
-func divide_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval / float64(mb.intval))
+func divide_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval / float64(input2.intval))
 }
-func divide_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval / mb.floatval)
+func divide_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval / input2.floatval)
 }
 
 var divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -310,17 +310,17 @@ var divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDivide(ma, mb *Mlrval) Mlrval {
-	return divide_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDivide(input1, input2 *Mlrval) Mlrval {
+	return divide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
 // Integer division: DSL operator '//' as in Python.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func int_divide_n_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func int_divide_n_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
@@ -346,14 +346,14 @@ func int_divide_n_ii(ma, mb *Mlrval) Mlrval {
 	return MlrvalFromInt(q)
 }
 
-func int_divide_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(float64(ma.intval) / mb.floatval))
+func int_divide_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
 }
-func int_divide_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(ma.floatval / float64(mb.intval)))
+func int_divide_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
 }
-func int_divide_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(ma.floatval / mb.floatval))
+func int_divide_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(input1.floatval / input2.floatval))
 }
 
 var int_divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -369,25 +369,25 @@ var int_divide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalIntDivide(ma, mb *Mlrval) Mlrval {
-	return int_divide_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalIntDivide(input1, input2 *Mlrval) Mlrval {
+	return int_divide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
 // Non-auto-overflowing addition: DSL operator '.+'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotplus_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval + mb.intval)
+func dotplus_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval + input2.intval)
 }
-func dotplus_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) + mb.floatval)
+func dotplus_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) + input2.floatval)
 }
-func dotplus_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval + float64(mb.intval))
+func dotplus_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval + float64(input2.intval))
 }
-func dotplus_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval + mb.floatval)
+func dotplus_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval + input2.floatval)
 }
 
 var dot_plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -403,25 +403,25 @@ var dot_plus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotPlus(ma, mb *Mlrval) Mlrval {
-	return dot_plus_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDotPlus(input1, input2 *Mlrval) Mlrval {
+	return dot_plus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
 // Non-auto-overflowing subtraction: DSL operator '.-'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotminus_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval - mb.intval)
+func dotminus_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval - input2.intval)
 }
-func dotminus_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) - mb.floatval)
+func dotminus_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) - input2.floatval)
 }
-func dotminus_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval - float64(mb.intval))
+func dotminus_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval - float64(input2.intval))
 }
-func dotminus_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval - mb.floatval)
+func dotminus_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval - input2.floatval)
 }
 
 var dotminus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -437,25 +437,25 @@ var dotminus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotMinus(ma, mb *Mlrval) Mlrval {
-	return dotminus_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDotMinus(input1, input2 *Mlrval) Mlrval {
+	return dotminus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Non-auto-overflowing multiplication: DSL operator '.*'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dottimes_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval * mb.intval)
+func dottimes_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval * input2.intval)
 }
-func dottimes_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) * mb.floatval)
+func dottimes_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) * input2.floatval)
 }
-func dottimes_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval * float64(mb.intval))
+func dottimes_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval * float64(input2.intval))
 }
-func dottimes_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval * mb.floatval)
+func dottimes_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval * input2.floatval)
 }
 
 var dottimes_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -471,25 +471,25 @@ var dottimes_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotTimes(ma, mb *Mlrval) Mlrval {
-	return dottimes_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDotTimes(input1, input2 *Mlrval) Mlrval {
+	return dottimes_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // 64-bit integer division: DSL operator './'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotdivide_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval / mb.intval)
+func dotdivide_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval / input2.intval)
 }
-func dotdivide_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval) / mb.floatval)
+func dotdivide_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval) / input2.floatval)
 }
-func dotdivide_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval / float64(mb.intval))
+func dotdivide_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval / float64(input2.intval))
 }
-func dotdivide_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(ma.floatval / mb.floatval)
+func dotdivide_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(input1.floatval / input2.floatval)
 }
 
 var dotdivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -505,17 +505,17 @@ var dotdivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotDivide(ma, mb *Mlrval) Mlrval {
-	return dotdivide_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDotDivide(input1, input2 *Mlrval) Mlrval {
+	return dotdivide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // 64-bit integer division: DSL operator './/'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func dotidivide_i_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func dotidivide_i_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
@@ -541,14 +541,14 @@ func dotidivide_i_ii(ma, mb *Mlrval) Mlrval {
 	return MlrvalFromInt(q)
 }
 
-func dotidivide_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(float64(ma.intval) / mb.floatval))
+func dotidivide_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(float64(input1.intval) / input2.floatval))
 }
-func dotidivide_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(ma.floatval / float64(mb.intval)))
+func dotidivide_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(input1.floatval / float64(input2.intval)))
 }
-func dotidivide_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Floor(ma.floatval / mb.floatval))
+func dotidivide_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Floor(input1.floatval / input2.floatval))
 }
 
 var dotidivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -564,16 +564,16 @@ var dotidivide_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalDotIntDivide(ma, mb *Mlrval) Mlrval {
-	return dotidivide_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDotIntDivide(input1, input2 *Mlrval) Mlrval {
+	return dotidivide_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Modulus
 
-func modulus_i_ii(ma, mb *Mlrval) Mlrval {
-	a := ma.intval
-	b := mb.intval
+func modulus_i_ii(input1, input2 *Mlrval) Mlrval {
+	a := input1.intval
+	b := input2.intval
 
 	if b == 0 {
 		// Compute inf/nan as with floats rather than fatal runtime FPE on integer divide by zero
@@ -595,21 +595,21 @@ func modulus_i_ii(ma, mb *Mlrval) Mlrval {
 	return MlrvalFromInt(m)
 }
 
-func modulus_f_fi(ma, mb *Mlrval) Mlrval {
-	a := ma.floatval
-	b := float64(mb.intval)
+func modulus_f_fi(input1, input2 *Mlrval) Mlrval {
+	a := input1.floatval
+	b := float64(input2.intval)
 	return MlrvalFromFloat64(a - b*math.Floor(a/b))
 }
 
-func modulus_f_if(ma, mb *Mlrval) Mlrval {
-	a := float64(ma.intval)
-	b := mb.floatval
+func modulus_f_if(input1, input2 *Mlrval) Mlrval {
+	a := float64(input1.intval)
+	b := input2.floatval
 	return MlrvalFromFloat64(a - b*math.Floor(a/b))
 }
 
-func modulus_f_ff(ma, mb *Mlrval) Mlrval {
-	a := ma.floatval
-	b := mb.floatval
+func modulus_f_ff(input1, input2 *Mlrval) Mlrval {
+	a := input1.floatval
+	b := input2.floatval
 	return MlrvalFromFloat64(a - b*math.Floor(a/b))
 }
 
@@ -626,8 +626,8 @@ var modulus_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalModulus(ma, mb *Mlrval) Mlrval {
-	return modulus_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalModulus(input1, input2 *Mlrval) Mlrval {
+	return modulus_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
@@ -675,47 +675,47 @@ func imodexp(a, e, m int) int {
 	return c
 }
 
-func imodop(ma, mb, mc *Mlrval, iop i_iii_func) Mlrval {
-	if !ma.IsLegit() {
-		return *ma
+func imodop(input1, input2, input3 *Mlrval, iop i_iii_func) Mlrval {
+	if !input1.IsLegit() {
+		return *input1
 	}
-	if !mb.IsLegit() {
-		return *mb
+	if !input2.IsLegit() {
+		return *input2
 	}
-	if !mc.IsLegit() {
-		return *mc
+	if !input3.IsLegit() {
+		return *input3
 	}
-	if !ma.IsInt() {
+	if !input1.IsInt() {
 		return MlrvalFromError()
 	}
-	if !mb.IsInt() {
+	if !input2.IsInt() {
 		return MlrvalFromError()
 	}
-	if !mc.IsInt() {
+	if !input3.IsInt() {
 		return MlrvalFromError()
 	}
 
-	return MlrvalFromInt(iop(ma.intval, mb.intval, mc.intval))
+	return MlrvalFromInt(iop(input1.intval, input2.intval, input3.intval))
 }
 
-func MlrvalModAdd(ma, mb, mc *Mlrval) Mlrval {
-	return imodop(ma, mb, mc, imodadd)
+func MlrvalModAdd(input1, input2, input3 *Mlrval) Mlrval {
+	return imodop(input1, input2, input3, imodadd)
 }
 
-func MlrvalModSub(ma, mb, mc *Mlrval) Mlrval {
-	return imodop(ma, mb, mc, imodsub)
+func MlrvalModSub(input1, input2, input3 *Mlrval) Mlrval {
+	return imodop(input1, input2, input3, imodsub)
 }
 
-func MlrvalModMul(ma, mb, mc *Mlrval) Mlrval {
-	return imodop(ma, mb, mc, imodmul)
+func MlrvalModMul(input1, input2, input3 *Mlrval) Mlrval {
+	return imodop(input1, input2, input3, imodmul)
 }
 
-func MlrvalModExp(ma, mb, mc *Mlrval) Mlrval {
+func MlrvalModExp(input1, input2, input3 *Mlrval) Mlrval {
 	// Pre-check for negative exponent
-	if mb.mvtype == MT_INT && mb.intval < 0 {
+	if input2.mvtype == MT_INT && input2.intval < 0 {
 		return MlrvalFromError()
 	}
-	return imodop(ma, mb, mc, imodexp)
+	return imodop(input1, input2, input3, imodexp)
 }
 
 // ================================================================
@@ -733,31 +733,31 @@ func MlrvalModExp(ma, mb, mc *Mlrval) Mlrval {
 // * empty-null always loses against numbers
 
 // ----------------------------------------------------------------
-func min_f_ff(ma, mb *Mlrval) Mlrval {
-	var a float64 = ma.floatval
-	var b float64 = mb.floatval
+func min_f_ff(input1, input2 *Mlrval) Mlrval {
+	var a float64 = input1.floatval
+	var b float64 = input2.floatval
 	return MlrvalFromFloat64(math.Min(a, b))
 }
 
-func min_f_fi(ma, mb *Mlrval) Mlrval {
-	var a float64 = ma.floatval
-	var b float64 = float64(mb.intval)
+func min_f_fi(input1, input2 *Mlrval) Mlrval {
+	var a float64 = input1.floatval
+	var b float64 = float64(input2.intval)
 	return MlrvalFromFloat64(math.Min(a, b))
 }
 
-func min_f_if(ma, mb *Mlrval) Mlrval {
-	var a float64 = float64(ma.intval)
-	var b float64 = mb.floatval
+func min_f_if(input1, input2 *Mlrval) Mlrval {
+	var a float64 = float64(input1.intval)
+	var b float64 = input2.floatval
 	return MlrvalFromFloat64(math.Min(a, b))
 }
 
-func min_i_ii(ma, mb *Mlrval) Mlrval {
-	var a int = ma.intval
-	var b int = mb.intval
+func min_i_ii(input1, input2 *Mlrval) Mlrval {
+	var a int = input1.intval
+	var b int = input2.intval
 	if a < b {
-		return *ma
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
@@ -765,21 +765,21 @@ func min_i_ii(ma, mb *Mlrval) Mlrval {
 // --- + ----- -----
 // a=F | min=a min=a
 // a=T | min=b min=b
-func min_b_bb(ma, mb *Mlrval) Mlrval {
-	if ma.boolval == false {
-		return *ma
+func min_b_bb(input1, input2 *Mlrval) Mlrval {
+	if input1.boolval == false {
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
-func min_s_ss(ma, mb *Mlrval) Mlrval {
-	var a string = ma.printrep
-	var b string = mb.printrep
+func min_s_ss(input1, input2 *Mlrval) Mlrval {
+	var a string = input1.printrep
+	var b string = input2.printrep
 	if a < b {
-		return *ma
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
@@ -796,8 +796,8 @@ var min_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMin(ma, mb *Mlrval) Mlrval {
-	return (min_dispositions[ma.mvtype][mb.mvtype])(ma, mb)
+func MlrvalBinaryMin(input1, input2 *Mlrval) Mlrval {
+	return (min_dispositions[input1.mvtype][input2.mvtype])(input1, input2)
 }
 
 func MlrvalVariadicMin(mlrvals []*Mlrval) Mlrval {
@@ -813,31 +813,31 @@ func MlrvalVariadicMin(mlrvals []*Mlrval) Mlrval {
 }
 
 // ----------------------------------------------------------------
-func max_f_ff(ma, mb *Mlrval) Mlrval {
-	var a float64 = ma.floatval
-	var b float64 = mb.floatval
+func max_f_ff(input1, input2 *Mlrval) Mlrval {
+	var a float64 = input1.floatval
+	var b float64 = input2.floatval
 	return MlrvalFromFloat64(math.Max(a, b))
 }
 
-func max_f_fi(ma, mb *Mlrval) Mlrval {
-	var a float64 = ma.floatval
-	var b float64 = float64(mb.intval)
+func max_f_fi(input1, input2 *Mlrval) Mlrval {
+	var a float64 = input1.floatval
+	var b float64 = float64(input2.intval)
 	return MlrvalFromFloat64(math.Max(a, b))
 }
 
-func max_f_if(ma, mb *Mlrval) Mlrval {
-	var a float64 = float64(ma.intval)
-	var b float64 = mb.floatval
+func max_f_if(input1, input2 *Mlrval) Mlrval {
+	var a float64 = float64(input1.intval)
+	var b float64 = input2.floatval
 	return MlrvalFromFloat64(math.Max(a, b))
 }
 
-func max_i_ii(ma, mb *Mlrval) Mlrval {
-	var a int = ma.intval
-	var b int = mb.intval
+func max_i_ii(input1, input2 *Mlrval) Mlrval {
+	var a int = input1.intval
+	var b int = input2.intval
 	if a > b {
-		return *ma
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
@@ -845,21 +845,21 @@ func max_i_ii(ma, mb *Mlrval) Mlrval {
 // --- + ----- -----
 // a=F | max=a max=b
 // a=T | max=a max=b
-func max_b_bb(ma, mb *Mlrval) Mlrval {
-	if mb.boolval == false {
-		return *ma
+func max_b_bb(input1, input2 *Mlrval) Mlrval {
+	if input2.boolval == false {
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
-func max_s_ss(ma, mb *Mlrval) Mlrval {
-	var a string = ma.printrep
-	var b string = mb.printrep
+func max_s_ss(input1, input2 *Mlrval) Mlrval {
+	var a string = input1.printrep
+	var b string = input2.printrep
 	if a > b {
-		return *ma
+		return *input1
 	} else {
-		return *mb
+		return *input2
 	}
 }
 
@@ -876,8 +876,8 @@ var max_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBinaryMax(ma, mb *Mlrval) Mlrval {
-	return (max_dispositions[ma.mvtype][mb.mvtype])(ma, mb)
+func MlrvalBinaryMax(input1, input2 *Mlrval) Mlrval {
+	return (max_dispositions[input1.mvtype][input2.mvtype])(input1, input2)
 }
 
 func MlrvalVariadicMax(mlrvals []*Mlrval) Mlrval {

--- a/go/src/types/mlrval_functions_arithmetic.go
+++ b/go/src/types/mlrval_functions_arithmetic.go
@@ -19,19 +19,19 @@ var upos_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalUnaryPlus(input1 *Mlrval) Mlrval {
-	return upos_dispositions[input1.mvtype](input1)
+func MlrvalUnaryPlus(output, input1 *Mlrval) {
+	upos_dispositions[input1.mvtype](output, input1)
 }
 
 // ================================================================
 // Unary minus operator
 
-func uneg_i_i(input1 *Mlrval) Mlrval {
-	return MlrvalFromInt(-input1.intval)
+func uneg_i_i(output, input1 *Mlrval) {
+	output.SetFromInt(-input1.intval)
 }
 
-func uneg_f_f(input1 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(-input1.floatval)
+func uneg_f_f(output, input1 *Mlrval) {
+	output.SetFromFloat64(-input1.floatval)
 }
 
 var uneg_dispositions = [MT_DIM]UnaryFunc{
@@ -46,18 +46,18 @@ var uneg_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalUnaryMinus(input1 *Mlrval) Mlrval {
-	return uneg_dispositions[input1.mvtype](input1)
+func MlrvalUnaryMinus(output, input1 *Mlrval) {
+	uneg_dispositions[input1.mvtype](output, input1)
 }
 
 // ================================================================
 // Logical NOT operator
 
-func MlrvalLogicalNOT(input1 *Mlrval) Mlrval {
+func MlrvalLogicalNOT(output, input1 *Mlrval) {
 	if input1.mvtype == MT_BOOL {
-		return MlrvalFromBool(!input1.boolval)
+		output.SetFromBool(!input1.boolval)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 

--- a/go/src/types/mlrval_functions_arithmetic.go
+++ b/go/src/types/mlrval_functions_arithmetic.go
@@ -675,47 +675,54 @@ func imodexp(a, e, m int) int {
 	return c
 }
 
-func imodop(input1, input2, input3 *Mlrval, iop i_iii_func) Mlrval {
+func imodop(output, input1, input2, input3 *Mlrval, iop i_iii_func) {
 	if !input1.IsLegit() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if !input2.IsLegit() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if !input3.IsLegit() {
-		return *input3
+		output.CopyFrom(input3)
+		return
 	}
 	if !input1.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input3.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	return MlrvalFromInt(iop(input1.intval, input2.intval, input3.intval))
+	output.SetFromInt(iop(input1.intval, input2.intval, input3.intval))
 }
 
-func MlrvalModAdd(input1, input2, input3 *Mlrval) Mlrval {
-	return imodop(input1, input2, input3, imodadd)
+func MlrvalModAdd(output, input1, input2, input3 *Mlrval) {
+	imodop(output, input1, input2, input3, imodadd)
 }
 
-func MlrvalModSub(input1, input2, input3 *Mlrval) Mlrval {
-	return imodop(input1, input2, input3, imodsub)
+func MlrvalModSub(output, input1, input2, input3 *Mlrval) {
+	imodop(output, input1, input2, input3, imodsub)
 }
 
-func MlrvalModMul(input1, input2, input3 *Mlrval) Mlrval {
-	return imodop(input1, input2, input3, imodmul)
+func MlrvalModMul(output, input1, input2, input3 *Mlrval) {
+	imodop(output, input1, input2, input3, imodmul)
 }
 
-func MlrvalModExp(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalModExp(output, input1, input2, input3 *Mlrval) {
 	// Pre-check for negative exponent
 	if input2.mvtype == MT_INT && input2.intval < 0 {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
-	return imodop(input1, input2, input3, imodexp)
+	imodop(output, input1, input2, input3, imodexp)
 }
 
 // ================================================================

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -82,77 +82,77 @@ type ComparatorFunc func(*Mlrval, *Mlrval) int
 
 // ----------------------------------------------------------------
 // Return error (unary)
-func _erro1(ma *Mlrval) Mlrval {
+func _erro1(input1 *Mlrval) Mlrval {
 	return MlrvalFromError()
 }
 
 // Return absent (unary)
-func _absn1(ma *Mlrval) Mlrval {
+func _absn1(input1 *Mlrval) Mlrval {
 	return MlrvalFromAbsent()
 }
 
 // Return void (unary)
-func _void1(ma *Mlrval) Mlrval {
+func _void1(input1 *Mlrval) Mlrval {
 	return MlrvalFromAbsent()
 }
 
 // Return argument (unary)
-func _1u___(ma *Mlrval) Mlrval {
-	return *ma
+func _1u___(input1 *Mlrval) Mlrval {
+	return *input1
 }
 
 // ----------------------------------------------------------------
 // Return error (binary)
-func _erro(ma, mb *Mlrval) Mlrval {
+func _erro(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromError()
 }
 
 // Return absent (binary)
-func _absn(ma, mb *Mlrval) Mlrval {
+func _absn(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromAbsent()
 }
 
 // Return void (binary)
-func _void(ma, mb *Mlrval) Mlrval {
+func _void(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromVoid()
 }
 
 // Return first argument (binary)
-func _1___(ma, mb *Mlrval) Mlrval {
-	return *ma
+func _1___(input1, input2 *Mlrval) Mlrval {
+	return *input1
 }
 
 // Return second argument (binary)
-func _2___(ma, mb *Mlrval) Mlrval {
-	return *mb
+func _2___(input1, input2 *Mlrval) Mlrval {
+	return *input2
 }
 
 // Return first argument, as string (binary)
-func _s1__(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromString(ma.String())
+func _s1__(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromString(input1.String())
 }
 
 // Return second argument, as string (binary)
-func _s2__(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromString(mb.String())
+func _s2__(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromString(input2.String())
 }
 
 // Return integer zero (binary)
-func _i0__(ma, mb *Mlrval) Mlrval {
+func _i0__(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromInt(0)
 }
 
 // Return float zero (binary)
-func _f0__(ma, mb *Mlrval) Mlrval {
+func _f0__(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromFloat64(0.0)
 }
 
 // Return boolean true (binary)
-func _true(ma, mb *Mlrval) Mlrval {
+func _true(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromBool(true)
 }
 
 // Return boolean false (binary)
-func _fals(ma, mb *Mlrval) Mlrval {
+func _fals(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromBool(false)
 }

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -48,7 +48,7 @@
 package types
 
 // Function-pointer type for zary functions.
-type ZaryFunc func() Mlrval
+type ZaryFunc func(output *Mlrval)
 
 // Function-pointer type for unary-operator disposition vectors.
 type UnaryFunc func(*Mlrval) Mlrval

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -55,7 +55,7 @@ type UnaryFunc func(output, input1 *Mlrval)
 
 // The asserting_{type} need access to the context to say things like 'Assertion ... failed
 // at filename {FILENAME} record number {NR}'.
-type ContextualUnaryFunc func(*Mlrval, *Context) Mlrval
+type ContextualUnaryFunc func(output, input1 *Mlrval, context *Context)
 
 // Helps keystroke-saving for wrapping Go math-library functions
 // Examples: cos, sin, etc.

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -63,13 +63,13 @@ type mathLibUnaryFunc func(float64) float64
 type mathLibUnaryFuncWrapper func(output, input1 *Mlrval, f mathLibUnaryFunc)
 
 // Function-pointer type for binary-operator disposition matrices.
-type BinaryFunc func(*Mlrval, *Mlrval) Mlrval
+type BinaryFunc func(output, input1, input2 *Mlrval)
 
 // Function-pointer type for ternary functions
 type TernaryFunc func(output, input1, input2, input3 *Mlrval)
 
 // Function-pointer type for variadic functions.
-type VariadicFunc func([]*Mlrval) Mlrval
+type VariadicFunc func(output *Mlrval, inputs []*Mlrval)
 
 // Function-pointer type for sorting. Returns < 0 if a < b, 0 if a == b, > 0 if a > b.
 type ComparatorFunc func(*Mlrval, *Mlrval) int
@@ -103,56 +103,56 @@ func _1u___(output, input1 *Mlrval) {
 
 // ----------------------------------------------------------------
 // Return error (binary)
-func _erro(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromError()
+func _erro(output, input1, input2 *Mlrval) {
+	output.SetFromError()
 }
 
 // Return absent (binary)
-func _absn(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromAbsent()
+func _absn(output, input1, input2 *Mlrval) {
+	output.SetFromAbsent()
 }
 
 // Return void (binary)
-func _void(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromVoid()
+func _void(output, input1, input2 *Mlrval) {
+	output.SetFromVoid()
 }
 
 // Return first argument (binary)
-func _1___(input1, input2 *Mlrval) Mlrval {
-	return *input1
+func _1___(output, input1, input2 *Mlrval) {
+	output.CopyFrom(input1)
 }
 
 // Return second argument (binary)
-func _2___(input1, input2 *Mlrval) Mlrval {
-	return *input2
+func _2___(output, input1, input2 *Mlrval) {
+	output.CopyFrom(input2)
 }
 
 // Return first argument, as string (binary)
-func _s1__(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(input1.String())
+func _s1__(output, input1, input2 *Mlrval) {
+	output.SetFromString(input1.String())
 }
 
 // Return second argument, as string (binary)
-func _s2__(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(input2.String())
+func _s2__(output, input1, input2 *Mlrval) {
+	output.SetFromString(input2.String())
 }
 
 // Return integer zero (binary)
-func _i0__(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(0)
+func _i0__(output, input1, input2 *Mlrval) {
+	output.SetFromInt(0)
 }
 
 // Return float zero (binary)
-func _f0__(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(0.0)
+func _f0__(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(0.0)
 }
 
 // Return boolean true (binary)
-func _true(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(true)
+func _true(output, input1, input2 *Mlrval) {
+	output.SetFromBool(true)
 }
 
 // Return boolean false (binary)
-func _fals(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(false)
+func _fals(output, input1, input2 *Mlrval) {
+	output.SetFromBool(false)
 }

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -51,7 +51,7 @@ package types
 type ZaryFunc func(output *Mlrval)
 
 // Function-pointer type for unary-operator disposition vectors.
-type UnaryFunc func(*Mlrval) Mlrval
+type UnaryFunc func(output, input1 *Mlrval)
 
 // The asserting_{type} need access to the context to say things like 'Assertion ... failed
 // at filename {FILENAME} record number {NR}'.
@@ -60,7 +60,7 @@ type ContextualUnaryFunc func(*Mlrval, *Context) Mlrval
 // Helps keystroke-saving for wrapping Go math-library functions
 // Examples: cos, sin, etc.
 type mathLibUnaryFunc func(float64) float64
-type mathLibUnaryFuncWrapper func(*Mlrval, mathLibUnaryFunc) Mlrval
+type mathLibUnaryFuncWrapper func(output, input1 *Mlrval, f mathLibUnaryFunc)
 
 // Function-pointer type for binary-operator disposition matrices.
 type BinaryFunc func(*Mlrval, *Mlrval) Mlrval
@@ -82,23 +82,23 @@ type ComparatorFunc func(*Mlrval, *Mlrval) int
 
 // ----------------------------------------------------------------
 // Return error (unary)
-func _erro1(input1 *Mlrval) Mlrval {
-	return MlrvalFromError()
+func _erro1(output, input1 *Mlrval) {
+	output.SetFromError()
 }
 
 // Return absent (unary)
-func _absn1(input1 *Mlrval) Mlrval {
-	return MlrvalFromAbsent()
+func _absn1(output, input1 *Mlrval) {
+	output.SetFromAbsent()
 }
 
 // Return void (unary)
-func _void1(input1 *Mlrval) Mlrval {
-	return MlrvalFromAbsent()
+func _void1(output, input1 *Mlrval) {
+	output.SetFromVoid()
 }
 
 // Return argument (unary)
-func _1u___(input1 *Mlrval) Mlrval {
-	return *input1
+func _1u___(output, input1 *Mlrval) {
+	output.CopyFrom(input1)
 }
 
 // ----------------------------------------------------------------

--- a/go/src/types/mlrval_functions_base.go
+++ b/go/src/types/mlrval_functions_base.go
@@ -66,7 +66,7 @@ type mathLibUnaryFuncWrapper func(*Mlrval, mathLibUnaryFunc) Mlrval
 type BinaryFunc func(*Mlrval, *Mlrval) Mlrval
 
 // Function-pointer type for ternary functions
-type TernaryFunc func(*Mlrval, *Mlrval, *Mlrval) Mlrval
+type TernaryFunc func(output, input1, input2, input3 *Mlrval)
 
 // Function-pointer type for variadic functions.
 type VariadicFunc func([]*Mlrval) Mlrval

--- a/go/src/types/mlrval_functions_bits.go
+++ b/go/src/types/mlrval_functions_bits.go
@@ -64,8 +64,8 @@ func MlrvalBitCount(output, input1 *Mlrval) {
 // ================================================================
 // Bitwise AND
 
-func bitwise_and_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval & input2.intval)
+func bitwise_and_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval & input2.intval)
 }
 
 var bitwise_and_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -81,15 +81,15 @@ var bitwise_and_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseAND(input1, input2 *Mlrval) Mlrval {
-	return bitwise_and_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalBitwiseAND(output, input1, input2 *Mlrval) {
+	bitwise_and_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Bitwise OR
 
-func bitwise_or_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval | input2.intval)
+func bitwise_or_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval | input2.intval)
 }
 
 var bitwise_or_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -105,15 +105,15 @@ var bitwise_or_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseOR(input1, input2 *Mlrval) Mlrval {
-	return bitwise_or_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalBitwiseOR(output, input1, input2 *Mlrval) {
+	bitwise_or_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Bitwise XOR
 
-func bitwise_xor_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval ^ input2.intval)
+func bitwise_xor_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval ^ input2.intval)
 }
 
 var bitwise_xor_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -129,15 +129,15 @@ var bitwise_xor_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseXOR(input1, input2 *Mlrval) Mlrval {
-	return bitwise_xor_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalBitwiseXOR(output, input1, input2 *Mlrval) {
+	bitwise_xor_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Left shift
 
-func lsh_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval << uint64(input2.intval))
+func lsh_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval << uint64(input2.intval))
 }
 
 var left_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -153,15 +153,15 @@ var left_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalLeftShift(input1, input2 *Mlrval) Mlrval {
-	return left_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalLeftShift(output, input1, input2 *Mlrval) {
+	left_shift_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Signed right shift
 
-func srsh_i_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromInt(input1.intval >> uint64(input2.intval))
+func srsh_i_ii(output, input1, input2 *Mlrval) {
+	output.SetFromInt(input1.intval >> uint64(input2.intval))
 }
 
 var signed_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -177,18 +177,18 @@ var signed_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalSignedRightShift(input1, input2 *Mlrval) Mlrval {
-	return signed_right_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalSignedRightShift(output, input1, input2 *Mlrval) {
+	signed_right_shift_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Unsigned right shift
 
-func ursh_i_ii(input1, input2 *Mlrval) Mlrval {
+func ursh_i_ii(output, input1, input2 *Mlrval) {
 	var ua uint64 = uint64(input1.intval)
 	var ub uint64 = uint64(input2.intval)
 	var uc = ua >> ub
-	return MlrvalFromInt(int(uc))
+	output.SetFromInt(int(uc))
 }
 
 var unsigned_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -204,6 +204,6 @@ var unsigned_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalUnsignedRightShift(input1, input2 *Mlrval) Mlrval {
-	return unsigned_right_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalUnsignedRightShift(output, input1, input2 *Mlrval) {
+	unsigned_right_shift_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }

--- a/go/src/types/mlrval_functions_bits.go
+++ b/go/src/types/mlrval_functions_bits.go
@@ -3,8 +3,8 @@ package types
 // ================================================================
 // Bitwise NOT
 
-func bitwise_not_i_i(input1 *Mlrval) Mlrval {
-	return MlrvalFromInt(^input1.intval)
+func bitwise_not_i_i(output, input1 *Mlrval) {
+	output.SetFromInt(^input1.intval)
 }
 
 var bitwise_not_dispositions = [MT_DIM]UnaryFunc{
@@ -19,8 +19,8 @@ var bitwise_not_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalBitwiseNOT(input1 *Mlrval) Mlrval {
-	return bitwise_not_dispositions[input1.mvtype](input1)
+func MlrvalBitwiseNOT(output, input1 *Mlrval) {
+	bitwise_not_dispositions[input1.mvtype](output, input1)
 }
 
 // ================================================================
@@ -34,7 +34,7 @@ const _m08 uint64 = 0x00ff00ff00ff00ff
 const _m16 uint64 = 0x0000ffff0000ffff
 const _m32 uint64 = 0x00000000ffffffff
 
-func bitcount_i_i(input1 *Mlrval) Mlrval {
+func bitcount_i_i(output, input1 *Mlrval) {
 	a := uint64(input1.intval)
 	a = (a & _m01) + ((a >> 1) & _m01)
 	a = (a & _m02) + ((a >> 2) & _m02)
@@ -42,7 +42,7 @@ func bitcount_i_i(input1 *Mlrval) Mlrval {
 	a = (a & _m08) + ((a >> 8) & _m08)
 	a = (a & _m16) + ((a >> 16) & _m16)
 	a = (a & _m32) + ((a >> 32) & _m32)
-	return MlrvalFromInt(int(a))
+	output.SetFromInt(int(a))
 }
 
 var bitcount_dispositions = [MT_DIM]UnaryFunc{
@@ -57,8 +57,8 @@ var bitcount_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalBitCount(input1 *Mlrval) Mlrval {
-	return bitcount_dispositions[input1.mvtype](input1)
+func MlrvalBitCount(output, input1 *Mlrval) {
+	bitcount_dispositions[input1.mvtype](output, input1)
 }
 
 // ================================================================

--- a/go/src/types/mlrval_functions_bits.go
+++ b/go/src/types/mlrval_functions_bits.go
@@ -3,8 +3,8 @@ package types
 // ================================================================
 // Bitwise NOT
 
-func bitwise_not_i_i(ma *Mlrval) Mlrval {
-	return MlrvalFromInt(^ma.intval)
+func bitwise_not_i_i(input1 *Mlrval) Mlrval {
+	return MlrvalFromInt(^input1.intval)
 }
 
 var bitwise_not_dispositions = [MT_DIM]UnaryFunc{
@@ -19,8 +19,8 @@ var bitwise_not_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalBitwiseNOT(ma *Mlrval) Mlrval {
-	return bitwise_not_dispositions[ma.mvtype](ma)
+func MlrvalBitwiseNOT(input1 *Mlrval) Mlrval {
+	return bitwise_not_dispositions[input1.mvtype](input1)
 }
 
 // ================================================================
@@ -34,8 +34,8 @@ const _m08 uint64 = 0x00ff00ff00ff00ff
 const _m16 uint64 = 0x0000ffff0000ffff
 const _m32 uint64 = 0x00000000ffffffff
 
-func bitcount_i_i(ma *Mlrval) Mlrval {
-	a := uint64(ma.intval)
+func bitcount_i_i(input1 *Mlrval) Mlrval {
+	a := uint64(input1.intval)
 	a = (a & _m01) + ((a >> 1) & _m01)
 	a = (a & _m02) + ((a >> 2) & _m02)
 	a = (a & _m04) + ((a >> 4) & _m04)
@@ -57,15 +57,15 @@ var bitcount_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _absn1,
 }
 
-func MlrvalBitCount(ma *Mlrval) Mlrval {
-	return bitcount_dispositions[ma.mvtype](ma)
+func MlrvalBitCount(input1 *Mlrval) Mlrval {
+	return bitcount_dispositions[input1.mvtype](input1)
 }
 
 // ================================================================
 // Bitwise AND
 
-func bitwise_and_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval & mb.intval)
+func bitwise_and_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval & input2.intval)
 }
 
 var bitwise_and_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -81,15 +81,15 @@ var bitwise_and_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseAND(ma, mb *Mlrval) Mlrval {
-	return bitwise_and_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalBitwiseAND(input1, input2 *Mlrval) Mlrval {
+	return bitwise_and_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Bitwise OR
 
-func bitwise_or_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval | mb.intval)
+func bitwise_or_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval | input2.intval)
 }
 
 var bitwise_or_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -105,15 +105,15 @@ var bitwise_or_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseOR(ma, mb *Mlrval) Mlrval {
-	return bitwise_or_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalBitwiseOR(input1, input2 *Mlrval) Mlrval {
+	return bitwise_or_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Bitwise XOR
 
-func bitwise_xor_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval ^ mb.intval)
+func bitwise_xor_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval ^ input2.intval)
 }
 
 var bitwise_xor_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -129,15 +129,15 @@ var bitwise_xor_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalBitwiseXOR(ma, mb *Mlrval) Mlrval {
-	return bitwise_xor_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalBitwiseXOR(input1, input2 *Mlrval) Mlrval {
+	return bitwise_xor_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Left shift
 
-func lsh_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval << uint64(mb.intval))
+func lsh_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval << uint64(input2.intval))
 }
 
 var left_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -153,15 +153,15 @@ var left_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalLeftShift(ma, mb *Mlrval) Mlrval {
-	return left_shift_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalLeftShift(input1, input2 *Mlrval) Mlrval {
+	return left_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Signed right shift
 
-func srsh_i_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromInt(ma.intval >> uint64(mb.intval))
+func srsh_i_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromInt(input1.intval >> uint64(input2.intval))
 }
 
 var signed_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -177,16 +177,16 @@ var signed_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalSignedRightShift(ma, mb *Mlrval) Mlrval {
-	return signed_right_shift_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalSignedRightShift(input1, input2 *Mlrval) Mlrval {
+	return signed_right_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ----------------------------------------------------------------
 // Unsigned right shift
 
-func ursh_i_ii(ma, mb *Mlrval) Mlrval {
-	var ua uint64 = uint64(ma.intval)
-	var ub uint64 = uint64(mb.intval)
+func ursh_i_ii(input1, input2 *Mlrval) Mlrval {
+	var ua uint64 = uint64(input1.intval)
+	var ub uint64 = uint64(input2.intval)
 	var uc = ua >> ub
 	return MlrvalFromInt(int(uc))
 }
@@ -204,6 +204,6 @@ var unsigned_right_shift_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalUnsignedRightShift(ma, mb *Mlrval) Mlrval {
-	return unsigned_right_shift_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalUnsignedRightShift(input1, input2 *Mlrval) Mlrval {
+	return unsigned_right_shift_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }

--- a/go/src/types/mlrval_functions_booleans.go
+++ b/go/src/types/mlrval_functions_booleans.go
@@ -9,173 +9,173 @@ import (
 )
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ss(ma *Mlrval, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep == mb.printrep)
+func eq_b_ss(input1 *Mlrval, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep == input2.printrep)
 }
-func ne_b_ss(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep != mb.printrep)
+func ne_b_ss(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep != input2.printrep)
 }
-func gt_b_ss(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep > mb.printrep)
+func gt_b_ss(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep > input2.printrep)
 }
-func ge_b_ss(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep >= mb.printrep)
+func ge_b_ss(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep >= input2.printrep)
 }
-func lt_b_ss(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep < mb.printrep)
+func lt_b_ss(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep < input2.printrep)
 }
-func le_b_ss(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep <= mb.printrep)
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() == mb.printrep)
-}
-func ne_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() != mb.printrep)
-}
-func gt_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() > mb.printrep)
-}
-func ge_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() >= mb.printrep)
-}
-func lt_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() < mb.printrep)
-}
-func le_b_xs(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.String() <= mb.printrep)
+func le_b_ss(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep <= input2.printrep)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep == mb.String())
+func eq_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() == input2.printrep)
 }
-func ne_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep != mb.String())
+func ne_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() != input2.printrep)
 }
-func gt_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep > mb.String())
+func gt_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() > input2.printrep)
 }
-func ge_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep >= mb.String())
+func ge_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() >= input2.printrep)
 }
-func lt_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep < mb.String())
+func lt_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() < input2.printrep)
 }
-func le_b_sx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.printrep <= mb.String())
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval == mb.intval)
-}
-func ne_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval != mb.intval)
-}
-func gt_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval > mb.intval)
-}
-func ge_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval >= mb.intval)
-}
-func lt_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval < mb.intval)
-}
-func le_b_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval <= mb.intval)
+func le_b_xs(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.String() <= input2.printrep)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) == mb.floatval)
+func eq_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep == input2.String())
 }
-func ne_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) != mb.floatval)
+func ne_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep != input2.String())
 }
-func gt_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) > mb.floatval)
+func gt_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep > input2.String())
 }
-func ge_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) >= mb.floatval)
+func ge_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep >= input2.String())
 }
-func lt_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) < mb.floatval)
+func lt_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep < input2.String())
 }
-func le_b_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(ma.intval) <= mb.floatval)
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval == float64(mb.intval))
-}
-func ne_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval != float64(mb.intval))
-}
-func gt_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval > float64(mb.intval))
-}
-func ge_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval >= float64(mb.intval))
-}
-func lt_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval < float64(mb.intval))
-}
-func le_b_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval <= float64(mb.intval))
+func le_b_sx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.printrep <= input2.String())
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval == mb.floatval)
+func eq_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval == input2.intval)
 }
-func ne_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval != mb.floatval)
+func ne_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval != input2.intval)
 }
-func gt_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval > mb.floatval)
+func gt_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval > input2.intval)
 }
-func ge_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval >= mb.floatval)
+func ge_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval >= input2.intval)
 }
-func lt_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval < mb.floatval)
+func lt_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval < input2.intval)
 }
-func le_b_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval <= mb.floatval)
+func le_b_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval <= input2.intval)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.boolval == mb.boolval)
+func eq_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) == input2.floatval)
 }
-func ne_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.boolval != mb.boolval)
+func ne_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) != input2.floatval)
+}
+func gt_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) > input2.floatval)
+}
+func ge_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) >= input2.floatval)
+}
+func lt_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) < input2.floatval)
+}
+func le_b_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(float64(input1.intval) <= input2.floatval)
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval == float64(input2.intval))
+}
+func ne_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval != float64(input2.intval))
+}
+func gt_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval > float64(input2.intval))
+}
+func ge_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval >= float64(input2.intval))
+}
+func lt_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval < float64(input2.intval))
+}
+func le_b_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval <= float64(input2.intval))
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval == input2.floatval)
+}
+func ne_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval != input2.floatval)
+}
+func gt_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval > input2.floatval)
+}
+func ge_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval >= input2.floatval)
+}
+func lt_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval < input2.floatval)
+}
+func le_b_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval <= input2.floatval)
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.boolval == input2.boolval)
+}
+func ne_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.boolval != input2.boolval)
 }
 
 // We could say ordering on bool is error, but, Miller allows
 // sorting on bool so it should allow ordering on bool.
 
-func gt_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(ma.boolval) > lib.BoolToInt(mb.boolval))
+func gt_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(lib.BoolToInt(input1.boolval) > lib.BoolToInt(input2.boolval))
 }
-func ge_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(ma.boolval) >= lib.BoolToInt(mb.boolval))
+func ge_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(lib.BoolToInt(input1.boolval) >= lib.BoolToInt(input2.boolval))
 }
-func lt_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(ma.boolval) < lib.BoolToInt(mb.boolval))
+func lt_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(lib.BoolToInt(input1.boolval) < lib.BoolToInt(input2.boolval))
 }
-func le_b_bb(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(ma.boolval) <= lib.BoolToInt(mb.boolval))
+func le_b_bb(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(lib.BoolToInt(input1.boolval) <= lib.BoolToInt(input2.boolval))
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_aa(ma, mb *Mlrval) Mlrval {
-	a := ma.arrayval
-	b := mb.arrayval
+func eq_b_aa(input1, input2 *Mlrval) Mlrval {
+	a := input1.arrayval
+	b := input2.arrayval
 
 	// Different-length arrays are not equal
 	if len(a) != len(b) {
@@ -192,17 +192,17 @@ func eq_b_aa(ma, mb *Mlrval) Mlrval {
 
 	return MlrvalFromBool(true)
 }
-func ne_b_aa(ma, mb *Mlrval) Mlrval {
-	eq := eq_b_aa(ma, mb)
+func ne_b_aa(input1, input2 *Mlrval) Mlrval {
+	eq := eq_b_aa(input1, input2)
 	return MlrvalFromBool(!eq.boolval)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_mm(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mapval.Equals(mb.mapval))
+func eq_b_mm(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mapval.Equals(input2.mapval))
 }
-func ne_b_mm(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromBool(!ma.mapval.Equals(mb.mapval))
+func ne_b_mm(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromBool(!input1.mapval.Equals(input2.mapval))
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -303,53 +303,53 @@ var le_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro},
 }
 
-func MlrvalEquals(ma, mb *Mlrval) Mlrval {
-	return eq_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalEquals(input1, input2 *Mlrval) Mlrval {
+	return eq_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func MlrvalNotEquals(ma, mb *Mlrval) Mlrval {
-	return ne_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalNotEquals(input1, input2 *Mlrval) Mlrval {
+	return ne_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func MlrvalGreaterThan(ma, mb *Mlrval) Mlrval {
-	return gt_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalGreaterThan(input1, input2 *Mlrval) Mlrval {
+	return gt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func MlrvalGreaterThanOrEquals(ma, mb *Mlrval) Mlrval {
-	return ge_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalGreaterThanOrEquals(input1, input2 *Mlrval) Mlrval {
+	return ge_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func MlrvalLessThan(ma, mb *Mlrval) Mlrval {
-	return lt_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalLessThan(input1, input2 *Mlrval) Mlrval {
+	return lt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func MlrvalLessThanOrEquals(ma, mb *Mlrval) Mlrval {
-	return le_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalLessThanOrEquals(input1, input2 *Mlrval) Mlrval {
+	return le_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // For Go's sort.Slice
-func MlrvalLessThanForSort(ma, mb *Mlrval) bool {
-	mretval := lt_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalLessThanForSort(input1, input2 *Mlrval) bool {
+	mretval := lt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 	retval, ok := mretval.GetBoolValue()
 	lib.InternalCodingErrorIf(!ok)
 	return retval
 }
 
 // ----------------------------------------------------------------
-func MlrvalLogicalAND(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype == MT_BOOL && mb.mvtype == MT_BOOL {
-		return MlrvalFromBool(ma.boolval && mb.boolval)
+func MlrvalLogicalAND(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
+		return MlrvalFromBool(input1.boolval && input2.boolval)
 	} else {
 		return MlrvalFromError()
 	}
 }
 
-func MlrvalLogicalOR(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype == MT_BOOL && mb.mvtype == MT_BOOL {
-		return MlrvalFromBool(ma.boolval || mb.boolval)
+func MlrvalLogicalOR(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
+		return MlrvalFromBool(input1.boolval || input2.boolval)
 	} else {
 		return MlrvalFromError()
 	}
 }
 
-func MlrvalLogicalXOR(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype == MT_BOOL && mb.mvtype == MT_BOOL {
-		return MlrvalFromBool(ma.boolval != mb.boolval)
+func MlrvalLogicalXOR(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
+		return MlrvalFromBool(input1.boolval != input2.boolval)
 	} else {
 		return MlrvalFromError()
 	}

--- a/go/src/types/mlrval_functions_booleans.go
+++ b/go/src/types/mlrval_functions_booleans.go
@@ -9,200 +9,204 @@ import (
 )
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ss(input1 *Mlrval, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep == input2.printrep)
+func eq_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep == input2.printrep)
 }
-func ne_b_ss(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep != input2.printrep)
+func ne_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep != input2.printrep)
 }
-func gt_b_ss(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep > input2.printrep)
+func gt_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep > input2.printrep)
 }
-func ge_b_ss(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep >= input2.printrep)
+func ge_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep >= input2.printrep)
 }
-func lt_b_ss(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep < input2.printrep)
+func lt_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep < input2.printrep)
 }
-func le_b_ss(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep <= input2.printrep)
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() == input2.printrep)
-}
-func ne_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() != input2.printrep)
-}
-func gt_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() > input2.printrep)
-}
-func ge_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() >= input2.printrep)
-}
-func lt_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() < input2.printrep)
-}
-func le_b_xs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.String() <= input2.printrep)
+func le_b_ss(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep <= input2.printrep)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep == input2.String())
+func eq_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() == input2.printrep)
 }
-func ne_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep != input2.String())
+func ne_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() != input2.printrep)
 }
-func gt_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep > input2.String())
+func gt_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() > input2.printrep)
 }
-func ge_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep >= input2.String())
+func ge_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() >= input2.printrep)
 }
-func lt_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep < input2.String())
+func lt_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() < input2.printrep)
 }
-func le_b_sx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.printrep <= input2.String())
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval == input2.intval)
-}
-func ne_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval != input2.intval)
-}
-func gt_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval > input2.intval)
-}
-func ge_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval >= input2.intval)
-}
-func lt_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval < input2.intval)
-}
-func le_b_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval <= input2.intval)
+func le_b_xs(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.String() <= input2.printrep)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) == input2.floatval)
+func eq_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep == input2.String())
 }
-func ne_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) != input2.floatval)
+func ne_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep != input2.String())
 }
-func gt_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) > input2.floatval)
+func gt_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep > input2.String())
 }
-func ge_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) >= input2.floatval)
+func ge_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep >= input2.String())
 }
-func lt_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) < input2.floatval)
+func lt_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep < input2.String())
 }
-func le_b_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(float64(input1.intval) <= input2.floatval)
-}
-
-//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval == float64(input2.intval))
-}
-func ne_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval != float64(input2.intval))
-}
-func gt_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval > float64(input2.intval))
-}
-func ge_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval >= float64(input2.intval))
-}
-func lt_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval < float64(input2.intval))
-}
-func le_b_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval <= float64(input2.intval))
+func le_b_sx(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.printrep <= input2.String())
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval == input2.floatval)
+func eq_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval == input2.intval)
 }
-func ne_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval != input2.floatval)
+func ne_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval != input2.intval)
 }
-func gt_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval > input2.floatval)
+func gt_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval > input2.intval)
 }
-func ge_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval >= input2.floatval)
+func ge_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval >= input2.intval)
 }
-func lt_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval < input2.floatval)
+func lt_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval < input2.intval)
 }
-func le_b_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval <= input2.floatval)
+func le_b_ii(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.intval <= input2.intval)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.boolval == input2.boolval)
+func eq_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) == input2.floatval)
 }
-func ne_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.boolval != input2.boolval)
+func ne_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) != input2.floatval)
+}
+func gt_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) > input2.floatval)
+}
+func ge_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) >= input2.floatval)
+}
+func lt_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) < input2.floatval)
+}
+func le_b_if(output, input1, input2 *Mlrval) {
+	output.SetFromBool(float64(input1.intval) <= input2.floatval)
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval == float64(input2.intval))
+}
+func ne_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval != float64(input2.intval))
+}
+func gt_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval > float64(input2.intval))
+}
+func ge_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval >= float64(input2.intval))
+}
+func lt_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval < float64(input2.intval))
+}
+func le_b_fi(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval <= float64(input2.intval))
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval == input2.floatval)
+}
+func ne_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval != input2.floatval)
+}
+func gt_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval > input2.floatval)
+}
+func ge_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval >= input2.floatval)
+}
+func lt_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval < input2.floatval)
+}
+func le_b_ff(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.floatval <= input2.floatval)
+}
+
+//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+func eq_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.boolval == input2.boolval)
+}
+func ne_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.boolval != input2.boolval)
 }
 
 // We could say ordering on bool is error, but, Miller allows
 // sorting on bool so it should allow ordering on bool.
 
-func gt_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(input1.boolval) > lib.BoolToInt(input2.boolval))
+func gt_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(lib.BoolToInt(input1.boolval) > lib.BoolToInt(input2.boolval))
 }
-func ge_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(input1.boolval) >= lib.BoolToInt(input2.boolval))
+func ge_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(lib.BoolToInt(input1.boolval) >= lib.BoolToInt(input2.boolval))
 }
-func lt_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(input1.boolval) < lib.BoolToInt(input2.boolval))
+func lt_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(lib.BoolToInt(input1.boolval) < lib.BoolToInt(input2.boolval))
 }
-func le_b_bb(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(lib.BoolToInt(input1.boolval) <= lib.BoolToInt(input2.boolval))
+func le_b_bb(output, input1, input2 *Mlrval) {
+	output.SetFromBool(lib.BoolToInt(input1.boolval) <= lib.BoolToInt(input2.boolval))
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_aa(input1, input2 *Mlrval) Mlrval {
+func eq_b_aa(output, input1, input2 *Mlrval) {
 	a := input1.arrayval
 	b := input2.arrayval
 
 	// Different-length arrays are not equal
 	if len(a) != len(b) {
-		return MlrvalFromBool(false) // stub
+		output.SetFromBool(false) // stub
+		return
 	}
 
 	// Same-length arrays: return false if any slot is not equal, else true.
 	for i := range a {
-		eq := MlrvalEquals(&a[i], &b[i])
+		eq := MlrvalFromError()
+		MlrvalEquals(&eq, &a[i], &b[i])
+		lib.InternalCodingErrorIf(eq.mvtype != MT_BOOL)
 		if eq.boolval == false {
-			return MlrvalFromBool(false)
+			output.SetFromBool(false)
+			return
 		}
 	}
 
-	return MlrvalFromBool(true)
+	output.SetFromBool(true)
 }
-func ne_b_aa(input1, input2 *Mlrval) Mlrval {
-	eq := eq_b_aa(input1, input2)
-	return MlrvalFromBool(!eq.boolval)
+func ne_b_aa(output, input1, input2 *Mlrval) {
+	eq_b_aa(output, input1, input2)
+	output.SetFromBool(!output.boolval)
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-func eq_b_mm(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mapval.Equals(input2.mapval))
+func eq_b_mm(output, input1, input2 *Mlrval) {
+	output.SetFromBool(input1.mapval.Equals(input2.mapval))
 }
-func ne_b_mm(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromBool(!input1.mapval.Equals(input2.mapval))
+func ne_b_mm(output, input1, input2 *Mlrval) {
+	output.SetFromBool(!input1.mapval.Equals(input2.mapval))
 }
 
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -303,54 +307,56 @@ var le_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro},
 }
 
-func MlrvalEquals(input1, input2 *Mlrval) Mlrval {
-	return eq_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalEquals(output, input1, input2 *Mlrval) {
+	eq_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
-func MlrvalNotEquals(input1, input2 *Mlrval) Mlrval {
-	return ne_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalNotEquals(output, input1, input2 *Mlrval) {
+	ne_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
-func MlrvalGreaterThan(input1, input2 *Mlrval) Mlrval {
-	return gt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalGreaterThan(output, input1, input2 *Mlrval) {
+	gt_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
-func MlrvalGreaterThanOrEquals(input1, input2 *Mlrval) Mlrval {
-	return ge_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalGreaterThanOrEquals(output, input1, input2 *Mlrval) {
+	ge_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
-func MlrvalLessThan(input1, input2 *Mlrval) Mlrval {
-	return lt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalLessThan(output, input1, input2 *Mlrval) {
+	lt_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
-func MlrvalLessThanOrEquals(input1, input2 *Mlrval) Mlrval {
-	return le_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalLessThanOrEquals(output, input1, input2 *Mlrval) {
+	le_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // For Go's sort.Slice
 func MlrvalLessThanForSort(input1, input2 *Mlrval) bool {
-	mretval := lt_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+	// xxx refactor to avoid copy
+	mretval := MlrvalFromFalse()
+	lt_dispositions[input1.mvtype][input2.mvtype](&mretval, input1, input2)
 	retval, ok := mretval.GetBoolValue()
 	lib.InternalCodingErrorIf(!ok)
 	return retval
 }
 
 // ----------------------------------------------------------------
-func MlrvalLogicalAND(input1, input2 *Mlrval) Mlrval {
+func MlrvalLogicalAND(output, input1, input2 *Mlrval) {
 	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
-		return MlrvalFromBool(input1.boolval && input2.boolval)
+		output.SetFromBool(input1.boolval && input2.boolval)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func MlrvalLogicalOR(input1, input2 *Mlrval) Mlrval {
+func MlrvalLogicalOR(output, input1, input2 *Mlrval) {
 	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
-		return MlrvalFromBool(input1.boolval || input2.boolval)
+		output.SetFromBool(input1.boolval || input2.boolval)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func MlrvalLogicalXOR(input1, input2 *Mlrval) Mlrval {
+func MlrvalLogicalXOR(output, input1, input2 *Mlrval) {
 	if input1.mvtype == MT_BOOL && input2.mvtype == MT_BOOL {
-		return MlrvalFromBool(input1.boolval != input2.boolval)
+		output.SetFromBool(input1.boolval != input2.boolval)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }

--- a/go/src/types/mlrval_functions_collections.go
+++ b/go/src/types/mlrval_functions_collections.go
@@ -10,8 +10,8 @@ import (
 
 // ================================================================
 // Map/array count. Scalars (including strings) have length 1.
-func MlrvalLength(ma *Mlrval) Mlrval {
-	switch ma.mvtype {
+func MlrvalLength(input1 *Mlrval) Mlrval {
+	switch input1.mvtype {
 	case MT_ERROR:
 		return MlrvalFromInt(0)
 		break
@@ -19,19 +19,19 @@ func MlrvalLength(ma *Mlrval) Mlrval {
 		return MlrvalFromInt(0)
 		break
 	case MT_ARRAY:
-		return MlrvalFromInt(int(len(ma.arrayval)))
+		return MlrvalFromInt(int(len(input1.arrayval)))
 		break
 	case MT_MAP:
-		return MlrvalFromInt(int(ma.mapval.FieldCount))
+		return MlrvalFromInt(int(input1.mapval.FieldCount))
 		break
 	}
 	return MlrvalFromInt(1)
 }
 
 // ================================================================
-func depth_from_array(ma *Mlrval) Mlrval {
+func depth_from_array(input1 *Mlrval) Mlrval {
 	maxChildDepth := 0
-	for _, child := range ma.arrayval {
+	for _, child := range input1.arrayval {
 		childDepth := MlrvalDepth(&child)
 		iChildDepth := int(childDepth.intval)
 		if iChildDepth > maxChildDepth {
@@ -41,9 +41,9 @@ func depth_from_array(ma *Mlrval) Mlrval {
 	return MlrvalFromInt(int(1 + maxChildDepth))
 }
 
-func depth_from_map(ma *Mlrval) Mlrval {
+func depth_from_map(input1 *Mlrval) Mlrval {
 	maxChildDepth := 0
-	for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+	for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 		child := pe.Value
 		childDepth := MlrvalDepth(child)
 		iChildDepth := int(childDepth.intval)
@@ -54,7 +54,7 @@ func depth_from_map(ma *Mlrval) Mlrval {
 	return MlrvalFromInt(int(1 + maxChildDepth))
 }
 
-func depth_from_scalar(ma *Mlrval) Mlrval {
+func depth_from_scalar(input1 *Mlrval) Mlrval {
 	return MlrvalFromInt(0)
 }
 
@@ -76,14 +76,14 @@ func init() {
 	}
 }
 
-func MlrvalDepth(ma *Mlrval) Mlrval {
-	return depth_dispositions[ma.mvtype](ma)
+func MlrvalDepth(input1 *Mlrval) Mlrval {
+	return depth_dispositions[input1.mvtype](input1)
 }
 
 // ================================================================
-func leafcount_from_array(ma *Mlrval) Mlrval {
+func leafcount_from_array(input1 *Mlrval) Mlrval {
 	sumChildLeafCount := 0
-	for _, child := range ma.arrayval {
+	for _, child := range input1.arrayval {
 		// Golang initialization loop if we do this :(
 		// childLeafCount := MlrvalLeafCount(&child)
 
@@ -100,9 +100,9 @@ func leafcount_from_array(ma *Mlrval) Mlrval {
 	return MlrvalFromInt(int(sumChildLeafCount))
 }
 
-func leafcount_from_map(ma *Mlrval) Mlrval {
+func leafcount_from_map(input1 *Mlrval) Mlrval {
 	sumChildLeafCount := 0
-	for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+	for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 		child := pe.Value
 
 		// Golang initialization loop if we do this :(
@@ -121,7 +121,7 @@ func leafcount_from_map(ma *Mlrval) Mlrval {
 	return MlrvalFromInt(int(sumChildLeafCount))
 }
 
-func leafcount_from_scalar(ma *Mlrval) Mlrval {
+func leafcount_from_scalar(input1 *Mlrval) Mlrval {
 	return MlrvalFromInt(1)
 }
 
@@ -137,35 +137,35 @@ var leafcount_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ leafcount_from_map,
 }
 
-func MlrvalLeafCount(ma *Mlrval) Mlrval {
-	return leafcount_dispositions[ma.mvtype](ma)
+func MlrvalLeafCount(input1 *Mlrval) Mlrval {
+	return leafcount_dispositions[input1.mvtype](input1)
 }
 
 // ----------------------------------------------------------------
-func has_key_in_array(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype == MT_STRING {
+func has_key_in_array(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype == MT_STRING {
 		return MlrvalFromFalse()
 	}
-	if mb.mvtype != MT_INT {
+	if input2.mvtype != MT_INT {
 		return MlrvalFromError()
 	}
-	_, ok := UnaliasArrayIndex(&ma.arrayval, mb.intval)
+	_, ok := UnaliasArrayIndex(&input1.arrayval, input2.intval)
 	return MlrvalFromBool(ok)
 }
 
-func has_key_in_map(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype == MT_STRING || mb.mvtype == MT_INT {
-		return MlrvalFromBool(ma.mapval.Has(mb.String()))
+func has_key_in_map(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype == MT_STRING || input2.mvtype == MT_INT {
+		return MlrvalFromBool(input1.mapval.Has(input2.String()))
 	} else {
 		return MlrvalFromError()
 	}
 }
 
-func MlrvalHasKey(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype == MT_ARRAY {
-		return has_key_in_array(ma, mb)
-	} else if ma.mvtype == MT_MAP {
-		return has_key_in_map(ma, mb)
+func MlrvalHasKey(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype == MT_ARRAY {
+		return has_key_in_array(input1, input2)
+	} else if input1.mvtype == MT_MAP {
+		return has_key_in_map(input1, input2)
 	} else {
 		return MlrvalFromError()
 	}
@@ -294,15 +294,15 @@ func MlrvalMapDiff(mlrvals []*Mlrval) Mlrval {
 // ================================================================
 // joink([1,2,3], ",") -> "1,2,3"
 // joink({"a":3,"b":4,"c":5}, ",") -> "a,b,c"
-func MlrvalJoinK(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype != MT_STRING {
+func MlrvalJoinK(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mb.printrep
-	if ma.mvtype == MT_MAP {
+	fieldSeparator := input2.printrep
+	if input1.mvtype == MT_MAP {
 		var buffer bytes.Buffer
 
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			buffer.WriteString(pe.Key)
 			if pe.Next != nil {
 				buffer.WriteString(fieldSeparator)
@@ -310,10 +310,10 @@ func MlrvalJoinK(ma, mb *Mlrval) Mlrval {
 		}
 
 		return MlrvalFromString(buffer.String())
-	} else if ma.mvtype == MT_ARRAY {
+	} else if input1.mvtype == MT_ARRAY {
 		var buffer bytes.Buffer
 
-		for i, _ := range ma.arrayval {
+		for i, _ := range input1.arrayval {
 			if i > 0 {
 				buffer.WriteString(fieldSeparator)
 			}
@@ -330,16 +330,16 @@ func MlrvalJoinK(ma, mb *Mlrval) Mlrval {
 // ----------------------------------------------------------------
 // joinv([3,4,5], ",") -> "3,4,5"
 // joinv({"a":3,"b":4,"c":5}, ",") -> "3,4,5"
-func MlrvalJoinV(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype != MT_STRING {
+func MlrvalJoinV(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mb.printrep
+	fieldSeparator := input2.printrep
 
-	if ma.mvtype == MT_MAP {
+	if input1.mvtype == MT_MAP {
 		var buffer bytes.Buffer
 
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			buffer.WriteString(pe.Value.String())
 			if pe.Next != nil {
 				buffer.WriteString(fieldSeparator)
@@ -347,10 +347,10 @@ func MlrvalJoinV(ma, mb *Mlrval) Mlrval {
 		}
 
 		return MlrvalFromString(buffer.String())
-	} else if ma.mvtype == MT_ARRAY {
+	} else if input1.mvtype == MT_ARRAY {
 		var buffer bytes.Buffer
 
-		for i, element := range ma.arrayval {
+		for i, element := range input1.arrayval {
 			if i > 0 {
 				buffer.WriteString(fieldSeparator)
 			}
@@ -366,20 +366,20 @@ func MlrvalJoinV(ma, mb *Mlrval) Mlrval {
 // ----------------------------------------------------------------
 // joinkv([3,4,5], "=", ",") -> "1=3,2=4,3=5"
 // joinkv({"a":3,"b":4,"c":5}, "=", ",") -> "a=3,b=4,c=5"
-func MlrvalJoinKV(ma, mb, mc *Mlrval) Mlrval {
-	if mb.mvtype != MT_STRING {
+func MlrvalJoinKV(input1, input2, input3 *Mlrval) Mlrval {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	pairSeparator := mb.printrep
-	if mc.mvtype != MT_STRING {
+	pairSeparator := input2.printrep
+	if input3.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mc.printrep
+	fieldSeparator := input3.printrep
 
-	if ma.mvtype == MT_MAP {
+	if input1.mvtype == MT_MAP {
 		var buffer bytes.Buffer
 
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			buffer.WriteString(pe.Key)
 			buffer.WriteString(pairSeparator)
 			buffer.WriteString(pe.Value.String())
@@ -389,10 +389,10 @@ func MlrvalJoinKV(ma, mb, mc *Mlrval) Mlrval {
 		}
 
 		return MlrvalFromString(buffer.String())
-	} else if ma.mvtype == MT_ARRAY {
+	} else if input1.mvtype == MT_ARRAY {
 		var buffer bytes.Buffer
 
-		for i, element := range ma.arrayval {
+		for i, element := range input1.arrayval {
 			if i > 0 {
 				buffer.WriteString(fieldSeparator)
 			}
@@ -410,22 +410,22 @@ func MlrvalJoinKV(ma, mb, mc *Mlrval) Mlrval {
 
 // ================================================================
 // splitkv("a=3,b=4,c=5", "=", ",") -> {"a":3,"b":4,"c":5}
-func MlrvalSplitKV(ma, mb, mc *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitKV(input1, input2, input3 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	pairSeparator := mb.printrep
-	if mc.mvtype != MT_STRING {
+	pairSeparator := input2.printrep
+	if input3.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mc.printrep
+	fieldSeparator := input3.printrep
 
 	retval := MlrvalEmptyMap()
 
-	fields := lib.SplitString(ma.printrep, fieldSeparator)
+	fields := lib.SplitString(input1.printrep, fieldSeparator)
 	for i, field := range fields {
 		pair := strings.SplitN(field, pairSeparator, 2)
 		if len(pair) == 1 {
@@ -446,22 +446,22 @@ func MlrvalSplitKV(ma, mb, mc *Mlrval) Mlrval {
 
 // ----------------------------------------------------------------
 // splitkvx("a=3,b=4,c=5", "=", ",") -> {"a":"3","b":"4","c":"5"}
-func MlrvalSplitKVX(ma, mb, mc *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitKVX(input1, input2, input3 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	pairSeparator := mb.printrep
-	if mc.mvtype != MT_STRING {
+	pairSeparator := input2.printrep
+	if input3.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mc.printrep
+	fieldSeparator := input3.printrep
 
 	retval := MlrvalEmptyMap()
 
-	fields := lib.SplitString(ma.printrep, fieldSeparator)
+	fields := lib.SplitString(input1.printrep, fieldSeparator)
 	for i, field := range fields {
 		pair := strings.SplitN(field, pairSeparator, 2)
 		if len(pair) == 1 {
@@ -482,17 +482,17 @@ func MlrvalSplitKVX(ma, mb, mc *Mlrval) Mlrval {
 
 // ----------------------------------------------------------------
 // splitnv("a,b,c", ",") -> {"1":"a","2":"b","3":"c"}
-func MlrvalSplitNV(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitNV(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
 
 	retval := MlrvalEmptyMap()
 
-	fields := lib.SplitString(ma.printrep, mb.printrep)
+	fields := lib.SplitString(input1.printrep, input2.printrep)
 	for i, field := range fields {
 		key := strconv.Itoa(i + 1) // Miller user-space indices are 1-up
 		value := MlrvalFromInferredType(field)
@@ -504,17 +504,17 @@ func MlrvalSplitNV(ma, mb *Mlrval) Mlrval {
 
 // ----------------------------------------------------------------
 // splitnvx("3,4,5", ",") -> {"1":"3","2":"4","3":"5"}
-func MlrvalSplitNVX(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitNVX(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
 
 	retval := MlrvalEmptyMap()
 
-	fields := lib.SplitString(ma.printrep, mb.printrep)
+	fields := lib.SplitString(input1.printrep, input2.printrep)
 	for i, field := range fields {
 		key := strconv.Itoa(i + 1) // Miller user-space indices are 1-up
 		value := MlrvalFromString(field)
@@ -526,16 +526,16 @@ func MlrvalSplitNVX(ma, mb *Mlrval) Mlrval {
 
 // ----------------------------------------------------------------
 // splita("3,4,5", ",") -> [3,4,5]
-func MlrvalSplitA(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitA(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	fieldSeparator := mb.printrep
+	fieldSeparator := input2.printrep
 
-	fields := lib.SplitString(ma.printrep, fieldSeparator)
+	fields := lib.SplitString(input1.printrep, fieldSeparator)
 
 	retval := NewSizedMlrvalArray(int(len(fields)))
 
@@ -550,15 +550,15 @@ func MlrvalSplitA(ma, mb *Mlrval) Mlrval {
 // ----------------------------------------------------------------
 // splitax("3,4,5", ",") -> ["3","4","5"]
 
-func MlrvalSplitAX(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype != MT_STRING {
+func MlrvalSplitAX(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if mb.mvtype != MT_STRING {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	input := ma.printrep
-	fieldSeparator := mb.printrep
+	input := input1.printrep
+	fieldSeparator := input2.printrep
 
 	return *mlrvalSplitAXHelper(input, fieldSeparator)
 }
@@ -578,19 +578,19 @@ func mlrvalSplitAXHelper(input string, separator string) *Mlrval {
 }
 
 // ----------------------------------------------------------------
-func MlrvalGetKeys(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_MAP {
-		retval := NewSizedMlrvalArray(ma.mapval.FieldCount)
+func MlrvalGetKeys(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_MAP {
+		retval := NewSizedMlrvalArray(input1.mapval.FieldCount)
 		i := 0
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			retval.arrayval[i] = MlrvalFromString(pe.Key)
 			i++
 		}
 		return *retval
 
-	} else if ma.mvtype == MT_ARRAY {
-		retval := NewSizedMlrvalArray(int(len(ma.arrayval)))
-		for i, _ := range ma.arrayval {
+	} else if input1.mvtype == MT_ARRAY {
+		retval := NewSizedMlrvalArray(int(len(input1.arrayval)))
+		for i, _ := range input1.arrayval {
 			retval.arrayval[i] = MlrvalFromInt(int(i + 1)) // Miller user-space indices are 1-up
 		}
 		return *retval
@@ -601,19 +601,19 @@ func MlrvalGetKeys(ma *Mlrval) Mlrval {
 }
 
 // ----------------------------------------------------------------
-func MlrvalGetValues(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_MAP {
-		retval := NewSizedMlrvalArray(ma.mapval.FieldCount)
+func MlrvalGetValues(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_MAP {
+		retval := NewSizedMlrvalArray(input1.mapval.FieldCount)
 		i := 0
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			retval.arrayval[i] = *pe.Value.Copy()
 			i++
 		}
 		return *retval
 
-	} else if ma.mvtype == MT_ARRAY {
-		retval := NewSizedMlrvalArray(int(len(ma.arrayval)))
-		for i, value := range ma.arrayval {
+	} else if input1.mvtype == MT_ARRAY {
+		retval := NewSizedMlrvalArray(int(len(input1.arrayval)))
+		for i, value := range input1.arrayval {
 			retval.arrayval[i] = *value.Copy()
 		}
 		return *retval
@@ -624,13 +624,13 @@ func MlrvalGetValues(ma *Mlrval) Mlrval {
 }
 
 // ----------------------------------------------------------------
-func MlrvalAppend(ma, mb *Mlrval) Mlrval {
-	if ma.mvtype != MT_ARRAY {
+func MlrvalAppend(input1, input2 *Mlrval) Mlrval {
+	if input1.mvtype != MT_ARRAY {
 		return MlrvalFromError()
 	}
 
-	macopy := ma.Copy()
-	mbcopy := mb.Copy()
+	macopy := input1.Copy()
+	mbcopy := input2.Copy()
 	macopy.ArrayAppend(mbcopy)
 	return *macopy
 }
@@ -641,41 +641,41 @@ func MlrvalAppend(ma, mb *Mlrval) Mlrval {
 // Third argument is map or array.
 // flatten("a", ".", {"b": { "c": 4 }}) is {"a.b.c" : 4}.
 // flatten("", ".", {"a": { "b": 3 }}) is {"a.b" : 3}.
-func MlrvalFlatten(ma, mb, mc *Mlrval) Mlrval {
-	if mc.mvtype == MT_MAP || mc.mvtype == MT_ARRAY {
-		if ma.mvtype != MT_STRING && ma.mvtype != MT_VOID {
+func MlrvalFlatten(input1, input2, input3 *Mlrval) Mlrval {
+	if input3.mvtype == MT_MAP || input3.mvtype == MT_ARRAY {
+		if input1.mvtype != MT_STRING && input1.mvtype != MT_VOID {
 			return MlrvalFromError()
 		}
-		prefix := ma.printrep
-		if mb.mvtype != MT_STRING {
+		prefix := input1.printrep
+		if input2.mvtype != MT_STRING {
 			return MlrvalFromError()
 		}
-		delimiter := mb.printrep
+		delimiter := input2.printrep
 
-		return mc.FlattenToMap(prefix, delimiter)
+		return input3.FlattenToMap(prefix, delimiter)
 	} else {
-		return *mc
+		return *input3
 	}
 }
 
 // flatten($*, ".") is the same as flatten("", ".", $*)
-func MlrvalFlattenBinary(ma, mb *Mlrval) Mlrval {
-	return MlrvalFlatten(MlrvalPointerFromVoid(), mb, ma)
+func MlrvalFlattenBinary(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFlatten(MlrvalPointerFromVoid(), input2, input1)
 }
 
 // ----------------------------------------------------------------
 // First argument is a map.
 // Second argument is a delimiter string.
 // unflatten({"a.b.c", ".") is {"a": { "b": { "c": 4}}}.
-func MlrvalUnflatten(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype != MT_STRING {
+func MlrvalUnflatten(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype != MT_STRING {
 		return MlrvalFromError()
 	}
-	if ma.mvtype != MT_MAP {
-		return *ma
+	if input1.mvtype != MT_MAP {
+		return *input1
 	}
-	oldmap := ma.mapval
-	separator := mb.printrep
+	oldmap := input1.mapval
+	separator := input2.printrep
 	newmap := NewMlrmap()
 
 	for pe := oldmap.Head; pe != nil; pe = pe.Next {
@@ -688,11 +688,11 @@ func MlrvalUnflatten(ma, mb *Mlrval) Mlrval {
 
 // ----------------------------------------------------------------
 // Converts maps with "1", "2", ... keys into arrays. Recurses nested data structures.
-func MlrvalArrayify(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_MAP {
+func MlrvalArrayify(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_MAP {
 		convertible := true
 		i := 0
-		for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+		for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 			sval := strconv.Itoa(i + 1) // Miller user-space indices are 1-up
 			i++
 			if pe.Key != sval {
@@ -703,38 +703,38 @@ func MlrvalArrayify(ma *Mlrval) Mlrval {
 		}
 
 		if convertible {
-			arrayval := make([]Mlrval, ma.mapval.FieldCount)
+			arrayval := make([]Mlrval, input1.mapval.FieldCount)
 			i := 0
-			for pe := ma.mapval.Head; pe != nil; pe = pe.Next {
+			for pe := input1.mapval.Head; pe != nil; pe = pe.Next {
 				arrayval[i] = *pe.Value.Copy()
 				i++
 			}
 			return MlrvalFromArrayLiteralReference(arrayval)
 
 		} else {
-			return *ma
+			return *input1
 		}
 
-	} else if ma.mvtype == MT_ARRAY {
-		for i, _ := range ma.arrayval {
-			ma.arrayval[i] = MlrvalArrayify(&ma.arrayval[i])
+	} else if input1.mvtype == MT_ARRAY {
+		for i, _ := range input1.arrayval {
+			input1.arrayval[i] = MlrvalArrayify(&input1.arrayval[i])
 		}
-		return *ma
+		return *input1
 
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalJSONParse(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_VOID {
-		return *ma
-	} else if ma.mvtype != MT_STRING {
+func MlrvalJSONParse(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_VOID {
+		return *input1
+	} else if input1.mvtype != MT_STRING {
 		return MlrvalFromError()
 	} else {
 		output := MlrvalFromPending()
-		err := output.UnmarshalJSON([]byte(ma.printrep))
+		err := output.UnmarshalJSON([]byte(input1.printrep))
 		if err == nil {
 			return output
 		} else {
@@ -743,8 +743,8 @@ func MlrvalJSONParse(ma *Mlrval) Mlrval {
 	}
 }
 
-func MlrvalJSONStringifyUnary(ma *Mlrval) Mlrval {
-	outputBytes, err := ma.MarshalJSON(JSON_SINGLE_LINE)
+func MlrvalJSONStringifyUnary(input1 *Mlrval) Mlrval {
+	outputBytes, err := input1.MarshalJSON(JSON_SINGLE_LINE)
 	if err != nil {
 		return MlrvalFromError()
 	} else {
@@ -752,9 +752,9 @@ func MlrvalJSONStringifyUnary(ma *Mlrval) Mlrval {
 	}
 }
 
-func MlrvalJSONStringifyBinary(ma, mb *Mlrval) Mlrval {
+func MlrvalJSONStringifyBinary(input1, input2 *Mlrval) Mlrval {
 	var jsonFormatting TJSONFormatting = JSON_SINGLE_LINE
-	useMultiline, ok := mb.GetBoolValue()
+	useMultiline, ok := input2.GetBoolValue()
 	if !ok {
 		return MlrvalFromError()
 	}
@@ -762,7 +762,7 @@ func MlrvalJSONStringifyBinary(ma, mb *Mlrval) Mlrval {
 		jsonFormatting = JSON_MULTILINE
 	}
 
-	outputBytes, err := ma.MarshalJSON(jsonFormatting)
+	outputBytes, err := input1.MarshalJSON(jsonFormatting)
 	if err != nil {
 		return MlrvalFromError()
 	} else {

--- a/go/src/types/mlrval_functions_collections.go
+++ b/go/src/types/mlrval_functions_collections.go
@@ -150,42 +150,46 @@ func MlrvalLeafCount(output, input1 *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func has_key_in_array(input1, input2 *Mlrval) Mlrval {
+func has_key_in_array(output, input1, input2 *Mlrval) {
 	if input2.mvtype == MT_STRING {
-		return MlrvalFromFalse()
+		output.SetFromFalse()
+		return
 	}
 	if input2.mvtype != MT_INT {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	_, ok := UnaliasArrayIndex(&input1.arrayval, input2.intval)
-	return MlrvalFromBool(ok)
+	output.SetFromBool(ok)
 }
 
-func has_key_in_map(input1, input2 *Mlrval) Mlrval {
+func has_key_in_map(output, input1, input2 *Mlrval) {
 	if input2.mvtype == MT_STRING || input2.mvtype == MT_INT {
-		return MlrvalFromBool(input1.mapval.Has(input2.String()))
+		output.SetFromBool(input1.mapval.Has(input2.String()))
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func MlrvalHasKey(input1, input2 *Mlrval) Mlrval {
+func MlrvalHasKey(output, input1, input2 *Mlrval) {
 	if input1.mvtype == MT_ARRAY {
-		return has_key_in_array(input1, input2)
+		has_key_in_array(output, input1, input2)
 	} else if input1.mvtype == MT_MAP {
-		return has_key_in_map(input1, input2)
+		has_key_in_map(output, input1, input2)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
 // ================================================================
-func MlrvalMapSelect(mlrvals []*Mlrval) Mlrval {
+func MlrvalMapSelect(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) < 1 {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if mlrvals[0].mvtype != MT_MAP {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	oldmap := mlrvals[0].mapval
 	newMap := NewMlrmap()
@@ -199,11 +203,13 @@ func MlrvalMapSelect(mlrvals []*Mlrval) Mlrval {
 				if element.mvtype == MT_STRING {
 					newKeys[element.printrep] = true
 				} else {
-					return MlrvalFromError()
+					output.SetFromError()
+					return
 				}
 			}
 		} else {
-			return MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 	}
 
@@ -215,16 +221,18 @@ func MlrvalMapSelect(mlrvals []*Mlrval) Mlrval {
 		}
 	}
 
-	return MlrvalFromMap(newMap)
+	output.SetFromMap(newMap)
 }
 
 // ----------------------------------------------------------------
-func MlrvalMapExcept(mlrvals []*Mlrval) Mlrval {
+func MlrvalMapExcept(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) < 1 {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if mlrvals[0].mvtype != MT_MAP {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	newMap := mlrvals[0].mapval.Copy()
 
@@ -236,33 +244,39 @@ func MlrvalMapExcept(mlrvals []*Mlrval) Mlrval {
 				if element.mvtype == MT_STRING {
 					newMap.Remove(element.printrep)
 				} else {
-					return MlrvalFromError()
+					output.SetFromError()
+					return
 				}
 			}
 		} else {
-			return MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 	}
 
-	return MlrvalFromMap(newMap)
+	output.SetFromMap(newMap)
 }
 
 // ----------------------------------------------------------------
-func MlrvalMapSum(mlrvals []*Mlrval) Mlrval {
+func MlrvalMapSum(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) == 0 {
-		return MlrvalEmptyMap()
+		output.SetFromEmptyMap()
+		return
 	}
 	if len(mlrvals) == 1 {
-		return *mlrvals[0]
+		output.CopyFrom(mlrvals[0])
+		return
 	}
 	if mlrvals[0].mvtype != MT_MAP {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	newMap := mlrvals[0].mapval.Copy()
 
 	for _, otherMapArg := range mlrvals[1:] {
 		if otherMapArg.mvtype != MT_MAP {
-			return MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 
 		for pe := otherMapArg.mapval.Head; pe != nil; pe = pe.Next {
@@ -270,25 +284,29 @@ func MlrvalMapSum(mlrvals []*Mlrval) Mlrval {
 		}
 	}
 
-	return MlrvalFromMap(newMap)
+	output.SetFromMap(newMap)
 }
 
 // ----------------------------------------------------------------
-func MlrvalMapDiff(mlrvals []*Mlrval) Mlrval {
+func MlrvalMapDiff(output *Mlrval, mlrvals []*Mlrval) {
 	if len(mlrvals) == 0 {
-		return MlrvalEmptyMap()
+		output.SetFromEmptyMap()
+		return
 	}
 	if len(mlrvals) == 1 {
-		return *mlrvals[0]
+		output.CopyFrom(mlrvals[0])
+		return
 	}
 	if mlrvals[0].mvtype != MT_MAP {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	newMap := mlrvals[0].mapval.Copy()
 
 	for _, otherMapArg := range mlrvals[1:] {
 		if otherMapArg.mvtype != MT_MAP {
-			return MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 
 		for pe := otherMapArg.mapval.Head; pe != nil; pe = pe.Next {
@@ -296,15 +314,16 @@ func MlrvalMapDiff(mlrvals []*Mlrval) Mlrval {
 		}
 	}
 
-	return MlrvalFromMap(newMap)
+	output.SetFromMap(newMap)
 }
 
 // ================================================================
 // joink([1,2,3], ",") -> "1,2,3"
 // joink({"a":3,"b":4,"c":5}, ",") -> "a,b,c"
-func MlrvalJoinK(input1, input2 *Mlrval) Mlrval {
+func MlrvalJoinK(output, input1, input2 *Mlrval) {
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	fieldSeparator := input2.printrep
 	if input1.mvtype == MT_MAP {
@@ -317,7 +336,7 @@ func MlrvalJoinK(input1, input2 *Mlrval) Mlrval {
 			}
 		}
 
-		return MlrvalFromString(buffer.String())
+		output.SetFromString(buffer.String())
 	} else if input1.mvtype == MT_ARRAY {
 		var buffer bytes.Buffer
 
@@ -329,18 +348,19 @@ func MlrvalJoinK(input1, input2 *Mlrval) Mlrval {
 			buffer.WriteString(strconv.Itoa(i + 1))
 		}
 
-		return MlrvalFromString(buffer.String())
+		output.SetFromString(buffer.String())
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
 // ----------------------------------------------------------------
 // joinv([3,4,5], ",") -> "3,4,5"
 // joinv({"a":3,"b":4,"c":5}, ",") -> "3,4,5"
-func MlrvalJoinV(input1, input2 *Mlrval) Mlrval {
+func MlrvalJoinV(output, input1, input2 *Mlrval) {
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	fieldSeparator := input2.printrep
 
@@ -354,7 +374,7 @@ func MlrvalJoinV(input1, input2 *Mlrval) Mlrval {
 			}
 		}
 
-		return MlrvalFromString(buffer.String())
+		output.SetFromString(buffer.String())
 	} else if input1.mvtype == MT_ARRAY {
 		var buffer bytes.Buffer
 
@@ -365,9 +385,9 @@ func MlrvalJoinV(input1, input2 *Mlrval) Mlrval {
 			buffer.WriteString(element.String())
 		}
 
-		return MlrvalFromString(buffer.String())
+		output.SetFromString(buffer.String())
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
@@ -494,99 +514,99 @@ func MlrvalSplitKVX(output, input1, input2, input3 *Mlrval) {
 
 // ----------------------------------------------------------------
 // splitnv("a,b,c", ",") -> {"1":"a","2":"b","3":"c"}
-func MlrvalSplitNV(input1, input2 *Mlrval) Mlrval {
+func MlrvalSplitNV(output, input1, input2 *Mlrval) {
 	if input1.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	retval := MlrvalEmptyMap()
+	*output = MlrvalEmptyMap()
 
 	fields := lib.SplitString(input1.printrep, input2.printrep)
 	for i, field := range fields {
 		key := strconv.Itoa(i + 1) // Miller user-space indices are 1-up
 		value := MlrvalFromInferredType(field)
-		retval.mapval.PutReference(key, &value)
+		output.mapval.PutReference(key, &value)
 	}
-
-	return retval
 }
 
 // ----------------------------------------------------------------
 // splitnvx("3,4,5", ",") -> {"1":"3","2":"4","3":"5"}
-func MlrvalSplitNVX(input1, input2 *Mlrval) Mlrval {
+func MlrvalSplitNVX(output, input1, input2 *Mlrval) {
 	if input1.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	retval := MlrvalEmptyMap()
+	*output = MlrvalEmptyMap()
 
 	fields := lib.SplitString(input1.printrep, input2.printrep)
 	for i, field := range fields {
 		key := strconv.Itoa(i + 1) // Miller user-space indices are 1-up
 		value := MlrvalFromString(field)
-		retval.mapval.PutReference(key, &value)
+		output.mapval.PutReference(key, &value)
 	}
-
-	return retval
 }
 
 // ----------------------------------------------------------------
 // splita("3,4,5", ",") -> [3,4,5]
-func MlrvalSplitA(input1, input2 *Mlrval) Mlrval {
+func MlrvalSplitA(output, input1, input2 *Mlrval) {
 	if input1.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	fieldSeparator := input2.printrep
 
 	fields := lib.SplitString(input1.printrep, fieldSeparator)
 
-	retval := NewSizedMlrvalArray(int(len(fields)))
+	*output = *NewSizedMlrvalArray(int(len(fields)))
 
 	for i, field := range fields {
 		value := MlrvalFromInferredType(field)
-		retval.arrayval[i] = value
+		output.arrayval[i] = value
 	}
-
-	return *retval
 }
 
 // ----------------------------------------------------------------
 // splitax("3,4,5", ",") -> ["3","4","5"]
 
-func MlrvalSplitAX(input1, input2 *Mlrval) Mlrval {
+func MlrvalSplitAX(output, input1, input2 *Mlrval) {
 	if input1.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	input := input1.printrep
 	fieldSeparator := input2.printrep
 
-	return *mlrvalSplitAXHelper(input, fieldSeparator)
+	mlrvalSplitAXHelper(output, input, fieldSeparator)
 }
 
 // Split out for MlrvalSplitAX and MlrvalUnflatten
-func mlrvalSplitAXHelper(input string, separator string) *Mlrval {
+func mlrvalSplitAXHelper(output *Mlrval, input string, separator string) {
 	fields := lib.SplitString(input, separator)
 
-	retval := NewSizedMlrvalArray(int(len(fields)))
+	*output = *NewSizedMlrvalArray(int(len(fields)))
 
 	for i, field := range fields {
 		value := MlrvalFromString(field)
-		retval.arrayval[i] = value
+		output.arrayval[i] = value
 	}
-
-	return retval
 }
 
 // ----------------------------------------------------------------
@@ -634,15 +654,14 @@ func MlrvalGetValues(output, input1 *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func MlrvalAppend(input1, input2 *Mlrval) Mlrval {
+func MlrvalAppend(output, input1, input2 *Mlrval) {
 	if input1.mvtype != MT_ARRAY {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	macopy := input1.Copy()
-	mbcopy := input2.Copy()
-	macopy.ArrayAppend(mbcopy)
-	return *macopy
+	*output = *input1.Copy()
+	output.ArrayAppend(input2.Copy())
 }
 
 // ----------------------------------------------------------------
@@ -672,23 +691,22 @@ func MlrvalFlatten(output, input1, input2, input3 *Mlrval) {
 }
 
 // flatten($*, ".") is the same as flatten("", ".", $*)
-func MlrvalFlattenBinary(input1, input2 *Mlrval) Mlrval {
-	// xxx temp
-	output := MlrvalFromAbsent()
-	MlrvalFlatten(&output, MlrvalPointerFromVoid(), input2, input1)
-	return output
+func MlrvalFlattenBinary(output, input1, input2 *Mlrval) {
+	MlrvalFlatten(output, MlrvalPointerFromVoid(), input2, input1)
 }
 
 // ----------------------------------------------------------------
 // First argument is a map.
 // Second argument is a delimiter string.
 // unflatten({"a.b.c", ".") is {"a": { "b": { "c": 4}}}.
-func MlrvalUnflatten(input1, input2 *Mlrval) Mlrval {
+func MlrvalUnflatten(output, input1, input2 *Mlrval) {
 	if input2.mvtype != MT_STRING {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input1.mvtype != MT_MAP {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	oldmap := input1.mapval
 	separator := input2.printrep
@@ -696,10 +714,11 @@ func MlrvalUnflatten(input1, input2 *Mlrval) Mlrval {
 
 	for pe := oldmap.Head; pe != nil; pe = pe.Next {
 		// TODO: factor out a shared helper function bewteen here and MlrvalSplitAX.
-		arrayOfIndices := mlrvalSplitAXHelper(pe.Key, separator)
+		arrayOfIndices := MlrvalFromError()
+		mlrvalSplitAXHelper(&arrayOfIndices, pe.Key, separator)
 		newmap.PutIndexed(MakePointerArray(arrayOfIndices.arrayval), pe.Value.Copy())
 	}
-	return MlrvalFromMapReferenced(newmap)
+	output.SetFromMapReferenced(newmap)
 }
 
 // ----------------------------------------------------------------
@@ -766,11 +785,12 @@ func MlrvalJSONStringifyUnary(output, input1 *Mlrval) {
 	}
 }
 
-func MlrvalJSONStringifyBinary(input1, input2 *Mlrval) Mlrval {
+func MlrvalJSONStringifyBinary(output, input1, input2 *Mlrval) {
 	var jsonFormatting TJSONFormatting = JSON_SINGLE_LINE
 	useMultiline, ok := input2.GetBoolValue()
 	if !ok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if useMultiline {
 		jsonFormatting = JSON_MULTILINE
@@ -778,8 +798,8 @@ func MlrvalJSONStringifyBinary(input1, input2 *Mlrval) Mlrval {
 
 	outputBytes, err := input1.MarshalJSON(jsonFormatting)
 	if err != nil {
-		return MlrvalFromError()
+		output.SetFromError()
 	} else {
-		return MlrvalFromString(string(outputBytes))
+		output.SetFromString(string(outputBytes))
 	}
 }

--- a/go/src/types/mlrval_functions_math.go
+++ b/go/src/types/mlrval_functions_math.go
@@ -1,16 +1,16 @@
 package types
 
 // Return error (unary math-library func)
-func _math_unary_erro1(ma *Mlrval, f mathLibUnaryFunc) Mlrval {
+func _math_unary_erro1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
 	return MlrvalFromError()
 }
 
 // Return absent (unary math-library func)
-func _math_unary_absn1(ma *Mlrval, f mathLibUnaryFunc) Mlrval {
+func _math_unary_absn1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
 	return MlrvalFromAbsent()
 }
 
 // Return void (unary math-library func)
-func _math_unary_void1(ma *Mlrval, f mathLibUnaryFunc) Mlrval {
+func _math_unary_void1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
 	return MlrvalFromAbsent()
 }

--- a/go/src/types/mlrval_functions_math.go
+++ b/go/src/types/mlrval_functions_math.go
@@ -1,16 +1,16 @@
 package types
 
 // Return error (unary math-library func)
-func _math_unary_erro1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromError()
+func _math_unary_erro1(output, input1 *Mlrval, f mathLibUnaryFunc) {
+	output.SetFromError()
 }
 
 // Return absent (unary math-library func)
-func _math_unary_absn1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromAbsent()
+func _math_unary_absn1(output, input1 *Mlrval, f mathLibUnaryFunc) {
+	output.SetFromAbsent()
 }
 
 // Return void (unary math-library func)
-func _math_unary_void1(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromAbsent()
+func _math_unary_void1(output, input1 *Mlrval, f mathLibUnaryFunc) {
+	output.SetFromAbsent()
 }

--- a/go/src/types/mlrval_functions_mathlib.go
+++ b/go/src/types/mlrval_functions_mathlib.go
@@ -145,17 +145,17 @@ func MlrvalTanh(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1
 // Exponentiation: DSL operator '**'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func pow_f_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(float64(input1.intval), float64(input2.intval)))
+func pow_f_ii(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Pow(float64(input1.intval), float64(input2.intval)))
 }
-func pow_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(float64(input1.intval), input2.floatval))
+func pow_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Pow(float64(input1.intval), input2.floatval))
 }
-func pow_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(input1.floatval, float64(input2.intval)))
+func pow_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Pow(input1.floatval, float64(input2.intval)))
 }
-func pow_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(input1.floatval, input2.floatval))
+func pow_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Pow(input1.floatval, input2.floatval))
 }
 
 var pow_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -171,22 +171,22 @@ var pow_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalPow(input1, input2 *Mlrval) Mlrval {
-	return pow_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalPow(output, input1, input2 *Mlrval) {
+	pow_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
-func atan2_f_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(float64(input1.intval), float64(input2.intval)))
+func atan2_f_ii(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Atan2(float64(input1.intval), float64(input2.intval)))
 }
-func atan2_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(float64(input1.intval), input2.floatval))
+func atan2_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Atan2(float64(input1.intval), input2.floatval))
 }
-func atan2_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(input1.floatval, float64(input2.intval)))
+func atan2_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Atan2(input1.floatval, float64(input2.intval)))
 }
-func atan2_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(input1.floatval, input2.floatval))
+func atan2_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(math.Atan2(input1.floatval, input2.floatval))
 }
 
 var atan2_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -202,8 +202,8 @@ var atan2_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalAtan2(input1, input2 *Mlrval) Mlrval {
-	return atan2_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalAtan2(output, input1, input2 *Mlrval) {
+	atan2_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -211,17 +211,17 @@ func mlr_roundm(x, m float64) float64 {
 	return math.Round(x/m) * m
 }
 
-func roundm_f_ii(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(float64(input1.intval), float64(input2.intval)))
+func roundm_f_ii(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(mlr_roundm(float64(input1.intval), float64(input2.intval)))
 }
-func roundm_f_if(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(float64(input1.intval), input2.floatval))
+func roundm_f_if(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(mlr_roundm(float64(input1.intval), input2.floatval))
 }
-func roundm_f_fi(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(input1.floatval, float64(input2.intval)))
+func roundm_f_fi(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(mlr_roundm(input1.floatval, float64(input2.intval)))
 }
-func roundm_f_ff(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(input1.floatval, input2.floatval))
+func roundm_f_ff(output, input1, input2 *Mlrval) {
+	output.SetFromFloat64(mlr_roundm(input1.floatval, input2.floatval))
 }
 
 var roundm_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -237,8 +237,8 @@ var roundm_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalRoundm(input1, input2 *Mlrval) Mlrval {
-	return roundm_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalRoundm(output, input1, input2 *Mlrval) {
+	roundm_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================

--- a/go/src/types/mlrval_functions_mathlib.go
+++ b/go/src/types/mlrval_functions_mathlib.go
@@ -240,30 +240,36 @@ func MlrvalRoundm(input1, input2 *Mlrval) Mlrval {
 }
 
 // ================================================================
-func MlrvalLogifit(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalLogifit(output, input1, input2, input3 *Mlrval) {
 	if !input1.IsLegit() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if !input2.IsLegit() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if !input3.IsLegit() {
-		return *input3
+		output.CopyFrom(input3)
+		return
 	}
 
 	// int/float OK; rest not
 	x, xok := input1.GetNumericToFloatValue()
 	if !xok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	m, mok := input2.GetNumericToFloatValue()
 	if !mok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	b, bok := input3.GetNumericToFloatValue()
 	if !bok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
-	return MlrvalFromFloat64(1.0 / (1.0 + math.Exp(-m*x-b)))
+	output.SetFromFloat64(1.0 / (1.0 + math.Exp(-m*x-b)))
 }

--- a/go/src/types/mlrval_functions_mathlib.go
+++ b/go/src/types/mlrval_functions_mathlib.go
@@ -90,11 +90,11 @@ func mlrInvqnorm(x float64) float64 {
 }
 
 // ----------------------------------------------------------------
-func math_unary_f_i(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromFloat64(f(float64(input1.intval)))
+func math_unary_f_i(output, input1 *Mlrval, f mathLibUnaryFunc) {
+	output.SetFromFloat64(f(float64(input1.intval)))
 }
-func math_unary_f_f(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromFloat64(f(input1.floatval))
+func math_unary_f_f(output, input1 *Mlrval, f mathLibUnaryFunc) {
+	output.SetFromFloat64(f(input1.floatval))
 }
 
 // Disposition vector for unary mathlib functions
@@ -110,34 +110,36 @@ var mudispo = [MT_DIM]mathLibUnaryFuncWrapper{
 	/*MAP    */ _math_unary_absn1,
 }
 
-func MlrvalAbs(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Abs) }
-func MlrvalAcos(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Acos) }
-func MlrvalAcosh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Acosh) }
-func MlrvalAsin(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Asin) }
-func MlrvalAsinh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Asinh) }
-func MlrvalAtan(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Atan) }
-func MlrvalAtanh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Atanh) }
-func MlrvalCbrt(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Cbrt) }
-func MlrvalCeil(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Ceil) }
-func MlrvalCos(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Cos) }
-func MlrvalCosh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Cosh) }
-func MlrvalErf(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Erf) }
-func MlrvalErfc(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Erfc) }
-func MlrvalExp(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Exp) }
-func MlrvalExpm1(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Expm1) }
-func MlrvalFloor(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Floor) }
-func MlrvalInvqnorm(input1 *Mlrval) Mlrval { return mudispo[input1.mvtype](input1, mlrInvqnorm) }
-func MlrvalLog(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Log) }
-func MlrvalLog10(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Log10) }
-func MlrvalLog1p(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Log1p) }
-func MlrvalQnorm(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, mlrQnorm) }
-func MlrvalRound(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Round) }
-func MlrvalSgn(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, mlrSgn) }
-func MlrvalSin(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Sin) }
-func MlrvalSinh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Sinh) }
-func MlrvalSqrt(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Sqrt) }
-func MlrvalTan(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Tan) }
-func MlrvalTanh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Tanh) }
+func MlrvalAbs(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Abs) }
+func MlrvalAcos(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Acos) }
+func MlrvalAcosh(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Acosh) }
+func MlrvalAsin(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Asin) }
+func MlrvalAsinh(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Asinh) }
+func MlrvalAtan(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Atan) }
+func MlrvalAtanh(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Atanh) }
+func MlrvalCbrt(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Cbrt) }
+func MlrvalCeil(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Ceil) }
+func MlrvalCos(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Cos) }
+func MlrvalCosh(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Cosh) }
+func MlrvalErf(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Erf) }
+func MlrvalErfc(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Erfc) }
+func MlrvalExp(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Exp) }
+func MlrvalExpm1(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Expm1) }
+func MlrvalFloor(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Floor) }
+func MlrvalInvqnorm(output, input1 *Mlrval) {
+	mudispo[input1.mvtype](output, input1, mlrInvqnorm)
+}
+func MlrvalLog(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Log) }
+func MlrvalLog10(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Log10) }
+func MlrvalLog1p(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Log1p) }
+func MlrvalQnorm(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, mlrQnorm) }
+func MlrvalRound(output, input1 *Mlrval) { mudispo[input1.mvtype](output, input1, math.Round) }
+func MlrvalSgn(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, mlrSgn) }
+func MlrvalSin(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Sin) }
+func MlrvalSinh(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Sinh) }
+func MlrvalSqrt(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Sqrt) }
+func MlrvalTan(output, input1 *Mlrval)   { mudispo[input1.mvtype](output, input1, math.Tan) }
+func MlrvalTanh(output, input1 *Mlrval)  { mudispo[input1.mvtype](output, input1, math.Tanh) }
 
 // ================================================================
 // Exponentiation: DSL operator '**'.  See also

--- a/go/src/types/mlrval_functions_mathlib.go
+++ b/go/src/types/mlrval_functions_mathlib.go
@@ -90,11 +90,11 @@ func mlrInvqnorm(x float64) float64 {
 }
 
 // ----------------------------------------------------------------
-func math_unary_f_i(ma *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromFloat64(f(float64(ma.intval)))
+func math_unary_f_i(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
+	return MlrvalFromFloat64(f(float64(input1.intval)))
 }
-func math_unary_f_f(ma *Mlrval, f mathLibUnaryFunc) Mlrval {
-	return MlrvalFromFloat64(f(ma.floatval))
+func math_unary_f_f(input1 *Mlrval, f mathLibUnaryFunc) Mlrval {
+	return MlrvalFromFloat64(f(input1.floatval))
 }
 
 // Disposition vector for unary mathlib functions
@@ -110,50 +110,50 @@ var mudispo = [MT_DIM]mathLibUnaryFuncWrapper{
 	/*MAP    */ _math_unary_absn1,
 }
 
-func MlrvalAbs(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Abs) }
-func MlrvalAcos(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Acos) }
-func MlrvalAcosh(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Acosh) }
-func MlrvalAsin(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Asin) }
-func MlrvalAsinh(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Asinh) }
-func MlrvalAtan(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Atan) }
-func MlrvalAtanh(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Atanh) }
-func MlrvalCbrt(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Cbrt) }
-func MlrvalCeil(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Ceil) }
-func MlrvalCos(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Cos) }
-func MlrvalCosh(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Cosh) }
-func MlrvalErf(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Erf) }
-func MlrvalErfc(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Erfc) }
-func MlrvalExp(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Exp) }
-func MlrvalExpm1(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Expm1) }
-func MlrvalFloor(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Floor) }
-func MlrvalInvqnorm(ma *Mlrval) Mlrval { return mudispo[ma.mvtype](ma, mlrInvqnorm) }
-func MlrvalLog(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Log) }
-func MlrvalLog10(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Log10) }
-func MlrvalLog1p(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Log1p) }
-func MlrvalQnorm(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, mlrQnorm) }
-func MlrvalRound(ma *Mlrval) Mlrval    { return mudispo[ma.mvtype](ma, math.Round) }
-func MlrvalSgn(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, mlrSgn) }
-func MlrvalSin(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Sin) }
-func MlrvalSinh(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Sinh) }
-func MlrvalSqrt(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Sqrt) }
-func MlrvalTan(ma *Mlrval) Mlrval      { return mudispo[ma.mvtype](ma, math.Tan) }
-func MlrvalTanh(ma *Mlrval) Mlrval     { return mudispo[ma.mvtype](ma, math.Tanh) }
+func MlrvalAbs(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Abs) }
+func MlrvalAcos(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Acos) }
+func MlrvalAcosh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Acosh) }
+func MlrvalAsin(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Asin) }
+func MlrvalAsinh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Asinh) }
+func MlrvalAtan(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Atan) }
+func MlrvalAtanh(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Atanh) }
+func MlrvalCbrt(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Cbrt) }
+func MlrvalCeil(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Ceil) }
+func MlrvalCos(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Cos) }
+func MlrvalCosh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Cosh) }
+func MlrvalErf(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Erf) }
+func MlrvalErfc(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Erfc) }
+func MlrvalExp(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Exp) }
+func MlrvalExpm1(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Expm1) }
+func MlrvalFloor(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Floor) }
+func MlrvalInvqnorm(input1 *Mlrval) Mlrval { return mudispo[input1.mvtype](input1, mlrInvqnorm) }
+func MlrvalLog(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Log) }
+func MlrvalLog10(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Log10) }
+func MlrvalLog1p(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Log1p) }
+func MlrvalQnorm(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, mlrQnorm) }
+func MlrvalRound(input1 *Mlrval) Mlrval    { return mudispo[input1.mvtype](input1, math.Round) }
+func MlrvalSgn(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, mlrSgn) }
+func MlrvalSin(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Sin) }
+func MlrvalSinh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Sinh) }
+func MlrvalSqrt(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Sqrt) }
+func MlrvalTan(input1 *Mlrval) Mlrval      { return mudispo[input1.mvtype](input1, math.Tan) }
+func MlrvalTanh(input1 *Mlrval) Mlrval     { return mudispo[input1.mvtype](input1, math.Tanh) }
 
 // ================================================================
 // Exponentiation: DSL operator '**'.  See also
 // http://johnkerl.org/miller/doc/reference.html#Arithmetic.
 
-func pow_f_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(float64(ma.intval), float64(mb.intval)))
+func pow_f_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Pow(float64(input1.intval), float64(input2.intval)))
 }
-func pow_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(float64(ma.intval), mb.floatval))
+func pow_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Pow(float64(input1.intval), input2.floatval))
 }
-func pow_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(ma.floatval, float64(mb.intval)))
+func pow_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Pow(input1.floatval, float64(input2.intval)))
 }
-func pow_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Pow(ma.floatval, mb.floatval))
+func pow_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Pow(input1.floatval, input2.floatval))
 }
 
 var pow_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -169,22 +169,22 @@ var pow_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalPow(ma, mb *Mlrval) Mlrval {
-	return pow_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalPow(input1, input2 *Mlrval) Mlrval {
+	return pow_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
-func atan2_f_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(float64(ma.intval), float64(mb.intval)))
+func atan2_f_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Atan2(float64(input1.intval), float64(input2.intval)))
 }
-func atan2_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(float64(ma.intval), mb.floatval))
+func atan2_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Atan2(float64(input1.intval), input2.floatval))
 }
-func atan2_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(ma.floatval, float64(mb.intval)))
+func atan2_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Atan2(input1.floatval, float64(input2.intval)))
 }
-func atan2_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(math.Atan2(ma.floatval, mb.floatval))
+func atan2_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(math.Atan2(input1.floatval, input2.floatval))
 }
 
 var atan2_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -200,8 +200,8 @@ var atan2_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalAtan2(ma, mb *Mlrval) Mlrval {
-	return atan2_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalAtan2(input1, input2 *Mlrval) Mlrval {
+	return atan2_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
@@ -209,17 +209,17 @@ func mlr_roundm(x, m float64) float64 {
 	return math.Round(x/m) * m
 }
 
-func roundm_f_ii(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(float64(ma.intval), float64(mb.intval)))
+func roundm_f_ii(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(mlr_roundm(float64(input1.intval), float64(input2.intval)))
 }
-func roundm_f_if(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(float64(ma.intval), mb.floatval))
+func roundm_f_if(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(mlr_roundm(float64(input1.intval), input2.floatval))
 }
-func roundm_f_fi(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(ma.floatval, float64(mb.intval)))
+func roundm_f_fi(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(mlr_roundm(input1.floatval, float64(input2.intval)))
 }
-func roundm_f_ff(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromFloat64(mlr_roundm(ma.floatval, mb.floatval))
+func roundm_f_ff(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(mlr_roundm(input1.floatval, input2.floatval))
 }
 
 var roundm_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -235,32 +235,32 @@ var roundm_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn},
 }
 
-func MlrvalRoundm(ma, mb *Mlrval) Mlrval {
-	return roundm_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalRoundm(input1, input2 *Mlrval) Mlrval {
+	return roundm_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
-func MlrvalLogifit(ma, mb, mc *Mlrval) Mlrval {
-	if !ma.IsLegit() {
-		return *ma
+func MlrvalLogifit(input1, input2, input3 *Mlrval) Mlrval {
+	if !input1.IsLegit() {
+		return *input1
 	}
-	if !mb.IsLegit() {
-		return *mb
+	if !input2.IsLegit() {
+		return *input2
 	}
-	if !mc.IsLegit() {
-		return *mc
+	if !input3.IsLegit() {
+		return *input3
 	}
 
 	// int/float OK; rest not
-	x, xok := ma.GetNumericToFloatValue()
+	x, xok := input1.GetNumericToFloatValue()
 	if !xok {
 		return MlrvalFromError()
 	}
-	m, mok := mb.GetNumericToFloatValue()
+	m, mok := input2.GetNumericToFloatValue()
 	if !mok {
 		return MlrvalFromError()
 	}
-	b, bok := mc.GetNumericToFloatValue()
+	b, bok := input3.GetNumericToFloatValue()
 	if !bok {
 		return MlrvalFromError()
 	}

--- a/go/src/types/mlrval_functions_random.go
+++ b/go/src/types/mlrval_functions_random.go
@@ -21,18 +21,22 @@ func MlrvalUrand32(output *Mlrval) {
 }
 
 // TODO: use a disposition matrix
-func MlrvalUrandInt(input1, input2 *Mlrval) Mlrval {
+func MlrvalUrandInt(output, input1, input2 *Mlrval) {
 	if !input1.IsLegit() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if !input2.IsLegit() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if !input1.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	a := input1.intval
@@ -48,25 +52,29 @@ func MlrvalUrandInt(input1, input2 *Mlrval) Mlrval {
 		hi = a + 1
 	}
 	u := int(math.Floor(float64(lo) + float64((hi-lo))*lib.RandFloat64()))
-	return MlrvalFromInt(u)
+	output.SetFromInt(u)
 }
 
-func MlrvalUrandRange(input1, input2 *Mlrval) Mlrval {
+func MlrvalUrandRange(output, input1, input2 *Mlrval) {
 	if !input1.IsLegit() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if !input2.IsLegit() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	a, aok := input1.GetNumericToFloatValue()
 	b, bok := input2.GetNumericToFloatValue()
 	if !aok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !bok {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
-	return MlrvalFromFloat64(
+	output.SetFromFloat64(
 		a + (b-a)*lib.RandFloat64(),
 	)
 }

--- a/go/src/types/mlrval_functions_random.go
+++ b/go/src/types/mlrval_functions_random.go
@@ -6,14 +6,14 @@ import (
 	"miller/src/lib"
 )
 
-func MlrvalUrand() Mlrval {
-	return MlrvalFromFloat64(
+func MlrvalUrand(output *Mlrval) {
+	output.SetFromFloat64(
 		lib.RandFloat64(),
 	)
 }
 
-func MlrvalUrand32() Mlrval {
-	return MlrvalFromInt(
+func MlrvalUrand32(output *Mlrval) {
+	output.SetFromInt(
 		int(
 			lib.RandUint32(),
 		),

--- a/go/src/types/mlrval_functions_random.go
+++ b/go/src/types/mlrval_functions_random.go
@@ -21,22 +21,22 @@ func MlrvalUrand32() Mlrval {
 }
 
 // TODO: use a disposition matrix
-func MlrvalUrandInt(ma, mb *Mlrval) Mlrval {
-	if !ma.IsLegit() {
-		return *ma
+func MlrvalUrandInt(input1, input2 *Mlrval) Mlrval {
+	if !input1.IsLegit() {
+		return *input1
 	}
-	if !mb.IsLegit() {
-		return *mb
+	if !input2.IsLegit() {
+		return *input2
 	}
-	if !ma.IsInt() {
+	if !input1.IsInt() {
 		return MlrvalFromError()
 	}
-	if !mb.IsInt() {
+	if !input2.IsInt() {
 		return MlrvalFromError()
 	}
 
-	a := ma.intval
-	b := mb.intval
+	a := input1.intval
+	b := input2.intval
 
 	var lo int = 0
 	var hi int = 0
@@ -51,15 +51,15 @@ func MlrvalUrandInt(ma, mb *Mlrval) Mlrval {
 	return MlrvalFromInt(u)
 }
 
-func MlrvalUrandRange(ma, mb *Mlrval) Mlrval {
-	if !ma.IsLegit() {
-		return *ma
+func MlrvalUrandRange(input1, input2 *Mlrval) Mlrval {
+	if !input1.IsLegit() {
+		return *input1
 	}
-	if !mb.IsLegit() {
-		return *mb
+	if !input2.IsLegit() {
+		return *input2
 	}
-	a, aok := ma.GetNumericToFloatValue()
-	b, bok := mb.GetNumericToFloatValue()
+	a, aok := input1.GetNumericToFloatValue()
+	b, bok := input2.GetNumericToFloatValue()
 	if !aok {
 		return MlrvalFromError()
 	}

--- a/go/src/types/mlrval_functions_regex.go
+++ b/go/src/types/mlrval_functions_regex.go
@@ -7,56 +7,56 @@ import (
 )
 
 // ================================================================
-func MlrvalSsub(ma, mb, mc *Mlrval) Mlrval {
-	if ma.IsErrorOrAbsent() {
-		return *ma
+func MlrvalSsub(input1, input2, input3 *Mlrval) Mlrval {
+	if input1.IsErrorOrAbsent() {
+		return *input1
 	}
-	if mb.IsErrorOrAbsent() {
-		return *mb
+	if input2.IsErrorOrAbsent() {
+		return *input2
 	}
-	if mc.IsErrorOrAbsent() {
-		return *mc
+	if input3.IsErrorOrAbsent() {
+		return *input3
 	}
-	if !ma.IsStringOrVoid() {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mb.IsStringOrVoid() {
+	if !input2.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mc.IsStringOrVoid() {
+	if !input3.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	return MlrvalFromString(
-		strings.Replace(ma.printrep, mb.printrep, mc.printrep, 1),
+		strings.Replace(input1.printrep, input2.printrep, input3.printrep, 1),
 	)
 }
 
 // ================================================================
 // TODO: make a variant which allows compiling the regexp once and reusing it
 // on each record
-func MlrvalSub(ma, mb, mc *Mlrval) Mlrval {
-	if ma.IsErrorOrAbsent() {
-		return *ma
+func MlrvalSub(input1, input2, input3 *Mlrval) Mlrval {
+	if input1.IsErrorOrAbsent() {
+		return *input1
 	}
-	if mb.IsErrorOrAbsent() {
-		return *mb
+	if input2.IsErrorOrAbsent() {
+		return *input2
 	}
-	if mc.IsErrorOrAbsent() {
-		return *mc
+	if input3.IsErrorOrAbsent() {
+		return *input3
 	}
-	if !ma.IsStringOrVoid() {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mb.IsStringOrVoid() {
+	if !input2.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mc.IsStringOrVoid() {
+	if !input3.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	// TODO: better exception-handling
-	re := lib.CompileMillerRegexOrDie(mb.printrep)
+	re := lib.CompileMillerRegexOrDie(input2.printrep)
 
-	output := lib.RegexReplaceOnce(re, ma.printrep, mc.printrep)
+	output := lib.RegexReplaceOnce(re, input1.printrep, input3.printrep)
 
 	return MlrvalFromString(output)
 }
@@ -64,57 +64,57 @@ func MlrvalSub(ma, mb, mc *Mlrval) Mlrval {
 // ================================================================
 // TODO: make a variant which allows compiling the regexp once and reusing it
 // on each record
-func MlrvalGsub(ma, mb, mc *Mlrval) Mlrval {
-	if ma.IsErrorOrAbsent() {
-		return *ma
+func MlrvalGsub(input1, input2, input3 *Mlrval) Mlrval {
+	if input1.IsErrorOrAbsent() {
+		return *input1
 	}
-	if mb.IsErrorOrAbsent() {
-		return *mb
+	if input2.IsErrorOrAbsent() {
+		return *input2
 	}
-	if mc.IsErrorOrAbsent() {
-		return *mc
+	if input3.IsErrorOrAbsent() {
+		return *input3
 	}
-	if !ma.IsStringOrVoid() {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mb.IsStringOrVoid() {
+	if !input2.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mc.IsStringOrVoid() {
+	if !input3.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	// TODO: better exception-handling
-	re := lib.CompileMillerRegexOrDie(mb.printrep)
+	re := lib.CompileMillerRegexOrDie(input2.printrep)
 	return MlrvalFromString(
-		re.ReplaceAllString(ma.printrep, mc.printrep),
+		re.ReplaceAllString(input1.printrep, input3.printrep),
 	)
 }
 
 // ================================================================
 // TODO: make a variant which allows compiling the regexp once and reusing it
 // on each record
-func MlrvalStringMatchesRegexp(ma, mb *Mlrval) Mlrval {
-	if !ma.IsLegit() {
-		return *ma
+func MlrvalStringMatchesRegexp(input1, input2 *Mlrval) Mlrval {
+	if !input1.IsLegit() {
+		return *input1
 	}
-	if !mb.IsLegit() {
-		return *mb
+	if !input2.IsLegit() {
+		return *input2
 	}
-	if !ma.IsStringOrVoid() {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mb.IsStringOrVoid() {
+	if !input2.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
 	// TODO: better exception-handling
-	re := lib.CompileMillerRegexOrDie(mb.printrep)
+	re := lib.CompileMillerRegexOrDie(input2.printrep)
 	return MlrvalFromBool(
-		re.MatchString(ma.printrep),
+		re.MatchString(input1.printrep),
 	)
 }
 
-func MlrvalStringDoesNotMatchRegexp(ma, mb *Mlrval) Mlrval {
-	matches := MlrvalStringMatchesRegexp(ma, mb)
+func MlrvalStringDoesNotMatchRegexp(input1, input2 *Mlrval) Mlrval {
+	matches := MlrvalStringMatchesRegexp(input1, input2)
 	if matches.mvtype == MT_BOOL {
 		return MlrvalFromBool(!matches.boolval)
 	} else {
@@ -123,16 +123,16 @@ func MlrvalStringDoesNotMatchRegexp(ma, mb *Mlrval) Mlrval {
 }
 
 // TODO: find a way to keep and stash a precompiled regex, somewhere in the CST ...
-func MlrvalRegextract(ma, mb *Mlrval) Mlrval {
-	if !ma.IsString() {
+func MlrvalRegextract(input1, input2 *Mlrval) Mlrval {
+	if !input1.IsString() {
 		return MlrvalFromError()
 	}
-	if !mb.IsString() {
+	if !input2.IsString() {
 		return MlrvalFromError()
 	}
-	regex := lib.CompileMillerRegexOrDie(mb.printrep)
+	regex := lib.CompileMillerRegexOrDie(input2.printrep)
 	// TODO: See if we need FindStringIndex or FindStringSubmatch to distinguish from matching "".
-	output := regex.FindString(ma.printrep)
+	output := regex.FindString(input1.printrep)
 	if output != "" {
 		return MlrvalFromString(output)
 	} else {
@@ -140,19 +140,19 @@ func MlrvalRegextract(ma, mb *Mlrval) Mlrval {
 	}
 }
 
-func MlrvalRegextractOrElse(ma, mb, mc *Mlrval) Mlrval {
-	if !ma.IsString() {
+func MlrvalRegextractOrElse(input1, input2, input3 *Mlrval) Mlrval {
+	if !input1.IsString() {
 		return MlrvalFromError()
 	}
-	if !mb.IsString() {
+	if !input2.IsString() {
 		return MlrvalFromError()
 	}
-	regex := lib.CompileMillerRegexOrDie(mb.printrep)
+	regex := lib.CompileMillerRegexOrDie(input2.printrep)
 	// TODO: See if we need FindStringIndex or FindStringSubmatch to distinguish from matching "".
-	output := regex.FindString(ma.printrep)
+	output := regex.FindString(input1.printrep)
 	if output != "" {
 		return MlrvalFromString(output)
 	} else {
-		return *mc
+		return *input3
 	}
 }

--- a/go/src/types/mlrval_functions_regex.go
+++ b/go/src/types/mlrval_functions_regex.go
@@ -7,85 +7,93 @@ import (
 )
 
 // ================================================================
-func MlrvalSsub(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalSsub(output, input1, input2, input3 *Mlrval) {
 	if input1.IsErrorOrAbsent() {
-		return *input1
+		output.CopyFrom(input1)
+	} else if input2.IsErrorOrAbsent() {
+		output.CopyFrom(input2)
+	} else if input3.IsErrorOrAbsent() {
+		output.CopyFrom(input3)
+	} else if !input1.IsStringOrVoid() {
+		output.SetFromError()
+	} else if !input2.IsStringOrVoid() {
+		output.SetFromError()
+	} else if !input3.IsStringOrVoid() {
+		output.SetFromError()
+	} else {
+		output.SetFromString(
+			strings.Replace(input1.printrep, input2.printrep, input3.printrep, 1),
+		)
 	}
-	if input2.IsErrorOrAbsent() {
-		return *input2
-	}
-	if input3.IsErrorOrAbsent() {
-		return *input3
-	}
-	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
-	}
-	if !input2.IsStringOrVoid() {
-		return MlrvalFromError()
-	}
-	if !input3.IsStringOrVoid() {
-		return MlrvalFromError()
-	}
-	return MlrvalFromString(
-		strings.Replace(input1.printrep, input2.printrep, input3.printrep, 1),
-	)
 }
 
 // ================================================================
 // TODO: make a variant which allows compiling the regexp once and reusing it
 // on each record
-func MlrvalSub(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalSub(output, input1, input2, input3 *Mlrval) {
 	if input1.IsErrorOrAbsent() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if input2.IsErrorOrAbsent() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if input3.IsErrorOrAbsent() {
-		return *input3
+		output.CopyFrom(input3)
+		return
 	}
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input3.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	// TODO: better exception-handling
 	re := lib.CompileMillerRegexOrDie(input2.printrep)
 
-	output := lib.RegexReplaceOnce(re, input1.printrep, input3.printrep)
+	replacement := lib.RegexReplaceOnce(re, input1.printrep, input3.printrep)
 
-	return MlrvalFromString(output)
+	output.SetFromString(replacement)
 }
 
 // ================================================================
 // TODO: make a variant which allows compiling the regexp once and reusing it
 // on each record
-func MlrvalGsub(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalGsub(output, input1, input2, input3 *Mlrval) {
 	if input1.IsErrorOrAbsent() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if input2.IsErrorOrAbsent() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if input3.IsErrorOrAbsent() {
-		return *input3
+		output.CopyFrom(input3)
+		return
 	}
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input3.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	// TODO: better exception-handling
 	re := lib.CompileMillerRegexOrDie(input2.printrep)
-	return MlrvalFromString(
+	output.SetFromString(
 		re.ReplaceAllString(input1.printrep, input3.printrep),
 	)
 }
@@ -140,19 +148,21 @@ func MlrvalRegextract(input1, input2 *Mlrval) Mlrval {
 	}
 }
 
-func MlrvalRegextractOrElse(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalRegextractOrElse(output, input1, input2, input3 *Mlrval) {
 	if !input1.IsString() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsString() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	regex := lib.CompileMillerRegexOrDie(input2.printrep)
 	// TODO: See if we need FindStringIndex or FindStringSubmatch to distinguish from matching "".
-	output := regex.FindString(input1.printrep)
-	if output != "" {
-		return MlrvalFromString(output)
+	found := regex.FindString(input1.printrep)
+	if found != "" {
+		output.SetFromString(found)
 	} else {
-		return *input3
+		output.CopyFrom(input3)
 	}
 }

--- a/go/src/types/mlrval_functions_sort.go
+++ b/go/src/types/mlrval_functions_sort.go
@@ -5,9 +5,9 @@
 package types
 
 // Lexical sort: just stringify everything.
-func LexicalAscendingComparator(ma *Mlrval, mb *Mlrval) int {
-	sa := ma.String()
-	sb := mb.String()
+func LexicalAscendingComparator(input1 *Mlrval, input2 *Mlrval) int {
+	sa := input1.String()
+	sb := input2.String()
 	if sa < sb {
 		return -1
 	} else if sa > sb {
@@ -16,8 +16,8 @@ func LexicalAscendingComparator(ma *Mlrval, mb *Mlrval) int {
 		return 0
 	}
 }
-func LexicalDescendingComparator(ma *Mlrval, mb *Mlrval) int {
-	return LexicalAscendingComparator(mb, ma)
+func LexicalDescendingComparator(input1 *Mlrval, input2 *Mlrval) int {
+	return LexicalAscendingComparator(input2, input1)
 }
 
 // ----------------------------------------------------------------
@@ -29,29 +29,29 @@ func LexicalDescendingComparator(ma *Mlrval, mb *Mlrval) int {
 // * numeric compares on numbers
 // * false < true
 
-func _neg1(ma, mb *Mlrval) int {
+func _neg1(input1, input2 *Mlrval) int {
 	return -1
 }
-func _zero(ma, mb *Mlrval) int {
+func _zero(input1, input2 *Mlrval) int {
 	return 0
 }
-func _pos1(ma, mb *Mlrval) int {
+func _pos1(input1, input2 *Mlrval) int {
 	return 1
 }
 
-func _scmp(ma, mb *Mlrval) int {
-	if ma.printrep < mb.printrep {
+func _scmp(input1, input2 *Mlrval) int {
+	if input1.printrep < input2.printrep {
 		return -1
-	} else if ma.printrep > mb.printrep {
+	} else if input1.printrep > input2.printrep {
 		return 1
 	} else {
 		return 0
 	}
 }
 
-func iicmp(ma, mb *Mlrval) int {
-	ca := ma.intval
-	cb := mb.intval
+func iicmp(input1, input2 *Mlrval) int {
+	ca := input1.intval
+	cb := input2.intval
 	if ca < cb {
 		return -1
 	} else if ca > cb {
@@ -60,9 +60,9 @@ func iicmp(ma, mb *Mlrval) int {
 		return 0
 	}
 }
-func ifcmp(ma, mb *Mlrval) int {
-	ca := float64(ma.intval)
-	cb := mb.floatval
+func ifcmp(input1, input2 *Mlrval) int {
+	ca := float64(input1.intval)
+	cb := input2.floatval
 	if ca < cb {
 		return -1
 	} else if ca > cb {
@@ -71,9 +71,9 @@ func ifcmp(ma, mb *Mlrval) int {
 		return 0
 	}
 }
-func ficmp(ma, mb *Mlrval) int {
-	ca := ma.floatval
-	cb := float64(mb.intval)
+func ficmp(input1, input2 *Mlrval) int {
+	ca := input1.floatval
+	cb := float64(input2.intval)
 	if ca < cb {
 		return -1
 	} else if ca > cb {
@@ -82,9 +82,9 @@ func ficmp(ma, mb *Mlrval) int {
 		return 0
 	}
 }
-func ffcmp(ma, mb *Mlrval) int {
-	ca := ma.floatval
-	cb := mb.floatval
+func ffcmp(input1, input2 *Mlrval) int {
+	ca := input1.floatval
+	cb := input2.floatval
 	if ca < cb {
 		return -1
 	} else if ca > cb {
@@ -94,9 +94,9 @@ func ffcmp(ma, mb *Mlrval) int {
 	}
 }
 
-func bbcmp(ma, mb *Mlrval) int {
-	a := ma.boolval
-	b := mb.boolval
+func bbcmp(input1, input2 *Mlrval) int {
+	a := input1.boolval
+	b := input2.boolval
 	if a == false {
 		if b == false {
 			return 0
@@ -134,9 +134,9 @@ var num_cmp_dispositions = [MT_DIM][MT_DIM]ComparatorFunc{
 	/*MAP    */ {_zero, _zero, _zero, _zero, _zero, _zero, _zero, _zero, _zero},
 }
 
-func NumericAscendingComparator(ma *Mlrval, mb *Mlrval) int {
-	return num_cmp_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func NumericAscendingComparator(input1 *Mlrval, input2 *Mlrval) int {
+	return num_cmp_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
-func NumericDescendingComparator(ma *Mlrval, mb *Mlrval) int {
-	return NumericAscendingComparator(mb, ma)
+func NumericDescendingComparator(input1 *Mlrval, input2 *Mlrval) int {
+	return NumericAscendingComparator(input2, input1)
 }

--- a/go/src/types/mlrval_functions_stats.go
+++ b/go/src/types/mlrval_functions_stats.go
@@ -50,7 +50,10 @@ func MlrvalGetStddev(mn, msum, msum2 *Mlrval) Mlrval {
 	if mvar.IsVoid() {
 		return mvar
 	}
-	return MlrvalSqrt(&mvar)
+	// xxx temp
+	output := MlrvalFromAbsent()
+	MlrvalSqrt(&output, &mvar)
+	return output
 }
 
 // ----------------------------------------------------------------
@@ -60,7 +63,9 @@ func MlrvalGetMeanEB(mn, msum, msum2 *Mlrval) Mlrval {
 		return mvar
 	}
 	mquot := MlrvalDivide(&mvar, mn)
-	return MlrvalSqrt(&mquot)
+	output := MlrvalFromAbsent()
+	MlrvalSqrt(&output, &mquot)
+	return output
 }
 
 // ----------------------------------------------------------------

--- a/go/src/types/mlrval_functions_stats.go
+++ b/go/src/types/mlrval_functions_stats.go
@@ -57,14 +57,15 @@ func MlrvalGetStddev(mn, msum, msum2 *Mlrval) Mlrval {
 }
 
 // ----------------------------------------------------------------
+// xxx refactor
 func MlrvalGetMeanEB(mn, msum, msum2 *Mlrval) Mlrval {
 	mvar := MlrvalGetVar(mn, msum, msum2)
 	if mvar.IsVoid() {
 		return mvar
 	}
-	mquot := MlrvalDivide(&mvar, mn)
-	output := MlrvalFromAbsent()
-	MlrvalSqrt(&output, &mquot)
+	output := MlrvalFromError()
+	MlrvalDivide(&output, &mvar, mn)
+	MlrvalSqrt(&output, &output)
 	return output
 }
 

--- a/go/src/types/mlrval_functions_strings.go
+++ b/go/src/types/mlrval_functions_strings.go
@@ -11,16 +11,16 @@ import (
 )
 
 // ================================================================
-func MlrvalStrlen(ma *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
+func MlrvalStrlen(input1 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	return MlrvalFromInt(int(utf8.RuneCountInString(ma.printrep)))
+	return MlrvalFromInt(int(utf8.RuneCountInString(input1.printrep)))
 }
 
 // ================================================================
-func MlrvalToString(ma *Mlrval) Mlrval {
-	return MlrvalFromString(ma.String())
+func MlrvalToString(input1 *Mlrval) Mlrval {
+	return MlrvalFromString(input1.String())
 }
 
 // ================================================================
@@ -37,8 +37,8 @@ func MlrvalToString(ma *Mlrval) Mlrval {
 // should be: always the string concatenation of the string representations of
 // the two arguments. So, we do the string-cast for the user.
 
-func dot_s_xx(ma, mb *Mlrval) Mlrval {
-	return MlrvalFromString(ma.String() + mb.String())
+func dot_s_xx(input1, input2 *Mlrval) Mlrval {
+	return MlrvalFromString(input1.String() + input2.String())
 }
 
 var dot_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -54,42 +54,42 @@ var dot_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx},
 }
 
-func MlrvalDot(ma, mb *Mlrval) Mlrval {
-	return dot_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalDot(input1, input2 *Mlrval) Mlrval {
+	return dot_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }
 
 // ================================================================
 // substr(s,m,n) gives substring of s from 1-up position m to n inclusive.
 // Negative indices -len .. -1 alias to 0 .. len-1.
 
-func MlrvalSubstr(ma, mb, mc *Mlrval) Mlrval {
-	if !ma.IsStringOrVoid() {
-		if ma.IsNumeric() {
+func MlrvalSubstr(input1, input2, input3 *Mlrval) Mlrval {
+	if !input1.IsStringOrVoid() {
+		if input1.IsNumeric() {
 			// JIT-stringify, if not already (e.g. intval scanned from string
 			// in input-file data)
-			ma.setPrintRep()
+			input1.setPrintRep()
 		} else {
 			return MlrvalFromError()
 		}
 	}
 	// TODO: fix this with regard to UTF-8 and runes.
-	strlen := int(len(ma.printrep))
+	strlen := int(len(input1.printrep))
 
 	// For array slices like s[1:2], s[:2], s[1:], when the lower index is
 	// empty in the DSL expression it comes in here as a 1. But when the upper
 	// index is empty in the DSL expression it comes in here as "".
-	if !mb.IsInt() {
+	if !input2.IsInt() {
 		return MlrvalFromError()
 	}
-	lowerMindex := mb.intval
+	lowerMindex := input2.intval
 
 	upperMindex := strlen
-	if mc.IsEmpty() {
+	if input3.IsEmpty() {
 		// Keep strlen
-	} else if !mc.IsInt() {
+	} else if !input3.IsInt() {
 		return MlrvalFromError()
 	} else {
-		upperMindex = mc.intval
+		upperMindex = input3.intval
 	}
 
 	// Convert from negative-aliased 1-up to positive-only 0-up
@@ -104,72 +104,72 @@ func MlrvalSubstr(ma, mb, mc *Mlrval) Mlrval {
 		// Note Golang slice indices are 0-up, and the 1st index is inclusive
 		// while the 2nd is exclusive. For Miller, indices are 1-up and both
 		// are inclusive.
-		return MlrvalFromString(ma.printrep[m : n+1])
+		return MlrvalFromString(input1.printrep[m : n+1])
 	}
 }
 
 // ================================================================
-func MlrvalTruncate(ma, mb *Mlrval) Mlrval {
-	if ma.IsErrorOrAbsent() {
-		return *ma
+func MlrvalTruncate(input1, input2 *Mlrval) Mlrval {
+	if input1.IsErrorOrAbsent() {
+		return *input1
 	}
-	if mb.IsErrorOrAbsent() {
-		return *mb
+	if input2.IsErrorOrAbsent() {
+		return *input2
 	}
-	if !ma.IsStringOrVoid() {
+	if !input1.IsStringOrVoid() {
 		return MlrvalFromError()
 	}
-	if !mb.IsInt() {
+	if !input2.IsInt() {
 		return MlrvalFromError()
 	}
-	if mb.intval < 0 {
+	if input2.intval < 0 {
 		return MlrvalFromError()
 	}
 
-	oldLength := int(len(ma.printrep))
-	maxLength := mb.intval
+	oldLength := int(len(input1.printrep))
+	maxLength := input2.intval
 	if oldLength <= maxLength {
-		return *ma
+		return *input1
 	} else {
-		return MlrvalFromString(ma.printrep[0:maxLength])
+		return MlrvalFromString(input1.printrep[0:maxLength])
 	}
 }
 
 // ================================================================
-func MlrvalLStrip(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(strings.TrimLeft(ma.printrep, " \t"))
+func MlrvalLStrip(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(strings.TrimLeft(input1.printrep, " \t"))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
-func MlrvalRStrip(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(strings.TrimRight(ma.printrep, " \t"))
+func MlrvalRStrip(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(strings.TrimRight(input1.printrep, " \t"))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
-func MlrvalStrip(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(strings.Trim(ma.printrep, " \t"))
+func MlrvalStrip(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(strings.Trim(input1.printrep, " \t"))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalCollapseWhitespace(ma *Mlrval) Mlrval {
-	return MlrvalCollapseWhitespaceRegexp(ma, WhitespaceRegexp())
+func MlrvalCollapseWhitespace(input1 *Mlrval) Mlrval {
+	return MlrvalCollapseWhitespaceRegexp(input1, WhitespaceRegexp())
 }
 
-func MlrvalCollapseWhitespaceRegexp(ma *Mlrval, whitespaceRegexp *regexp.Regexp) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(whitespaceRegexp.ReplaceAllString(ma.printrep, " "))
+func MlrvalCollapseWhitespaceRegexp(input1 *Mlrval, whitespaceRegexp *regexp.Regexp) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(whitespaceRegexp.ReplaceAllString(input1.printrep, " "))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
@@ -178,32 +178,32 @@ func WhitespaceRegexp() *regexp.Regexp {
 }
 
 // ================================================================
-func MlrvalToUpper(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(strings.ToUpper(ma.printrep))
-	} else if ma.mvtype == MT_VOID {
-		return *ma
+func MlrvalToUpper(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(strings.ToUpper(input1.printrep))
+	} else if input1.mvtype == MT_VOID {
+		return *input1
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
-func MlrvalToLower(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		return MlrvalFromString(strings.ToLower(ma.printrep))
-	} else if ma.mvtype == MT_VOID {
-		return *ma
+func MlrvalToLower(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		return MlrvalFromString(strings.ToLower(input1.printrep))
+	} else if input1.mvtype == MT_VOID {
+		return *input1
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
-func MlrvalCapitalize(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_STRING {
-		if ma.printrep == "" {
-			return *ma
+func MlrvalCapitalize(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_STRING {
+		if input1.printrep == "" {
+			return *input1
 		} else {
-			runes := []rune(ma.printrep)
+			runes := []rune(input1.printrep)
 			rfirst := runes[0]
 			rrest := runes[1:]
 			sfirst := strings.ToUpper(string(rfirst))
@@ -211,49 +211,49 @@ func MlrvalCapitalize(ma *Mlrval) Mlrval {
 			return MlrvalFromString(sfirst + srest)
 		}
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalCleanWhitespace(ma *Mlrval) Mlrval {
-	temp := MlrvalCollapseWhitespaceRegexp(ma, WhitespaceRegexp())
+func MlrvalCleanWhitespace(input1 *Mlrval) Mlrval {
+	temp := MlrvalCollapseWhitespaceRegexp(input1, WhitespaceRegexp())
 	return MlrvalStrip(&temp)
 }
 
 // ================================================================
-func MlrvalHexfmt(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_INT {
-		return MlrvalFromString("0x" + strconv.FormatUint(uint64(ma.intval), 16))
+func MlrvalHexfmt(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_INT {
+		return MlrvalFromString("0x" + strconv.FormatUint(uint64(input1.intval), 16))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
 // ----------------------------------------------------------------
-func fmtnum_is(ma, mb *Mlrval) Mlrval {
+func fmtnum_is(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromString(
 		fmt.Sprintf(
-			mb.printrep,
-			ma.intval,
+			input2.printrep,
+			input1.intval,
 		),
 	)
 }
 
-func fmtnum_fs(ma, mb *Mlrval) Mlrval {
+func fmtnum_fs(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromString(
 		fmt.Sprintf(
-			mb.printrep,
-			ma.floatval,
+			input2.printrep,
+			input1.floatval,
 		),
 	)
 }
 
-func fmtnum_bs(ma, mb *Mlrval) Mlrval {
+func fmtnum_bs(input1, input2 *Mlrval) Mlrval {
 	return MlrvalFromString(
 		fmt.Sprintf(
-			mb.printrep,
-			lib.BoolToInt(ma.boolval),
+			input2.printrep,
+			lib.BoolToInt(input1.boolval),
 		),
 	)
 }
@@ -271,6 +271,6 @@ var fmtnum_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
 }
 
-func MlrvalFmtNum(ma, mb *Mlrval) Mlrval {
-	return fmtnum_dispositions[ma.mvtype][mb.mvtype](ma, mb)
+func MlrvalFmtNum(input1, input2 *Mlrval) Mlrval {
+	return fmtnum_dispositions[input1.mvtype][input2.mvtype](input1, input2)
 }

--- a/go/src/types/mlrval_functions_strings.go
+++ b/go/src/types/mlrval_functions_strings.go
@@ -38,8 +38,8 @@ func MlrvalToString(output, input1 *Mlrval) {
 // should be: always the string concatenation of the string representations of
 // the two arguments. So, we do the string-cast for the user.
 
-func dot_s_xx(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(input1.String() + input2.String())
+func dot_s_xx(output, input1, input2 *Mlrval) {
+	output.SetFromString(input1.String() + input2.String())
 }
 
 var dot_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
@@ -55,8 +55,8 @@ var dot_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_absn, _absn, _absn, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx},
 }
 
-func MlrvalDot(input1, input2 *Mlrval) Mlrval {
-	return dot_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalDot(output, input1, input2 *Mlrval) {
+	dot_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }
 
 // ================================================================
@@ -113,29 +113,34 @@ func MlrvalSubstr(output, input1, input2, input3 *Mlrval) {
 }
 
 // ================================================================
-func MlrvalTruncate(input1, input2 *Mlrval) Mlrval {
+func MlrvalTruncate(output, input1, input2 *Mlrval) {
 	if input1.IsErrorOrAbsent() {
-		return *input1
+		output.CopyFrom(input1)
+		return
 	}
 	if input2.IsErrorOrAbsent() {
-		return *input2
+		output.CopyFrom(input2)
+		return
 	}
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if !input2.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	if input2.intval < 0 {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 
 	oldLength := int(len(input1.printrep))
 	maxLength := input2.intval
 	if oldLength <= maxLength {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return MlrvalFromString(input1.printrep[0:maxLength])
+		output.SetFromString(input1.printrep[0:maxLength])
 	}
 }
 
@@ -235,8 +240,8 @@ func MlrvalHexfmt(output, input1 *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func fmtnum_is(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(
+func fmtnum_is(output, input1, input2 *Mlrval) {
+	output.SetFromString(
 		fmt.Sprintf(
 			input2.printrep,
 			input1.intval,
@@ -244,8 +249,8 @@ func fmtnum_is(input1, input2 *Mlrval) Mlrval {
 	)
 }
 
-func fmtnum_fs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(
+func fmtnum_fs(output, input1, input2 *Mlrval) {
+	output.SetFromString(
 		fmt.Sprintf(
 			input2.printrep,
 			input1.floatval,
@@ -253,8 +258,8 @@ func fmtnum_fs(input1, input2 *Mlrval) Mlrval {
 	)
 }
 
-func fmtnum_bs(input1, input2 *Mlrval) Mlrval {
-	return MlrvalFromString(
+func fmtnum_bs(output, input1, input2 *Mlrval) {
+	output.SetFromString(
 		fmt.Sprintf(
 			input2.printrep,
 			lib.BoolToInt(input1.boolval),
@@ -275,6 +280,6 @@ var fmtnum_dispositions = [MT_DIM][MT_DIM]BinaryFunc{
 	/*MAP    */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
 }
 
-func MlrvalFmtNum(input1, input2 *Mlrval) Mlrval {
-	return fmtnum_dispositions[input1.mvtype][input2.mvtype](input1, input2)
+func MlrvalFmtNum(output, input1, input2 *Mlrval) {
+	fmtnum_dispositions[input1.mvtype][input2.mvtype](output, input1, input2)
 }

--- a/go/src/types/mlrval_functions_strings.go
+++ b/go/src/types/mlrval_functions_strings.go
@@ -62,14 +62,15 @@ func MlrvalDot(input1, input2 *Mlrval) Mlrval {
 // substr(s,m,n) gives substring of s from 1-up position m to n inclusive.
 // Negative indices -len .. -1 alias to 0 .. len-1.
 
-func MlrvalSubstr(input1, input2, input3 *Mlrval) Mlrval {
+func MlrvalSubstr(output, input1, input2, input3 *Mlrval) {
 	if !input1.IsStringOrVoid() {
 		if input1.IsNumeric() {
 			// JIT-stringify, if not already (e.g. intval scanned from string
 			// in input-file data)
 			input1.setPrintRep()
 		} else {
-			return MlrvalFromError()
+			output.SetFromError()
+			return
 		}
 	}
 	// TODO: fix this with regard to UTF-8 and runes.
@@ -79,7 +80,8 @@ func MlrvalSubstr(input1, input2, input3 *Mlrval) Mlrval {
 	// empty in the DSL expression it comes in here as a 1. But when the upper
 	// index is empty in the DSL expression it comes in here as "".
 	if !input2.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	}
 	lowerMindex := input2.intval
 
@@ -87,7 +89,8 @@ func MlrvalSubstr(input1, input2, input3 *Mlrval) Mlrval {
 	if input3.IsEmpty() {
 		// Keep strlen
 	} else if !input3.IsInt() {
-		return MlrvalFromError()
+		output.SetFromError()
+		return
 	} else {
 		upperMindex = input3.intval
 	}
@@ -97,14 +100,14 @@ func MlrvalSubstr(input1, input2, input3 *Mlrval) Mlrval {
 	n, nok := UnaliasArrayLengthIndex(strlen, upperMindex)
 
 	if !mok || !nok {
-		return MlrvalFromString("")
+		output.SetFromString("")
 	} else if m > n {
-		return MlrvalFromError()
+		output.SetFromError()
 	} else {
 		// Note Golang slice indices are 0-up, and the 1st index is inclusive
 		// while the 2nd is exclusive. For Miller, indices are 1-up and both
 		// are inclusive.
-		return MlrvalFromString(input1.printrep[m : n+1])
+		output.SetFromString(input1.printrep[m : n+1])
 	}
 }
 

--- a/go/src/types/mlrval_functions_strings.go
+++ b/go/src/types/mlrval_functions_strings.go
@@ -11,16 +11,17 @@ import (
 )
 
 // ================================================================
-func MlrvalStrlen(input1 *Mlrval) Mlrval {
+func MlrvalStrlen(output, input1 *Mlrval) {
 	if !input1.IsStringOrVoid() {
-		return MlrvalFromError()
+		output.SetFromError()
+	} else {
+		output.SetFromInt(int(utf8.RuneCountInString(input1.printrep)))
 	}
-	return MlrvalFromInt(int(utf8.RuneCountInString(input1.printrep)))
 }
 
 // ================================================================
-func MlrvalToString(input1 *Mlrval) Mlrval {
-	return MlrvalFromString(input1.String())
+func MlrvalToString(output, input1 *Mlrval) {
+	output.SetFromString(input1.String())
 }
 
 // ================================================================
@@ -139,40 +140,40 @@ func MlrvalTruncate(input1, input2 *Mlrval) Mlrval {
 }
 
 // ================================================================
-func MlrvalLStrip(input1 *Mlrval) Mlrval {
+func MlrvalLStrip(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(strings.TrimLeft(input1.printrep, " \t"))
+		output.SetFromString(strings.TrimLeft(input1.printrep, " \t"))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
-func MlrvalRStrip(input1 *Mlrval) Mlrval {
+func MlrvalRStrip(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(strings.TrimRight(input1.printrep, " \t"))
+		output.SetFromString(strings.TrimRight(input1.printrep, " \t"))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
-func MlrvalStrip(input1 *Mlrval) Mlrval {
+func MlrvalStrip(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(strings.Trim(input1.printrep, " \t"))
+		output.SetFromString(strings.Trim(input1.printrep, " \t"))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalCollapseWhitespace(input1 *Mlrval) Mlrval {
-	return MlrvalCollapseWhitespaceRegexp(input1, WhitespaceRegexp())
+func MlrvalCollapseWhitespace(output, input1 *Mlrval) {
+	MlrvalCollapseWhitespaceRegexp(output, input1, WhitespaceRegexp())
 }
 
-func MlrvalCollapseWhitespaceRegexp(input1 *Mlrval, whitespaceRegexp *regexp.Regexp) Mlrval {
+func MlrvalCollapseWhitespaceRegexp(output, input1 *Mlrval, whitespaceRegexp *regexp.Regexp) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(whitespaceRegexp.ReplaceAllString(input1.printrep, " "))
+		output.SetFromString(whitespaceRegexp.ReplaceAllString(input1.printrep, " "))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
@@ -181,55 +182,55 @@ func WhitespaceRegexp() *regexp.Regexp {
 }
 
 // ================================================================
-func MlrvalToUpper(input1 *Mlrval) Mlrval {
+func MlrvalToUpper(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(strings.ToUpper(input1.printrep))
+		output.SetFromString(strings.ToUpper(input1.printrep))
 	} else if input1.mvtype == MT_VOID {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
-func MlrvalToLower(input1 *Mlrval) Mlrval {
+func MlrvalToLower(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
-		return MlrvalFromString(strings.ToLower(input1.printrep))
+		output.SetFromString(strings.ToLower(input1.printrep))
 	} else if input1.mvtype == MT_VOID {
-		return *input1
+		output.CopyFrom(input1)
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
-func MlrvalCapitalize(input1 *Mlrval) Mlrval {
+func MlrvalCapitalize(output, input1 *Mlrval) {
 	if input1.mvtype == MT_STRING {
 		if input1.printrep == "" {
-			return *input1
+			output.CopyFrom(input1)
 		} else {
 			runes := []rune(input1.printrep)
 			rfirst := runes[0]
 			rrest := runes[1:]
 			sfirst := strings.ToUpper(string(rfirst))
 			srest := string(rrest)
-			return MlrvalFromString(sfirst + srest)
+			output.SetFromString(sfirst + srest)
 		}
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalCleanWhitespace(input1 *Mlrval) Mlrval {
-	temp := MlrvalCollapseWhitespaceRegexp(input1, WhitespaceRegexp())
-	return MlrvalStrip(&temp)
+func MlrvalCleanWhitespace(output, input1 *Mlrval) {
+	MlrvalCollapseWhitespaceRegexp(output, input1, WhitespaceRegexp())
+	MlrvalStrip(output, output)
 }
 
 // ================================================================
-func MlrvalHexfmt(input1 *Mlrval) Mlrval {
+func MlrvalHexfmt(output, input1 *Mlrval) {
 	if input1.mvtype == MT_INT {
-		return MlrvalFromString("0x" + strconv.FormatUint(uint64(input1.intval), 16))
+		output.SetFromString("0x" + strconv.FormatUint(uint64(input1.intval), 16))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 

--- a/go/src/types/mlrval_functions_time.go
+++ b/go/src/types/mlrval_functions_time.go
@@ -7,13 +7,13 @@ import (
 )
 
 // ================================================================
-func MlrvalSystime() Mlrval {
-	return MlrvalFromFloat64(
+func MlrvalSystime(output *Mlrval) {
+	output.SetFromFloat64(
 		float64(time.Now().UnixNano()) / 1.0e9,
 	)
 }
-func MlrvalSystimeInt() Mlrval {
-	return MlrvalFromInt(int(time.Now().Unix()))
+func MlrvalSystimeInt(output *Mlrval) {
+	output.SetFromInt(int(time.Now().Unix()))
 }
 
 var startTime float64
@@ -21,8 +21,8 @@ var startTime float64
 func init() {
 	startTime = float64(time.Now().UnixNano()) / 1.0e9
 }
-func MlrvalUptime() Mlrval {
-	return MlrvalFromFloat64(
+func MlrvalUptime(output *Mlrval) {
+	output.SetFromFloat64(
 		float64(time.Now().UnixNano())/1.0e9 - startTime,
 	)
 }

--- a/go/src/types/mlrval_functions_time.go
+++ b/go/src/types/mlrval_functions_time.go
@@ -39,9 +39,7 @@ func MlrvalSec2GMTUnary(output, input1 *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func MlrvalSec2GMTBinary(input1, input2 *Mlrval) Mlrval {
-	// xxx temp
-	output := MlrvalFromAbsent()
+func MlrvalSec2GMTBinary(output, input1, input2 *Mlrval) {
 	if input2.mvtype != MT_INT {
 		output.SetFromError()
 	} else if input1.mvtype == MT_FLOAT {
@@ -51,5 +49,4 @@ func MlrvalSec2GMTBinary(input1, input2 *Mlrval) Mlrval {
 	} else {
 		output.CopyFrom(input1)
 	}
-	return output
 }

--- a/go/src/types/mlrval_functions_time.go
+++ b/go/src/types/mlrval_functions_time.go
@@ -28,26 +28,26 @@ func MlrvalUptime() Mlrval {
 }
 
 // ================================================================
-func MlrvalSec2GMTUnary(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_FLOAT {
-		return MlrvalFromString(lib.Sec2GMT(ma.floatval, 0))
-	} else if ma.mvtype == MT_INT {
-		return MlrvalFromString(lib.Sec2GMT(float64(ma.intval), 0))
+func MlrvalSec2GMTUnary(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_FLOAT {
+		return MlrvalFromString(lib.Sec2GMT(input1.floatval, 0))
+	} else if input1.mvtype == MT_INT {
+		return MlrvalFromString(lib.Sec2GMT(float64(input1.intval), 0))
 	} else {
-		return *ma
+		return *input1
 	}
 }
 
 // ----------------------------------------------------------------
-func MlrvalSec2GMTBinary(ma, mb *Mlrval) Mlrval {
-	if mb.mvtype != MT_INT {
+func MlrvalSec2GMTBinary(input1, input2 *Mlrval) Mlrval {
+	if input2.mvtype != MT_INT {
 		return MlrvalFromError()
 	}
-	if ma.mvtype == MT_FLOAT {
-		return MlrvalFromString(lib.Sec2GMT(ma.floatval, int(mb.intval)))
-	} else if ma.mvtype == MT_INT {
-		return MlrvalFromString(lib.Sec2GMT(float64(ma.intval), int(mb.intval)))
+	if input1.mvtype == MT_FLOAT {
+		return MlrvalFromString(lib.Sec2GMT(input1.floatval, int(input2.intval)))
+	} else if input1.mvtype == MT_INT {
+		return MlrvalFromString(lib.Sec2GMT(float64(input1.intval), int(input2.intval)))
 	} else {
-		return *ma
+		return *input1
 	}
 }

--- a/go/src/types/mlrval_functions_time.go
+++ b/go/src/types/mlrval_functions_time.go
@@ -28,26 +28,28 @@ func MlrvalUptime(output *Mlrval) {
 }
 
 // ================================================================
-func MlrvalSec2GMTUnary(input1 *Mlrval) Mlrval {
+func MlrvalSec2GMTUnary(output, input1 *Mlrval) {
 	if input1.mvtype == MT_FLOAT {
-		return MlrvalFromString(lib.Sec2GMT(input1.floatval, 0))
+		output.SetFromString(lib.Sec2GMT(input1.floatval, 0))
 	} else if input1.mvtype == MT_INT {
-		return MlrvalFromString(lib.Sec2GMT(float64(input1.intval), 0))
+		output.SetFromString(lib.Sec2GMT(float64(input1.intval), 0))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
 }
 
 // ----------------------------------------------------------------
 func MlrvalSec2GMTBinary(input1, input2 *Mlrval) Mlrval {
+	// xxx temp
+	output := MlrvalFromAbsent()
 	if input2.mvtype != MT_INT {
-		return MlrvalFromError()
-	}
-	if input1.mvtype == MT_FLOAT {
-		return MlrvalFromString(lib.Sec2GMT(input1.floatval, int(input2.intval)))
+		output.SetFromError()
+	} else if input1.mvtype == MT_FLOAT {
+		output.SetFromString(lib.Sec2GMT(input1.floatval, int(input2.intval)))
 	} else if input1.mvtype == MT_INT {
-		return MlrvalFromString(lib.Sec2GMT(float64(input1.intval), int(input2.intval)))
+		output.SetFromString(lib.Sec2GMT(float64(input1.intval), int(input2.intval)))
 	} else {
-		return *input1
+		output.CopyFrom(input1)
 	}
+	return output
 }

--- a/go/src/types/mlrval_functions_types.go
+++ b/go/src/types/mlrval_functions_types.go
@@ -8,29 +8,29 @@ import (
 )
 
 // ================================================================
-func MlrvalTypeof(input1 *Mlrval) Mlrval {
-	return MlrvalFromString(input1.GetTypeName())
+func MlrvalTypeof(output, input1 *Mlrval) {
+	output.SetFromString(input1.GetTypeName())
 }
 
 // ----------------------------------------------------------------
-func string_to_int(input1 *Mlrval) Mlrval {
+func string_to_int(output, input1 *Mlrval) {
 	i, ok := lib.TryIntFromString(input1.printrep)
 	if ok {
-		return MlrvalFromInt(i)
+		output.SetFromInt(i)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func float_to_int(input1 *Mlrval) Mlrval {
-	return MlrvalFromInt(int(input1.floatval))
+func float_to_int(output, input1 *Mlrval) {
+	output.SetFromInt(int(input1.floatval))
 }
 
-func bool_to_int(input1 *Mlrval) Mlrval {
+func bool_to_int(output, input1 *Mlrval) {
 	if input1.boolval == true {
-		return MlrvalFromInt(1)
+		output.SetFromInt(1)
 	} else {
-		return MlrvalFromInt(0)
+		output.SetFromInt(0)
 	}
 }
 
@@ -46,29 +46,29 @@ var to_int_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToInt(input1 *Mlrval) Mlrval {
-	return to_int_dispositions[input1.mvtype](input1)
+func MlrvalToInt(output, input1 *Mlrval) {
+	to_int_dispositions[input1.mvtype](output, input1)
 }
 
 // ----------------------------------------------------------------
-func string_to_float(input1 *Mlrval) Mlrval {
+func string_to_float(output, input1 *Mlrval) {
 	f, ok := lib.TryFloat64FromString(input1.printrep)
 	if ok {
-		return MlrvalFromFloat64(f)
+		output.SetFromFloat64(f)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func int_to_float(input1 *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(input1.intval))
+func int_to_float(output, input1 *Mlrval) {
+	output.SetFromFloat64(float64(input1.intval))
 }
 
-func bool_to_float(input1 *Mlrval) Mlrval {
+func bool_to_float(output, input1 *Mlrval) {
 	if input1.boolval == true {
-		return MlrvalFromFloat64(1.0)
+		output.SetFromFloat64(1.0)
 	} else {
-		return MlrvalFromFloat64(0.0)
+		output.SetFromFloat64(0.0)
 	}
 }
 
@@ -84,26 +84,26 @@ var to_float_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToFloat(input1 *Mlrval) Mlrval {
-	return to_float_dispositions[input1.mvtype](input1)
+func MlrvalToFloat(output, input1 *Mlrval) {
+	to_float_dispositions[input1.mvtype](output, input1)
 }
 
 // ----------------------------------------------------------------
-func string_to_boolean(input1 *Mlrval) Mlrval {
+func string_to_boolean(output, input1 *Mlrval) {
 	b, ok := lib.TryBoolFromBoolString(input1.printrep)
 	if ok {
-		return MlrvalFromBool(b)
+		output.SetFromBool(b)
 	} else {
-		return MlrvalFromError()
+		output.SetFromError()
 	}
 }
 
-func int_to_bool(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.intval != 0)
+func int_to_bool(output, input1 *Mlrval) {
+	output.SetFromBool(input1.intval != 0)
 }
 
-func float_to_bool(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.floatval != 0.0)
+func float_to_bool(output, input1 *Mlrval) {
+	output.SetFromBool(input1.floatval != 0.0)
 }
 
 var to_boolean_dispositions = [MT_DIM]UnaryFunc{
@@ -118,83 +118,87 @@ var to_boolean_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToBoolean(input1 *Mlrval) Mlrval {
-	return to_boolean_dispositions[input1.mvtype](input1)
+func MlrvalToBoolean(output, input1 *Mlrval) {
+	to_boolean_dispositions[input1.mvtype](output, input1)
 }
 
 // ----------------------------------------------------------------
-func MlrvalIsAbsent(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_ABSENT)
+func MlrvalIsAbsent(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_ABSENT)
 }
-func MlrvalIsError(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_ERROR)
+func MlrvalIsError(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_ERROR)
 }
-func MlrvalIsBool(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_BOOL)
+func MlrvalIsBool(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_BOOL)
 }
-func MlrvalIsBoolean(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_BOOL)
+func MlrvalIsBoolean(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_BOOL)
 }
-func MlrvalIsEmpty(input1 *Mlrval) Mlrval {
+func MlrvalIsEmpty(output, input1 *Mlrval) {
 	if input1.mvtype == MT_VOID {
-		return MlrvalFromTrue()
-	}
-	if input1.mvtype == MT_STRING {
+		output.SetFromTrue()
+	} else if input1.mvtype == MT_STRING {
 		if input1.printrep == "" {
-			return MlrvalFromTrue()
+			output.SetFromTrue()
+		} else {
+			output.SetFromFalse()
 		}
+	} else {
+		output.SetFromFalse()
 	}
-	return MlrvalFromFalse()
 }
-func MlrvalIsEmptyMap(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount == 0)
+func MlrvalIsEmptyMap(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount == 0)
 }
-func MlrvalIsFloat(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_FLOAT)
+func MlrvalIsFloat(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_FLOAT)
 }
-func MlrvalIsInt(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_INT)
+func MlrvalIsInt(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_INT)
 }
-func MlrvalIsMap(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_MAP)
+func MlrvalIsMap(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_MAP)
 }
-func MlrvalIsArray(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_ARRAY)
+func MlrvalIsArray(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_ARRAY)
 }
-func MlrvalIsNonEmptyMap(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount != 0)
+func MlrvalIsNonEmptyMap(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount != 0)
 }
-func MlrvalIsNotEmpty(input1 *Mlrval) Mlrval {
+func MlrvalIsNotEmpty(output, input1 *Mlrval) {
 	if input1.mvtype == MT_VOID {
-		return MlrvalFromFalse()
-	}
-	if input1.mvtype == MT_STRING {
+		output.SetFromFalse()
+	} else if input1.mvtype == MT_STRING {
 		if input1.printrep == "" {
-			return MlrvalFromFalse()
+			output.SetFromFalse()
+		} else {
+			output.SetFromTrue()
 		}
+	} else {
+		output.SetFromTrue()
 	}
-	return MlrvalFromTrue()
 }
-func MlrvalIsNotMap(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype != MT_MAP)
+func MlrvalIsNotMap(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype != MT_MAP)
 }
-func MlrvalIsNotArray(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype != MT_ARRAY)
+func MlrvalIsNotArray(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype != MT_ARRAY)
 }
-func MlrvalIsNotNull(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype != MT_ABSENT && input1.mvtype != MT_VOID)
+func MlrvalIsNotNull(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype != MT_ABSENT && input1.mvtype != MT_VOID)
 }
-func MlrvalIsNull(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_ABSENT || input1.mvtype == MT_VOID)
+func MlrvalIsNull(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_ABSENT || input1.mvtype == MT_VOID)
 }
-func MlrvalIsNumeric(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_INT || input1.mvtype == MT_FLOAT)
+func MlrvalIsNumeric(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_INT || input1.mvtype == MT_FLOAT)
 }
-func MlrvalIsPresent(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype != MT_ABSENT)
+func MlrvalIsPresent(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype != MT_ABSENT)
 }
-func MlrvalIsString(input1 *Mlrval) Mlrval {
-	return MlrvalFromBool(input1.mvtype == MT_STRING || input1.mvtype == MT_VOID)
+func MlrvalIsString(output, input1 *Mlrval) {
+	output.SetFromBool(input1.mvtype == MT_STRING || input1.mvtype == MT_VOID)
 }
 
 // ----------------------------------------------------------------
@@ -218,78 +222,97 @@ func assertingCommon(input1, check *Mlrval, description string, context *Context
 }
 
 func MlrvalAssertingAbsent(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsAbsent(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsAbsent(&check, input1)
 	return assertingCommon(input1, &check, "is_absent", context)
 }
 func MlrvalAssertingError(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsError(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsError(&check, input1)
 	return assertingCommon(input1, &check, "is_error", context)
 }
 func MlrvalAssertingBool(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsBool(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsBool(&check, input1)
 	return assertingCommon(input1, &check, "is_bool", context)
 }
 func MlrvalAssertingBoolean(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsBoolean(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsBoolean(&check, input1)
 	return assertingCommon(input1, &check, "is_boolean", context)
 }
 func MlrvalAssertingEmpty(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsEmpty(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsEmpty(&check, input1)
 	return assertingCommon(input1, &check, "is_empty", context)
 }
 func MlrvalAssertingEmptyMap(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsEmptyMap(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsEmptyMap(&check, input1)
 	return assertingCommon(input1, &check, "is_empty_map", context)
 }
 func MlrvalAssertingFloat(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsFloat(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsFloat(&check, input1)
 	return assertingCommon(input1, &check, "is_float", context)
 }
 func MlrvalAssertingInt(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsInt(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsInt(&check, input1)
 	return assertingCommon(input1, &check, "is_int", context)
 }
 func MlrvalAssertingMap(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsMap(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsMap(&check, input1)
 	return assertingCommon(input1, &check, "is_map", context)
 }
 func MlrvalAssertingArray(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsArray(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsArray(&check, input1)
 	return assertingCommon(input1, &check, "is_array", context)
 }
 func MlrvalAssertingNonEmptyMap(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNonEmptyMap(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNonEmptyMap(&check, input1)
 	return assertingCommon(input1, &check, "is_non_empty_map", context)
 }
 func MlrvalAssertingNotEmpty(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotEmpty(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNotEmpty(&check, input1)
 	return assertingCommon(input1, &check, "is_not_empty", context)
 }
 func MlrvalAssertingNotMap(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotMap(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNotMap(&check, input1)
 	return assertingCommon(input1, &check, "is_not_map", context)
 }
 func MlrvalAssertingNotArray(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotArray(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNotArray(&check, input1)
 	return assertingCommon(input1, &check, "is_not_array", context)
 }
 func MlrvalAssertingNotNull(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotNull(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNotNull(&check, input1)
 	return assertingCommon(input1, &check, "is_not_null", context)
 }
 func MlrvalAssertingNull(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNull(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNull(&check, input1)
 	return assertingCommon(input1, &check, "is_null", context)
 }
 func MlrvalAssertingNumeric(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNumeric(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsNumeric(&check, input1)
 	return assertingCommon(input1, &check, "is_numeric", context)
 }
 func MlrvalAssertingPresent(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsPresent(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsPresent(&check, input1)
 	return assertingCommon(input1, &check, "is_present", context)
 }
 func MlrvalAssertingString(input1 *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsString(input1)
+	check := MlrvalFromAbsent()
+	MlrvalIsString(&check, input1)
 	return assertingCommon(input1, &check, "is_string", context)
 }

--- a/go/src/types/mlrval_functions_types.go
+++ b/go/src/types/mlrval_functions_types.go
@@ -8,13 +8,13 @@ import (
 )
 
 // ================================================================
-func MlrvalTypeof(ma *Mlrval) Mlrval {
-	return MlrvalFromString(ma.GetTypeName())
+func MlrvalTypeof(input1 *Mlrval) Mlrval {
+	return MlrvalFromString(input1.GetTypeName())
 }
 
 // ----------------------------------------------------------------
-func string_to_int(ma *Mlrval) Mlrval {
-	i, ok := lib.TryIntFromString(ma.printrep)
+func string_to_int(input1 *Mlrval) Mlrval {
+	i, ok := lib.TryIntFromString(input1.printrep)
 	if ok {
 		return MlrvalFromInt(i)
 	} else {
@@ -22,12 +22,12 @@ func string_to_int(ma *Mlrval) Mlrval {
 	}
 }
 
-func float_to_int(ma *Mlrval) Mlrval {
-	return MlrvalFromInt(int(ma.floatval))
+func float_to_int(input1 *Mlrval) Mlrval {
+	return MlrvalFromInt(int(input1.floatval))
 }
 
-func bool_to_int(ma *Mlrval) Mlrval {
-	if ma.boolval == true {
+func bool_to_int(input1 *Mlrval) Mlrval {
+	if input1.boolval == true {
 		return MlrvalFromInt(1)
 	} else {
 		return MlrvalFromInt(0)
@@ -46,13 +46,13 @@ var to_int_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToInt(ma *Mlrval) Mlrval {
-	return to_int_dispositions[ma.mvtype](ma)
+func MlrvalToInt(input1 *Mlrval) Mlrval {
+	return to_int_dispositions[input1.mvtype](input1)
 }
 
 // ----------------------------------------------------------------
-func string_to_float(ma *Mlrval) Mlrval {
-	f, ok := lib.TryFloat64FromString(ma.printrep)
+func string_to_float(input1 *Mlrval) Mlrval {
+	f, ok := lib.TryFloat64FromString(input1.printrep)
 	if ok {
 		return MlrvalFromFloat64(f)
 	} else {
@@ -60,12 +60,12 @@ func string_to_float(ma *Mlrval) Mlrval {
 	}
 }
 
-func int_to_float(ma *Mlrval) Mlrval {
-	return MlrvalFromFloat64(float64(ma.intval))
+func int_to_float(input1 *Mlrval) Mlrval {
+	return MlrvalFromFloat64(float64(input1.intval))
 }
 
-func bool_to_float(ma *Mlrval) Mlrval {
-	if ma.boolval == true {
+func bool_to_float(input1 *Mlrval) Mlrval {
+	if input1.boolval == true {
 		return MlrvalFromFloat64(1.0)
 	} else {
 		return MlrvalFromFloat64(0.0)
@@ -84,13 +84,13 @@ var to_float_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToFloat(ma *Mlrval) Mlrval {
-	return to_float_dispositions[ma.mvtype](ma)
+func MlrvalToFloat(input1 *Mlrval) Mlrval {
+	return to_float_dispositions[input1.mvtype](input1)
 }
 
 // ----------------------------------------------------------------
-func string_to_boolean(ma *Mlrval) Mlrval {
-	b, ok := lib.TryBoolFromBoolString(ma.printrep)
+func string_to_boolean(input1 *Mlrval) Mlrval {
+	b, ok := lib.TryBoolFromBoolString(input1.printrep)
 	if ok {
 		return MlrvalFromBool(b)
 	} else {
@@ -98,12 +98,12 @@ func string_to_boolean(ma *Mlrval) Mlrval {
 	}
 }
 
-func int_to_bool(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.intval != 0)
+func int_to_bool(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.intval != 0)
 }
 
-func float_to_bool(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.floatval != 0.0)
+func float_to_bool(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.floatval != 0.0)
 }
 
 var to_boolean_dispositions = [MT_DIM]UnaryFunc{
@@ -118,87 +118,87 @@ var to_boolean_dispositions = [MT_DIM]UnaryFunc{
 	/*MAP    */ _erro1,
 }
 
-func MlrvalToBoolean(ma *Mlrval) Mlrval {
-	return to_boolean_dispositions[ma.mvtype](ma)
+func MlrvalToBoolean(input1 *Mlrval) Mlrval {
+	return to_boolean_dispositions[input1.mvtype](input1)
 }
 
 // ----------------------------------------------------------------
-func MlrvalIsAbsent(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_ABSENT)
+func MlrvalIsAbsent(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_ABSENT)
 }
-func MlrvalIsError(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_ERROR)
+func MlrvalIsError(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_ERROR)
 }
-func MlrvalIsBool(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_BOOL)
+func MlrvalIsBool(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_BOOL)
 }
-func MlrvalIsBoolean(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_BOOL)
+func MlrvalIsBoolean(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_BOOL)
 }
-func MlrvalIsEmpty(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_VOID {
+func MlrvalIsEmpty(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_VOID {
 		return MlrvalFromTrue()
 	}
-	if ma.mvtype == MT_STRING {
-		if ma.printrep == "" {
+	if input1.mvtype == MT_STRING {
+		if input1.printrep == "" {
 			return MlrvalFromTrue()
 		}
 	}
 	return MlrvalFromFalse()
 }
-func MlrvalIsEmptyMap(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_MAP && ma.mapval.FieldCount == 0)
+func MlrvalIsEmptyMap(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount == 0)
 }
-func MlrvalIsFloat(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_FLOAT)
+func MlrvalIsFloat(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_FLOAT)
 }
-func MlrvalIsInt(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_INT)
+func MlrvalIsInt(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_INT)
 }
-func MlrvalIsMap(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_MAP)
+func MlrvalIsMap(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_MAP)
 }
-func MlrvalIsArray(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_ARRAY)
+func MlrvalIsArray(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_ARRAY)
 }
-func MlrvalIsNonEmptyMap(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_MAP && ma.mapval.FieldCount != 0)
+func MlrvalIsNonEmptyMap(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_MAP && input1.mapval.FieldCount != 0)
 }
-func MlrvalIsNotEmpty(ma *Mlrval) Mlrval {
-	if ma.mvtype == MT_VOID {
+func MlrvalIsNotEmpty(input1 *Mlrval) Mlrval {
+	if input1.mvtype == MT_VOID {
 		return MlrvalFromFalse()
 	}
-	if ma.mvtype == MT_STRING {
-		if ma.printrep == "" {
+	if input1.mvtype == MT_STRING {
+		if input1.printrep == "" {
 			return MlrvalFromFalse()
 		}
 	}
 	return MlrvalFromTrue()
 }
-func MlrvalIsNotMap(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype != MT_MAP)
+func MlrvalIsNotMap(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype != MT_MAP)
 }
-func MlrvalIsNotArray(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype != MT_ARRAY)
+func MlrvalIsNotArray(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype != MT_ARRAY)
 }
-func MlrvalIsNotNull(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype != MT_ABSENT && ma.mvtype != MT_VOID)
+func MlrvalIsNotNull(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype != MT_ABSENT && input1.mvtype != MT_VOID)
 }
-func MlrvalIsNull(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_ABSENT || ma.mvtype == MT_VOID)
+func MlrvalIsNull(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_ABSENT || input1.mvtype == MT_VOID)
 }
-func MlrvalIsNumeric(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_INT || ma.mvtype == MT_FLOAT)
+func MlrvalIsNumeric(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_INT || input1.mvtype == MT_FLOAT)
 }
-func MlrvalIsPresent(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype != MT_ABSENT)
+func MlrvalIsPresent(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype != MT_ABSENT)
 }
-func MlrvalIsString(ma *Mlrval) Mlrval {
-	return MlrvalFromBool(ma.mvtype == MT_STRING || ma.mvtype == MT_VOID)
+func MlrvalIsString(input1 *Mlrval) Mlrval {
+	return MlrvalFromBool(input1.mvtype == MT_STRING || input1.mvtype == MT_VOID)
 }
 
 // ----------------------------------------------------------------
-func assertingCommon(ma, check *Mlrval, description string, context *Context) Mlrval {
+func assertingCommon(input1, check *Mlrval, description string, context *Context) Mlrval {
 	if check.IsFalse() {
 		// TODO: get context as in the C impl
 		//fprintf(stderr, "%s: %s type-assertion failed at NR=%lld FNR=%lld FILENAME=%s\n",
@@ -214,82 +214,82 @@ func assertingCommon(ma, check *Mlrval, description string, context *Context) Ml
 		)
 		os.Exit(1)
 	}
-	return *ma
+	return *input1
 }
 
-func MlrvalAssertingAbsent(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsAbsent(ma)
-	return assertingCommon(ma, &check, "is_absent", context)
+func MlrvalAssertingAbsent(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsAbsent(input1)
+	return assertingCommon(input1, &check, "is_absent", context)
 }
-func MlrvalAssertingError(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsError(ma)
-	return assertingCommon(ma, &check, "is_error", context)
+func MlrvalAssertingError(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsError(input1)
+	return assertingCommon(input1, &check, "is_error", context)
 }
-func MlrvalAssertingBool(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsBool(ma)
-	return assertingCommon(ma, &check, "is_bool", context)
+func MlrvalAssertingBool(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsBool(input1)
+	return assertingCommon(input1, &check, "is_bool", context)
 }
-func MlrvalAssertingBoolean(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsBoolean(ma)
-	return assertingCommon(ma, &check, "is_boolean", context)
+func MlrvalAssertingBoolean(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsBoolean(input1)
+	return assertingCommon(input1, &check, "is_boolean", context)
 }
-func MlrvalAssertingEmpty(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsEmpty(ma)
-	return assertingCommon(ma, &check, "is_empty", context)
+func MlrvalAssertingEmpty(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsEmpty(input1)
+	return assertingCommon(input1, &check, "is_empty", context)
 }
-func MlrvalAssertingEmptyMap(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsEmptyMap(ma)
-	return assertingCommon(ma, &check, "is_empty_map", context)
+func MlrvalAssertingEmptyMap(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsEmptyMap(input1)
+	return assertingCommon(input1, &check, "is_empty_map", context)
 }
-func MlrvalAssertingFloat(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsFloat(ma)
-	return assertingCommon(ma, &check, "is_float", context)
+func MlrvalAssertingFloat(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsFloat(input1)
+	return assertingCommon(input1, &check, "is_float", context)
 }
-func MlrvalAssertingInt(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsInt(ma)
-	return assertingCommon(ma, &check, "is_int", context)
+func MlrvalAssertingInt(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsInt(input1)
+	return assertingCommon(input1, &check, "is_int", context)
 }
-func MlrvalAssertingMap(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsMap(ma)
-	return assertingCommon(ma, &check, "is_map", context)
+func MlrvalAssertingMap(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsMap(input1)
+	return assertingCommon(input1, &check, "is_map", context)
 }
-func MlrvalAssertingArray(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsArray(ma)
-	return assertingCommon(ma, &check, "is_array", context)
+func MlrvalAssertingArray(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsArray(input1)
+	return assertingCommon(input1, &check, "is_array", context)
 }
-func MlrvalAssertingNonEmptyMap(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNonEmptyMap(ma)
-	return assertingCommon(ma, &check, "is_non_empty_map", context)
+func MlrvalAssertingNonEmptyMap(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNonEmptyMap(input1)
+	return assertingCommon(input1, &check, "is_non_empty_map", context)
 }
-func MlrvalAssertingNotEmpty(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotEmpty(ma)
-	return assertingCommon(ma, &check, "is_not_empty", context)
+func MlrvalAssertingNotEmpty(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNotEmpty(input1)
+	return assertingCommon(input1, &check, "is_not_empty", context)
 }
-func MlrvalAssertingNotMap(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotMap(ma)
-	return assertingCommon(ma, &check, "is_not_map", context)
+func MlrvalAssertingNotMap(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNotMap(input1)
+	return assertingCommon(input1, &check, "is_not_map", context)
 }
-func MlrvalAssertingNotArray(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotArray(ma)
-	return assertingCommon(ma, &check, "is_not_array", context)
+func MlrvalAssertingNotArray(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNotArray(input1)
+	return assertingCommon(input1, &check, "is_not_array", context)
 }
-func MlrvalAssertingNotNull(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNotNull(ma)
-	return assertingCommon(ma, &check, "is_not_null", context)
+func MlrvalAssertingNotNull(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNotNull(input1)
+	return assertingCommon(input1, &check, "is_not_null", context)
 }
-func MlrvalAssertingNull(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNull(ma)
-	return assertingCommon(ma, &check, "is_null", context)
+func MlrvalAssertingNull(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNull(input1)
+	return assertingCommon(input1, &check, "is_null", context)
 }
-func MlrvalAssertingNumeric(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsNumeric(ma)
-	return assertingCommon(ma, &check, "is_numeric", context)
+func MlrvalAssertingNumeric(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsNumeric(input1)
+	return assertingCommon(input1, &check, "is_numeric", context)
 }
-func MlrvalAssertingPresent(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsPresent(ma)
-	return assertingCommon(ma, &check, "is_present", context)
+func MlrvalAssertingPresent(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsPresent(input1)
+	return assertingCommon(input1, &check, "is_present", context)
 }
-func MlrvalAssertingString(ma *Mlrval, context *Context) Mlrval {
-	check := MlrvalIsString(ma)
-	return assertingCommon(ma, &check, "is_string", context)
+func MlrvalAssertingString(input1 *Mlrval, context *Context) Mlrval {
+	check := MlrvalIsString(input1)
+	return assertingCommon(input1, &check, "is_string", context)
 }

--- a/go/src/types/mlrval_functions_types.go
+++ b/go/src/types/mlrval_functions_types.go
@@ -202,7 +202,7 @@ func MlrvalIsString(output, input1 *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func assertingCommon(input1, check *Mlrval, description string, context *Context) Mlrval {
+func assertingCommon(output, input1, check *Mlrval, description string, context *Context) {
 	if check.IsFalse() {
 		// TODO: get context as in the C impl
 		//fprintf(stderr, "%s: %s type-assertion failed at NR=%lld FNR=%lld FILENAME=%s\n",
@@ -218,101 +218,101 @@ func assertingCommon(input1, check *Mlrval, description string, context *Context
 		)
 		os.Exit(1)
 	}
-	return *input1
+	output.CopyFrom(input1)
 }
 
-func MlrvalAssertingAbsent(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingAbsent(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsAbsent(&check, input1)
-	return assertingCommon(input1, &check, "is_absent", context)
+	assertingCommon(output, input1, &check, "is_absent", context)
 }
-func MlrvalAssertingError(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingError(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsError(&check, input1)
-	return assertingCommon(input1, &check, "is_error", context)
+	assertingCommon(output, input1, &check, "is_error", context)
 }
-func MlrvalAssertingBool(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingBool(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsBool(&check, input1)
-	return assertingCommon(input1, &check, "is_bool", context)
+	assertingCommon(output, input1, &check, "is_bool", context)
 }
-func MlrvalAssertingBoolean(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingBoolean(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsBoolean(&check, input1)
-	return assertingCommon(input1, &check, "is_boolean", context)
+	assertingCommon(output, input1, &check, "is_boolean", context)
 }
-func MlrvalAssertingEmpty(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingEmpty(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsEmpty(&check, input1)
-	return assertingCommon(input1, &check, "is_empty", context)
+	assertingCommon(output, input1, &check, "is_empty", context)
 }
-func MlrvalAssertingEmptyMap(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingEmptyMap(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsEmptyMap(&check, input1)
-	return assertingCommon(input1, &check, "is_empty_map", context)
+	assertingCommon(output, input1, &check, "is_empty_map", context)
 }
-func MlrvalAssertingFloat(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingFloat(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsFloat(&check, input1)
-	return assertingCommon(input1, &check, "is_float", context)
+	assertingCommon(output, input1, &check, "is_float", context)
 }
-func MlrvalAssertingInt(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingInt(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsInt(&check, input1)
-	return assertingCommon(input1, &check, "is_int", context)
+	assertingCommon(output, input1, &check, "is_int", context)
 }
-func MlrvalAssertingMap(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingMap(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsMap(&check, input1)
-	return assertingCommon(input1, &check, "is_map", context)
+	assertingCommon(output, input1, &check, "is_map", context)
 }
-func MlrvalAssertingArray(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingArray(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsArray(&check, input1)
-	return assertingCommon(input1, &check, "is_array", context)
+	assertingCommon(output, input1, &check, "is_array", context)
 }
-func MlrvalAssertingNonEmptyMap(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNonEmptyMap(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNonEmptyMap(&check, input1)
-	return assertingCommon(input1, &check, "is_non_empty_map", context)
+	assertingCommon(output, input1, &check, "is_non_empty_map", context)
 }
-func MlrvalAssertingNotEmpty(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNotEmpty(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNotEmpty(&check, input1)
-	return assertingCommon(input1, &check, "is_not_empty", context)
+	assertingCommon(output, input1, &check, "is_not_empty", context)
 }
-func MlrvalAssertingNotMap(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNotMap(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNotMap(&check, input1)
-	return assertingCommon(input1, &check, "is_not_map", context)
+	assertingCommon(output, input1, &check, "is_not_map", context)
 }
-func MlrvalAssertingNotArray(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNotArray(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNotArray(&check, input1)
-	return assertingCommon(input1, &check, "is_not_array", context)
+	assertingCommon(output, input1, &check, "is_not_array", context)
 }
-func MlrvalAssertingNotNull(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNotNull(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNotNull(&check, input1)
-	return assertingCommon(input1, &check, "is_not_null", context)
+	assertingCommon(output, input1, &check, "is_not_null", context)
 }
-func MlrvalAssertingNull(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNull(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNull(&check, input1)
-	return assertingCommon(input1, &check, "is_null", context)
+	assertingCommon(output, input1, &check, "is_null", context)
 }
-func MlrvalAssertingNumeric(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingNumeric(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsNumeric(&check, input1)
-	return assertingCommon(input1, &check, "is_numeric", context)
+	assertingCommon(output, input1, &check, "is_numeric", context)
 }
-func MlrvalAssertingPresent(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingPresent(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsPresent(&check, input1)
-	return assertingCommon(input1, &check, "is_present", context)
+	assertingCommon(output, input1, &check, "is_present", context)
 }
-func MlrvalAssertingString(input1 *Mlrval, context *Context) Mlrval {
+func MlrvalAssertingString(output, input1 *Mlrval, context *Context) {
 	check := MlrvalFromAbsent()
 	MlrvalIsString(&check, input1)
-	return assertingCommon(input1, &check, "is_string", context)
+	assertingCommon(output, input1, &check, "is_string", context)
 }

--- a/go/src/types/mlrval_new.go
+++ b/go/src/types/mlrval_new.go
@@ -50,6 +50,11 @@ func MlrvalFromAbsent() Mlrval {
 	}
 }
 
+func MlrvalPointerFromError() *Mlrval {
+	retval := MlrvalFromError()
+	return &retval
+}
+
 func MlrvalPointerFromAbsent() *Mlrval {
 	retval := MlrvalFromAbsent()
 	return &retval

--- a/go/src/types/mlrval_set.go
+++ b/go/src/types/mlrval_set.go
@@ -9,6 +9,16 @@ import (
 )
 
 // ----------------------------------------------------------------
+func (this *Mlrval) CopyFrom(that *Mlrval) {
+	*this = *that
+	if this.mvtype == MT_MAP {
+		this.mapval = that.mapval.Copy()
+	} else if this.mvtype == MT_ARRAY {
+		this.arrayval = CopyMlrvalArray(that.arrayval)
+	}
+}
+
+// ----------------------------------------------------------------
 func (this *Mlrval) SetFromPending() {
 	this.mvtype = MT_PENDING
 	this.printrep = "(bug-if-you-see-this-pending-type)"

--- a/go/src/types/mlrval_set.go
+++ b/go/src/types/mlrval_set.go
@@ -18,6 +18,67 @@ func (this *Mlrval) CopyFrom(that *Mlrval) {
 	}
 }
 
+// TODO: experimental -- no performance improvement was found.
+// Idea: profiling shows that data-copies of mlrvals consumes much of the time
+// for the u/mand.mlr benchmark. Instead of copying all mlrval attributes, copy
+// only those appropriate for the mvtype.
+
+//type mlrvalCopyFunc func(output, input *Mlrval)
+//
+//func mlrvalCopyError(output, input *Mlrval) {
+//	output.printrep = input.printrep
+//	output.printrepValid = input.printrepValid
+//}
+//func mlrvalCopyAbsent(output, input *Mlrval) {
+//	output.printrep = input.printrep
+//	output.printrepValid = input.printrepValid
+//}
+//func mlrvalCopyVoid(output, input *Mlrval) {
+//	output.printrep = input.printrep
+//	output.printrepValid = input.printrepValid
+//}
+//func mlrvalCopyString(output, input *Mlrval) {
+//	output.printrep = input.printrep
+//	output.printrepValid = input.printrepValid
+//}
+//func mlrvalCopyInt(output, input *Mlrval) {
+//	output.intval = input.intval
+//	output.printrepValid = false
+//}
+//func mlrvalCopyFloat(output, input *Mlrval) {
+//	output.floatval = input.floatval
+//	output.printrepValid = false
+//}
+//func mlrvalCopyBool(output, input *Mlrval) {
+//	output.boolval = input.boolval
+//	output.printrepValid = false
+//}
+//func mlrvalCopyArray(output, input *Mlrval) {
+//	output.arrayval = CopyMlrvalArray(input.arrayval)
+//	output.printrepValid = false
+//}
+//func mlrvalCopyMap(output, input *Mlrval) {
+//	output.mapval = input.mapval.Copy()
+//	output.printrepValid = false
+//}
+//
+//var mlrvalCopyDispositions = [MT_DIM]UnaryFunc{
+//	/*ERROR  */ mlrvalCopyError,
+//	/*ABSENT */ mlrvalCopyAbsent,
+//	/*VOID   */ mlrvalCopyVoid,
+//	/*STRING */ mlrvalCopyString,
+//	/*INT    */ mlrvalCopyInt,
+//	/*FLOAT  */ mlrvalCopyFloat,
+//	/*BOOL   */ mlrvalCopyBool,
+//	/*ARRAY  */ mlrvalCopyArray,
+//	/*MAP    */ mlrvalCopyMap,
+//}
+//
+//func (this *Mlrval) CopyFrom(that *Mlrval) {
+//	this.mvtype = that.mvtype
+//    mlrvalCopyDispositions[that.mvtype](this, that)
+//}
+
 // ----------------------------------------------------------------
 func (this *Mlrval) SetFromPending() {
 	this.mvtype = MT_PENDING

--- a/go/src/types/mlrval_set.go
+++ b/go/src/types/mlrval_set.go
@@ -1,0 +1,179 @@
+// ================================================================
+// Constructors
+// ================================================================
+
+package types
+
+import (
+	"miller/src/lib"
+)
+
+// ----------------------------------------------------------------
+func (this *Mlrval) SetFromPending() {
+	this.mvtype = MT_PENDING
+	this.printrep = "(bug-if-you-see-this-pending-type)"
+	this.printrepValid = false
+}
+
+func (this *Mlrval) SetFromError() {
+	this.mvtype = MT_ERROR
+	this.printrep = "(error)" // xxx const somewhere
+	this.printrepValid = true
+}
+
+func (this *Mlrval) SetFromAbsent() {
+	this.mvtype = MT_ABSENT
+	this.printrep = "(absent)"
+	this.printrepValid = true
+}
+
+func (this *Mlrval) SetFromVoid() {
+	this.mvtype = MT_VOID
+	this.printrep = ""
+	this.printrepValid = true
+}
+
+func (this *Mlrval) SetFromString(input string) {
+	if input == "" {
+		this.SetFromVoid()
+	} else {
+		this.mvtype = MT_STRING
+		this.printrep = input
+		this.printrepValid = true
+	}
+}
+
+// xxx comment why two -- one for from parsed user data; other for from math ops
+func (this *Mlrval) SetFromIntString(input string) {
+	ival, ok := lib.TryIntFromString(input)
+	// xxx comment assummption is input-string already deemed parseable so no error return
+	lib.InternalCodingErrorIf(!ok)
+	this.mvtype = MT_INT
+	this.printrep = input
+	this.printrepValid = true
+	this.intval = ival
+}
+
+func (this *Mlrval) SetFromInt(input int) {
+	this.mvtype = MT_INT
+	this.printrepValid = false
+	this.intval = input
+}
+
+// xxx comment why two -- one for from parsed user data; other for from math ops
+// xxx comment assummption is input-string already deemed parseable so no error return
+func (this *Mlrval) SetFromFloat64String(input string) {
+	fval, ok := lib.TryFloat64FromString(input)
+	// xxx comment assummption is input-string already deemed parseable so no error return
+	lib.InternalCodingErrorIf(!ok)
+	this.mvtype = MT_FLOAT
+	this.printrep = input
+	this.printrepValid = true
+	this.floatval = fval
+}
+
+func (this *Mlrval) SetFromFloat64(input float64) {
+	this.mvtype = MT_FLOAT
+	this.printrepValid = false
+	this.floatval = input
+}
+
+func (this *Mlrval) SetFromTrue() {
+	this.mvtype = MT_BOOL
+	this.printrep = "true"
+	this.printrepValid = true
+	this.boolval = true
+}
+
+func (this *Mlrval) SetFromFalse() {
+	this.mvtype = MT_BOOL
+	this.printrep = "false"
+	this.printrepValid = true
+	this.boolval = false
+}
+
+func (this *Mlrval) SetFromBool(input bool) {
+	if input == true {
+		this.SetFromTrue()
+	} else {
+		this.SetFromFalse()
+	}
+}
+
+func (this *Mlrval) SetFromBoolString(input string) {
+	if input == "true" {
+		this.SetFromTrue()
+	} else {
+		this.SetFromFalse()
+	}
+	// else panic
+}
+
+func (this *Mlrval) SetFromInferredType(input string) {
+	// xxx the parsing has happened so stash it ...
+	// xxx emphasize the invariant that a non-invalid printrep always
+	// matches the nval ...
+	if input == "" {
+		this.SetFromVoid()
+	}
+
+	_, iok := lib.TryIntFromString(input)
+	if iok {
+		this.SetFromIntString(input)
+	}
+
+	_, fok := lib.TryFloat64FromString(input)
+	if fok {
+		this.SetFromFloat64String(input)
+	}
+
+	_, bok := lib.TryBoolFromBoolString(input)
+	if bok {
+		this.SetFromBoolString(input)
+	}
+
+	this.SetFromString(input)
+}
+
+func (this *Mlrval) SetFromEmptyMap() {
+	this.mvtype = MT_MAP
+	this.printrepValid = false
+	this.mapval = NewMlrmap()
+}
+
+// ----------------------------------------------------------------
+// Does not copy the data. We can make a (this *Mlrval) SetFromArrayLiteralCopy if needed
+// using values.CopyMlrvalArray().
+func (this *Mlrval) SetFromArrayLiteralReference(input []Mlrval) {
+	this.mvtype = MT_ARRAY
+	this.printrepValid = false
+	this.arrayval = input
+}
+
+func (this *Mlrval) SetFromMap(that *Mlrmap) {
+	this.SetFromEmptyMap()
+	if that == nil {
+		// xxx maybe return 2nd-arg error in the API
+		this.SetFromError()
+		return
+	}
+
+	for pe := that.Head; pe != nil; pe = pe.Next {
+		this.mapval.PutCopy(pe.Key, pe.Value)
+	}
+}
+
+// Like previous but doesn't copy. Only safe when the argument's sole purpose
+// is to be passed into here.
+func (this *Mlrval) SetFromMapReferenced(that *Mlrmap) {
+	this.SetFromEmptyMap()
+	if that == nil {
+		// xxx maybe return 2nd-arg error in the API
+		this.SetFromError()
+		return
+	}
+
+	for pe := that.Head; pe != nil; pe = pe.Next {
+		this.mapval.PutReference(pe.Key, pe.Value)
+	}
+}

--- a/go/src/types/mlrval_typing.go
+++ b/go/src/types/mlrval_typing.go
@@ -91,7 +91,7 @@ func (this *TypeGatedMlrvalVariable) Assign(value *Mlrval) error {
 		return err
 	}
 
-	this.value = value.Copy()
+	this.value.CopyFrom(value)
 	return nil
 }
 

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -15,15 +15,11 @@ TOP OF LIST:
   o take care w/ copying (non-pointer) mlrvals though
 
 * cst-no-alloc refactor ...
-  - udf args back
-  ! binary on-stack imitate elsewheres
-  ! no 'malloc-avoidance'
   - prof:
     mlr --cpuprofile cpu.pprof -n put -q -s 'iwidth=200' -s iheight=200 -s silent=true -f u/mand.mlr
   - dispo-vec the CopyFrom method
   - MlrvalLessThanForSort
   - MlrvalGetMeanEB et al.
-  - double-check trims of go.mod
   - var delta types.Mlrval for uninits
   - nice narrative write-up w/ the C stack-allocator problem, Go non-solutionk,
     profilng methods, GC readings/findings, before-and-after CST data structures,

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -15,9 +15,15 @@ TOP OF LIST:
   o take care w/ copying (non-pointer) mlrvals though
 
 * cst-no-alloc refactor ...
+  - udf args back
+  ! binary on-stack imitate elsewheres
+  ! no 'malloc-avoidance'
+  - prof:
+    mlr --cpuprofile cpu.pprof -n put -q -s 'iwidth=200' -s iheight=200 -s silent=true -f u/mand.mlr
   - dispo-vec the CopyFrom method
   - MlrvalLessThanForSort
   - MlrvalGetMeanEB et al.
+  - double-check trims of go.mod
   - var delta types.Mlrval for uninits
   - nice narrative write-up w/ the C stack-allocator problem, Go non-solutionk,
     profilng methods, GC readings/findings, before-and-after CST data structures,

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -16,6 +16,9 @@ TOP OF LIST:
 
 * cst-no-alloc refactor ...
   - dispo-vec the CopyFrom method
+  - MlrvalLessThanForSort
+  - MlrvalGetMeanEB et al.
+  - var delta types.Mlrval for uninits
   - nice narrative write-up w/ the C stack-allocator problem, Go non-solutionk,
     profilng methods, GC readings/findings, before-and-after CST data structures,
     final perf results.

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -15,7 +15,8 @@ TOP OF LIST:
   o take care w/ copying (non-pointer) mlrvals though
 
 * cst-no-alloc refactor ...
-  - nice narrartive write-up w/ the C stack-allocator problem, Go non-solutionk,
+  - dispo-vec the CopyFrom method
+  - nice narrative write-up w/ the C stack-allocator problem, Go non-solutionk,
     profilng methods, GC readings/findings, before-and-after CST data structures,
     final perf results.
   - defer the stack-allocation PR until after

--- a/go/u/mand.mlr
+++ b/go/u/mand.mlr
@@ -1,14 +1,15 @@
 # Mandelbrot set generator: simple example of Miller DSL as programming language.
 begin {
 	# Set defaults
-	@rcorn     = -2.0;
-	@icorn     = -2.0;
-	@side      = 4.0;
-	@iheight   =  500;
-	@iwidth    = 1000;
-	@maxits    =  100;
-	@levelstep =    5;
-	@chars     = "@X*o-.";
+	@rcorn     ??= -2.0;
+	@icorn     ??= -2.0;
+	@side      ??= 4.0;
+	@iheight   ??=  500;
+	@iwidth    ??= 1000;
+	@maxits    ??=  100;
+	@levelstep ??=    5;
+	@chars     ??= "@X*o-.";
+  @silent    ??= false;
 }
 
 # Override defaults
@@ -20,28 +21,36 @@ begin {
 @maxits    = $maxits;
 @levelstep = $levelstep;
 @chars     = $chars;
+@silent    = $silent;
 
 end {
-	print "RCORN     = ".@rcorn;
-	print "ICORN     = ".@icorn;
-	print "SIDE      = ".@side;
-	print "IHEIGHT   = ".@iheight;
-	print "IWIDTH    = ".@iwidth;
-	print "MAXITS    = ".@maxits;
-	print "LEVELSTEP = ".@levelstep;
-	print "CHARS     = ".@chars;
+  if (!@silent) {
+  	print "RCORN     = ".@rcorn;
+  	print "ICORN     = ".@icorn;
+  	print "SIDE      = ".@side;
+  	print "IHEIGHT   = ".@iheight;
+  	print "IWIDTH    = ".@iwidth;
+  	print "MAXITS    = ".@maxits;
+  	print "LEVELSTEP = ".@levelstep;
+  	print "CHARS     = ".@chars;
+  }
 
 	for (int ii = @iheight-1; ii >= 0; ii -= 1) {
 		num ci = @icorn + (ii/@iheight) * @side;
 		for (int ir = 0; ir < @iwidth; ir += 1) {
 			num cr = @rcorn + (ir/@iwidth) * @side;
-			printn get_point_plot(cr, ci, @maxits);
+      str c = get_point_plot(cr, ci, @maxits);
+      if (!@silent) {
+			  printn c
+      }
 		}
-		print;
+    if (!@silent) {
+		  print;
+    }
 	}
 }
 
-func get_point_plot(cr, ci, maxits) {
+func get_point_plot(cr, ci, maxits): str {
 	num zr = 0.0;
 	num zi = 0.0;
 


### PR DESCRIPTION
Avoid some data-copies -- having lots of little mallocs (even with bounded heap) doesn't work as well in Go as in C.

Idea is for `z = x + y`, instead of `func MlrvalPlus(input1, input2 *Mlrval) Mlrval`, do `func MlrvalPlus(output, input1, input2 *Mlrval)` where the `output` space is pre-allocated for each relevant CST node.