### PR TITLE
Stack allocator

### DIFF
--- a/go/gc-raw-notes.txt
+++ b/go/gc-raw-notes.txt
@@ -17,6 +17,10 @@
     - c  3.2s
     - go pre-alloccate 45s
 
+Why 5MB goal with GOGC=100????
+
+GOGC=100000 GODEBUG=gctrace=1 mlr -n put -q -f u/mand.mlr 1> /dev/null
+
 * u/mand.mlr silent option
 
 https://blog.twitch.tv/en/2019/04/10/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap-26c2462549a2/
@@ -46,3 +50,50 @@ https://github.com/golang/go/issues/23044
 i https://hub.packtpub.com/implementing-memory-management-with-golang-garbage-collector/
 
 i mlr --cpuprofile cpu.pprof -n put -q  -s iheight=100 -s iwidth=100 -f u/mand.mlr > /dev/null
+
+? SetGCPercent
+? SetMaxHeap
+
+mlr --cpuprofile cpu.pprof -n put -q  -s iheight=500 -s iwidth=500 -f u/mand.mlr > /dev/null
+go tool pprof mlr cpu.pprof
+top10
+
+go tool pprof --pdf mlr cpu.pprof > mlr-call-graph.pdf
+mv mlr-call-graph.pdf ~/Desktop
+
+runtime.duffcopy
+  https://stackoverflow.com/questions/45786687/runtime-duffcopy-is-called-a-lot
+runtime.madvise
+
+GOGC=off
+GODEBUG=gctrace=1
+
+export PATH=${PATH}:~/git/brendangregg/FlameGraph/
+go-torch cpu.pprof
+mv torch.svg ~/Desktop/
+
+i mlr --cpuprofile cpu.pprof -n put -q  -s iheight=500 -s iwidth=500 -f u/mand.mlr > /dev/null
+
+i https://hub.packtpub.com/implementing-memory-management-with-golang-garbage-collector/
+
+i https://golang.org/pkg/runtime/
+
+! flame-graph readme; & profile-readme out of mlr.go & into separate .md file
+i mlr --cpuprofile cpu.pprof -n put -q  -s iheight=100 -s iwidth=100 -f u/mand.mlr > /dev/null
+i GODEBUG=gctrace=1 mlr -n put -q  -s iheight=500 -s iwidth=500 -f u/mand.mlr > /dev/null| head -n 100
+  gc 1 @0.129s 1%: 0.012+3.9+0.002 ms clock, 0.048+3.7/3.7/7.5+0.010 ms cpu, 10240->10240->0 MB, 10241 MB goal, 4 P
+  gc 2 @0.140s 2%: 0.009+2.1+0.002 ms clock, 0.038+2.0/2.0/4.0+0.011 ms cpu, 4->4->0         MB, 5     MB goal, 4 P
+  gc 3 @0.149s 2%: 0.032+2.1+0.021 ms clock, 0.12+2.0/2.0/4.0+0.087  ms cpu, 4->4->0         MB, 5     MB goal, 4 P
+  gc 4 @0.157s 3%: 0.035+2.1+0.014 ms clock, 0.14+2.0/1.9/4.1+0.059  ms cpu, 4->4->0         MB, 5     MB goal, 4 P
+  gc 5 @0.166s 3%: 0.034+2.2+0.024 ms clock, 0.13+2.0/1.9/4.0+0.098  ms cpu, 4->4->0         MB, 5     MB goal, 4 P
+
+mem.Alloc: 176104
+mem.TotalAlloc: 176104
+mem.HeapAlloc: 176104
+mem.NumGC: 0
+
+mem.Alloc: 1179440
+mem.TotalAlloc: 16,529,643,664
+mem.HeapAlloc: 1179440
+mem.NumGC: 4254
+

