### PR TITLE
Corrected URL links to repository data files

### DIFF
--- a/docs/cookbook2.rst
+++ b/docs/cookbook2.rst
@@ -7,7 +7,7 @@ Cookbook part 2: Random things, and some math
 Randomly selecting words from a list
 ----------------------------------------------------------------
 
-Given this `word list <data/english-words.txt>`_, first take a look to see what the first few lines look like:
+Given this `word list <https://github.com/johnkerl/miller/blob/master/docs/data/english-words.txt>`_, first take a look to see what the first few lines look like:
 
 ::
 
@@ -42,7 +42,7 @@ Then the following will randomly sample ten words with four to eight characters 
 Randomly generating jabberwocky words
 ----------------------------------------------------------------
 
-These are simple *n*-grams as `described here <http://johnkerl.org/randspell/randspell-slides-ts.pdf>`_. Some common functions are `located here <ngrams/ngfuncs.mlr.txt>`_. Then here are scripts for `1-grams <ngrams/ng1.mlr.txt>`_ `2-grams <ngrams/ng2.mlr.txt>`_ `3-grams <ngrams/ng3.mlr.txt>`_ `4-grams <ngrams/ng4.mlr.txt>`_, and `5-grams <ngrams/ng5.mlr.txt>`_.
+These are simple *n*-grams as `described here <http://johnkerl.org/randspell/randspell-slides-ts.pdf>`_. Some common functions are `located here <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ngfuncs.mlr.txt>`_. Then here are scripts for `1-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng1.mlr.txt>`_ `2-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng2.mlr.txt>`_ `3-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng3.mlr.txt>`_ `4-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng4.mlr.txt>`_, and `5-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng5.mlr.txt>`_.
 
 The idea is that words from the input file are consumed, then taken apart and pasted back together in ways which imitate the letter-to-letter transitions found in the word list -- giving us automatically generated words in the same vein as *bromance* and *spork*:
 

--- a/docs/cookbook2.rst.in
+++ b/docs/cookbook2.rst.in
@@ -4,7 +4,7 @@ Cookbook part 2: Random things, and some math
 Randomly selecting words from a list
 ----------------------------------------------------------------
 
-Given this `word list <data/english-words.txt>`_, first take a look to see what the first few lines look like:
+Given this `word list <https://github.com/johnkerl/miller/blob/master/docs/data/english-words.txt>`_, first take a look to see what the first few lines look like:
 
 ::
 
@@ -39,7 +39,7 @@ Then the following will randomly sample ten words with four to eight characters 
 Randomly generating jabberwocky words
 ----------------------------------------------------------------
 
-These are simple *n*-grams as `described here <http://johnkerl.org/randspell/randspell-slides-ts.pdf>`_. Some common functions are `located here <ngrams/ngfuncs.mlr.txt>`_. Then here are scripts for `1-grams <ngrams/ng1.mlr.txt>`_ `2-grams <ngrams/ng2.mlr.txt>`_ `3-grams <ngrams/ng3.mlr.txt>`_ `4-grams <ngrams/ng4.mlr.txt>`_, and `5-grams <ngrams/ng5.mlr.txt>`_.
+These are simple *n*-grams as `described here <http://johnkerl.org/randspell/randspell-slides-ts.pdf>`_. Some common functions are `located here <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ngfuncs.mlr.txt>`_. Then here are scripts for `1-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng1.mlr.txt>`_ `2-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng2.mlr.txt>`_ `3-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng3.mlr.txt>`_ `4-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng4.mlr.txt>`_, and `5-grams <https://github.com/johnkerl/miller/blob/master/docs/ngrams/ng5.mlr.txt>`_.
 
 The idea is that words from the input file are consumed, then taken apart and pasted back together in ways which imitate the letter-to-letter transitions found in the word list -- giving us automatically generated words in the same vein as *bromance* and *spork*:
 

--- a/docs/data-examples.rst
+++ b/docs/data-examples.rst
@@ -81,7 +81,7 @@ Categorization of total insured value:
 Color/shape data
 ----------------------------------------------------------------
 
-The `colored-shapes.dkvp <data/colored-shapes.dkvp>`_ file is some sample data produced by the `mkdat2 <https://github.com/johnkerl/miller/blob/master/doc/datagen/mkdat2>`_ script. The idea is:
+The `colored-shapes.dkvp <https://github.com/johnkerl/miller/blob/master/docs/data/colored-shapes.dkvp>`_ file is some sample data produced by the `mkdat2 <https://github.com/johnkerl/miller/blob/master/doc/datagen/mkdat2>`_ script. The idea is:
 
 * Produce some data with known distributions and correlations, and verify that Miller recovers those properties empirically.
 * Each record is labeled with one of a few colors and one of a few shapes.

--- a/docs/data-examples.rst.in
+++ b/docs/data-examples.rst.in
@@ -39,7 +39,7 @@ POKI_RUN_COMMAND{{mlr --from data/flins.csv --icsv --opprint stats2 -a corr,linr
 Color/shape data
 ----------------------------------------------------------------
 
-The `colored-shapes.dkvp <data/colored-shapes.dkvp>`_ file is some sample data produced by the `mkdat2 <https://github.com/johnkerl/miller/blob/master/doc/datagen/mkdat2>`_ script. The idea is:
+The `colored-shapes.dkvp <https://github.com/johnkerl/miller/blob/master/docs/data/colored-shapes.dkvp>`_ file is some sample data produced by the `mkdat2 <https://github.com/johnkerl/miller/blob/master/doc/datagen/mkdat2>`_ script. The idea is:
 
 * Produce some data with known distributions and correlations, and verify that Miller recovers those properties empirically.
 * Each record is labeled with one of a few colors and one of a few shapes.


### PR DESCRIPTION
There are a few points in the documentation web site with dead relative links to data files.
This PR substitutes them with absolute links to the repo files.

Opened #446 before from the wrong account, sorry :)