### PR TITLE
Fix rslls handling in XSV reader after comments line has more fields than data line

### DIFF
--- a/c/input/lrec_reader_stdio_csv.c
+++ b/c/input/lrec_reader_stdio_csv.c
@@ -536,9 +536,9 @@ static lrec_t* paste_indices_and_data(lrec_reader_stdio_csv_state_t* pstate, rsl
 	context_t* pctx)
 {
 	lrec_t* prec = lrec_unbacked_alloc();
-	int idx = 0;
-	for (rsllse_t* pd = pdata_fields->phead; pd != NULL; pd = pd->pnext) {
-		idx++;
+	int dlen = pdata_fields->length;
+	rsllse_t* pd = pdata_fields->phead;
+	for (int idx = 1; idx <= dlen; idx++, pd = pd->pnext) {
 		char key_free_flags = 0;
 		char* key = low_int_to_string(idx, &key_free_flags);
 		char value_free_flags = pd->free_flag;


### PR DESCRIPTION
The idea of the `rslls`data structure was, as a performance optimization, to not always free and reallocate linked lists on every record. Rather, keep the longest-ever length allocated, and re-use the data structure from one record to the next, with a `length` parameter indicating the number of fields actually used in a given record.

Example, longest-ever record had 47 fields; current has 31. The `rslls` will be a linked list of 47 fields but the `length` will be 31.

Problem is in the XSV reader, the implicit-CSV-header function failed to honor that and was walking the entire list without consulting the `length` parameter. In short, failing to follow this advice: https://github.com/johnkerl/miller/blob/master/c/containers/rslls.h#L23

This is an old, old bug that happened to get triggered as reported on https://github.com/johnkerl/miller/issues/427 since there was a comments line with more fields than the next data line, and the use-case was implicit-CSV-header mode.

Note https://github.com/johnkerl/miller/blob/master/c/input/lrec_reader_stdio_csv.c#L540 is a non-implicit-header spot in the same file which is respecting the `length` parameter, as intended.