--- a/go/gg
+++ b/go/gg
@@ -52,8 +52,39 @@ mention() {
 
 # ================================================================
 
-run_mlr --from r put -q 'for (k in $*) { print k }; print'
+run_mlr --from r put -q '
+  a = 1;
+  b = 2;
+  print;
+  print "OUT1a ". a;
+  print "OUT1b ". b;
+  if (NR == 1) {
+    a = 3;
+    c = 4;
+    print "IN1a  ". a;
+    print "IN1c  ". c;
+  } else {
+    b = 5;
+    d = 6;
+    print "IN2a  ". b;
+    print "IN2c  ". d;
+  }
+  print "OUT2a ". a;
+  print "OUT2a ". b;
+'
 
-run_mlr --from r put -q 'for (k,v in $*) { print k; print v }; print'
+# OUT1a 1
+# OUT1b 2
+# IN1a  3
+# IN1c  4
+# OUT2a 3
+# OUT2a 2
+#
+# OUT1a 1
+# OUT1b 2
+# IN2a  5
+# IN2c  6
+# OUT2a 1
+# OUT2a 5
 
 # ================================================================

--- a/go/mlr.go
+++ b/go/mlr.go
@@ -51,9 +51,6 @@ func main() {
 	// found then this function will not return.
 	auxents.Dispatch(os.Args)
 
-	//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-	// Start of Miller main per se
-
 	options, recordTransformers, err := cli.ParseCommandLine(os.Args)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, os.Args[0], ": ", err)

--- a/go/src/dsl/cst/for.go
+++ b/go/src/dsl/cst/for.go
@@ -510,7 +510,7 @@ func (this *ForLoopMultivariableNode) Execute(state *runtime.State) (*BlockExitP
 	// from any of the latter is a break from all.  However, at this point, the
 	// break has been "broken" and should not be returned to the caller.
 	// Return-statements should, though.
-	blockExitPayload, err := this.executeOuter(indexMlrval, this.keyVariableNames, state)
+	blockExitPayload, err := this.executeOuter(indexMlrval, this.keyIndexVariables, state)
 	if blockExitPayload == nil {
 		return nil, err
 	} else {

--- a/go/src/dsl/cst/leaves.go
+++ b/go/src/dsl/cst/leaves.go
@@ -184,7 +184,7 @@ func (this *RootNode) BuildLocalVariableNode(variableName string) *LocalVariable
 func (this *LocalVariableNode) Evaluate(
 	state *runtime.State,
 ) *types.Mlrval {
-	value := state.Stack.Get(this.variableName)
+	value := state.Stack.Get(this.stackVariable)
 	if value == nil {
 		return types.MLRVAL_ABSENT
 	} else {

--- a/go/src/dsl/cst/leaves.go
+++ b/go/src/dsl/cst/leaves.go
@@ -173,12 +173,12 @@ func (this *FullOosvarRvalueNode) Evaluate(
 
 // ----------------------------------------------------------------
 type LocalVariableNode struct {
-	variableName string
+	stackVariable *runtime.StackVariable
 }
 
 func (this *RootNode) BuildLocalVariableNode(variableName string) *LocalVariableNode {
 	return &LocalVariableNode{
-		variableName: variableName,
+		stackVariable: runtime.NewStackVariable(variableName),
 	}
 }
 func (this *LocalVariableNode) Evaluate(

--- a/go/src/dsl/cst/lvalues.go
+++ b/go/src/dsl/cst/lvalues.go
@@ -779,8 +779,8 @@ func (this *FullOosvarLvalueNode) UnassignIndexed(
 
 // ----------------------------------------------------------------
 type LocalVariableLvalueNode struct {
-	variableName string
-	typeName     string
+	stackVariable *runtime.StackVariable
+	typeName      string
 
 	// a = 1;
 	// b = 1;
@@ -804,19 +804,19 @@ func (this *RootNode) BuildLocalVariableLvalueNode(astNode *dsl.ASTNode) (IAssig
 		defineTypedAtScope = true
 	}
 	return NewLocalVariableLvalueNode(
-		variableName,
+		runtime.NewStackVariable(variableName),
 		typeName,
 		defineTypedAtScope,
 	), nil
 }
 
 func NewLocalVariableLvalueNode(
-	variableName string,
+	stackVariable *runtime.StackVariable,
 	typeName string,
 	defineTypedAtScope bool,
 ) *LocalVariableLvalueNode {
 	return &LocalVariableLvalueNode{
-		variableName:       variableName,
+		stackVariable:      stackVariable,
 		typeName:           typeName,
 		defineTypedAtScope: defineTypedAtScope,
 	}
@@ -839,15 +839,15 @@ func (this *LocalVariableLvalueNode) AssignIndexed(
 	var err error = nil
 	if indices == nil {
 		if this.defineTypedAtScope {
-			err = state.Stack.DefineTypedAtScope(this.variableName, this.typeName, rvalue)
+			err = state.Stack.DefineTypedAtScope(this.stackVariable, this.typeName, rvalue)
 		} else {
-			err = state.Stack.Set(this.variableName, rvalue)
+			err = state.Stack.Set(this.stackVariable, rvalue)
 		}
 	} else {
 		// There is no 'map x[1] = {}' in the DSL grammar.
 		lib.InternalCodingErrorIf(this.defineTypedAtScope)
 
-		err = state.Stack.SetIndexed(this.variableName, indices, rvalue)
+		err = state.Stack.SetIndexed(this.stackVariable, indices, rvalue)
 	}
 	return err
 }
@@ -863,9 +863,9 @@ func (this *LocalVariableLvalueNode) UnassignIndexed(
 	state *runtime.State,
 ) {
 	if indices == nil {
-		state.Stack.Unset(this.variableName)
+		state.Stack.Unset(this.stackVariable)
 	} else {
-		state.Stack.UnsetIndexed(this.variableName, indices)
+		state.Stack.UnsetIndexed(this.stackVariable, indices)
 	}
 }
 

--- a/go/src/dsl/cst/udf.go
+++ b/go/src/dsl/cst/udf.go
@@ -129,7 +129,7 @@ func (this *UDFCallsite) Evaluate(
 
 	for i, _ := range arguments {
 		err := state.Stack.DefineTypedAtScope(
-			this.udf.signature.typeGatedParameterNames[i].Name,
+			runtime.NewStackVariable(this.udf.signature.typeGatedParameterNames[i].Name),
 			this.udf.signature.typeGatedParameterNames[i].TypeName,
 			arguments[i],
 		)

--- a/go/src/dsl/cst/uds.go
+++ b/go/src/dsl/cst/uds.go
@@ -123,7 +123,7 @@ func (this *UDSCallsite) Execute(state *runtime.State) (*BlockExitPayload, error
 
 	for i, _ := range arguments {
 		err := state.Stack.DefineTypedAtScope(
-			this.uds.signature.typeGatedParameterNames[i].Name,
+			runtime.NewStackVariable(this.uds.signature.typeGatedParameterNames[i].Name),
 			this.uds.signature.typeGatedParameterNames[i].TypeName,
 			arguments[i],
 		)

--- a/go/src/runtime/stack.go
+++ b/go/src/runtime/stack.go
@@ -186,6 +186,7 @@ type StackFrameSet struct {
 }
 
 func newStackFrameSet() *StackFrameSet {
+	// TODO: to array
 	stackFrames := list.New()
 	stackFrames.PushFront(newStackFrame())
 	return &StackFrameSet{
@@ -194,10 +195,12 @@ func newStackFrameSet() *StackFrameSet {
 }
 
 func (this *StackFrameSet) pushStackFrame() {
+	// TODO: to array
 	this.stackFrames.PushFront(newStackFrame())
 }
 
 func (this *StackFrameSet) popStackFrame() {
+	// TODO: to array
 	this.stackFrames.Remove(this.stackFrames.Front())
 }
 
@@ -218,6 +221,7 @@ func (this *StackFrameSet) defineTypedAtScope(
 	typeName string,
 	mlrval *types.Mlrval,
 ) error {
+	// TODO: to array
 	return this.stackFrames.Front().Value.(*StackFrame).defineTyped(
 		stackVariable, typeName, mlrval,
 	)
@@ -228,6 +232,7 @@ func (this *StackFrameSet) setAtScope(
 	stackVariable *StackVariable,
 	mlrval *types.Mlrval,
 ) error {
+	// TODO: to array
 	return this.stackFrames.Front().Value.(*StackFrame).set(stackVariable, mlrval)
 }
 
@@ -236,6 +241,7 @@ func (this *StackFrameSet) set(
 	stackVariable *StackVariable,
 	mlrval *types.Mlrval,
 ) error {
+	// TODO: to array
 	for entry := this.stackFrames.Front(); entry != nil; entry = entry.Next() {
 		stackFrame := entry.Value.(*StackFrame)
 		if stackFrame.has(stackVariable) {
@@ -251,6 +257,7 @@ func (this *StackFrameSet) setIndexed(
 	indices []*types.Mlrval,
 	mlrval *types.Mlrval,
 ) error {
+	// TODO: to array
 	for entry := this.stackFrames.Front(); entry != nil; entry = entry.Next() {
 		stackFrame := entry.Value.(*StackFrame)
 		if stackFrame.has(stackVariable) {

--- a/go/src/runtime/stack.go
+++ b/go/src/runtime/stack.go
@@ -228,7 +228,7 @@ func (this *StackFrameSet) get(
 	// TODO: comment
 	fso := stackVariable.frameSetOffset
 	oif := stackVariable.offsetInFrame
-	if fso >= 0 && oif > 0 {
+	if fso >= 0 && fso < len(this.stackFrames) && oif >= 0 && oif < len(this.stackFrames[fso].vars) {
 		return this.stackFrames[fso].vars[oif].GetValue()
 	} else {
 		return this.getUncached(stackVariable)
@@ -285,7 +285,7 @@ func (this *StackFrameSet) set(
 ) error {
 	fso := stackVariable.frameSetOffset
 	oif := stackVariable.offsetInFrame
-	if fso >= 0 && oif > 0 {
+	if fso >= 0 && fso < len(this.stackFrames) && oif >= 0 && oif < len(this.stackFrames[fso].vars) {
 		return this.stackFrames[fso].vars[oif].Assign(mlrval.Copy())
 	} else {
 		return this.setUncached(stackVariable, mlrval)
@@ -427,7 +427,6 @@ func (this *StackFrame) set(
 		stackVariable.offsetInFrame = offsetInFrame
 		return nil
 	} else {
-		return slot.Assign(mlrval)
 		return this.vars[offset].Assign(mlrval)
 	}
 }

--- a/go/src/types/mlrval_typing.go
+++ b/go/src/types/mlrval_typing.go
@@ -77,6 +77,10 @@ func NewTypeGatedMlrvalVariable(
 	}, nil
 }
 
+func (this *TypeGatedMlrvalVariable) GetName() string {
+	return this.typeGatedMlrvalName.Name
+}
+
 func (this *TypeGatedMlrvalVariable) GetValue() *Mlrval {
 	return this.value
 }

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -295,6 +295,26 @@ GOCC UPSTREAMS:
 * support "abc" (not just 'a' 'b' 'c') in the lexer part
 
 ----------------------------------------------------------------
+<<<<<<< HEAD
+=======
+FLAME GRAPHS
+
+go get -u github.com/google/pprof
+ll ~/go/bin/pprof
+go get -u github.com/uber/go-torch
+
+cd ~/git
+mkdir brendangregg
+cd brendangregg
+git clone https://github.com/brendangregg/FlameGraph
+
+cd /path/to/mlr/go
+export PATH=${PATH}:~/git/brendangregg/FlameGraph/
+go-torch cpu.pprof
+mv torch.svg ~/Desktop/
+
+----------------------------------------------------------------
+>>>>>>> cb2647ab... perf-debug [WIP]
 NITS/NON-IMMEDIATE:
 
 * "Miller: " prefixes on all errors.New

--- a/go/u/mand.mlr
+++ b/go/u/mand.mlr
@@ -12,17 +12,6 @@ begin {
   @silent    ??= false;
 }
 
-# Override defaults
-@rcorn     = $rcorn;
-@icorn     = $icorn;
-@side      = $side;
-@iheight   = $iheight;
-@iwidth    = $iwidth;
-@maxits    = $maxits;
-@levelstep = $levelstep;
-@chars     = $chars;
-@silent    = $silent;
-
 end {
   if (!@silent) {
   	print "RCORN     = ".@rcorn;


### PR DESCRIPTION
Local variables are tracked by hashmaps. However, `z=x+y` (or what have you) in a for-loop results in redundant hash-map lookups. Here, roughly paralleling the Miller C impl, we remember offsets of local variables in the stack and store them so they can be referenced more quickly on subsequent accesses.