### PR TITLE
GitHub actions artifacts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,16 +33,16 @@ jobs:
 
     - name: UploadArtifacts
       uses: actions/upload-artifact@v2
-      if: matrix.os == 'ubuntu-latest'
-      with: 
-        name: ubuntu/mlr
-        path: go/mlr
-      if: matrix.os == 'macos-latest'
-      with: 
-        name: macos/mlr
-        path: go/mlr
-      if: matrix.os == 'windows-latest'
-      with: 
-        name: windows/mlr
-        path: go/mlr.exe
-
+      with:
+        strategy:
+          matrix:
+            include:
+              - os: ubuntu-latest
+                name: ubuntu/mlr
+                path: go/mlr
+              - os: macos-latest
+                name: macos/mlr
+                path: go/mlr
+              - os: windows-latest
+                name: windows/mlr
+                path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,5 +37,5 @@ jobs:
         name: ${{ matrix.os }} /mlr
         if: matrix.config.os == 'windows-latest'
         path: go/mlr.exe
-        if: matrix.config.os != 'windows-latest'
+        else:
         path: go/mlr

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,8 @@ jobs:
       # and let the GitHub Actions re-run.
       run: cd go && go test -v ./... && ./mlr regtest -m ./mlr -vv
 
+    # After extensive futzwithing, this is still not quite right.  The Ubuntu &
+    # MacOS executables have the same path and one overwrites the other. :(
     - name: UploadArtifactsUbuntu
       if: ${{ matrix.os }} == ubuntu-latest
       uses: actions/upload-artifact@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,18 +33,9 @@ jobs:
 
     - name: UploadArtifacts
       uses: actions/upload-artifact@v2
-      strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              with:
-                name: ubuntu/mlr
-                path: go/mlr
-            - os: macos-latest
-              with:
-                name: macos/mlr
-                path: go/mlr
-            - os: windows-latest
-              with:
-                name: windows/mlr
-                path: go/mlr.exe
+      with:
+        name: ${{ matrix.os }} /mlr
+        if: matrix.config.os == 'windows-latest'
+          path: go/mlr.exe
+        if: matrix.config.os != 'windows-latest'
+          path: go/mlr

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,21 +32,21 @@ jobs:
       run: cd go && go test -v ./... && ./mlr regtest -m ./mlr -vv
 
     - name: UploadArtifactsUbuntu
-      if: ${{ matrix.os } == ubuntu-latest
+      if: ${{ matrix.os }} == ubuntu-latest
       uses: actions/upload-artifact@v2
       with:
         name: ubuntu/mlr
         path: go/mlr
 
     - name: UploadArtifactsMacOS
-      if: ${{ matrix.os } == macos-latest
+      if: ${{ matrix.os }} == macos-latest
       uses: actions/upload-artifact@v2
       with:
         name: macos/mlr
         path: go/mlr
 
     - name: UploadArtifactsWindows
-      if: ${{ matrix.os } == windows-latest
+      if: ${{ matrix.os }} == windows-latest
       uses: actions/upload-artifact@v2
       with:
         name: windows/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,19 +35,19 @@ jobs:
       if: ${{ matrix.os }} == ubuntu-latest
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu/mlr
+        name: mlr-ubuntu
         path: go/mlr
 
     - name: UploadArtifactsMacOS
       if: ${{ matrix.os }} == macos-latest
       uses: actions/upload-artifact@v2
       with:
-        name: macos/mlr
+        name: mlr-macos
         path: go/mlr
 
     - name: UploadArtifactsWindows
       if: ${{ matrix.os }} == windows-latest
       uses: actions/upload-artifact@v2
       with:
-        name: windows/mlr.exe
+        name: mlr-windows
         path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,15 +34,15 @@ jobs:
     - name: UploadArtifacts
       uses: actions/upload-artifact@v2
       if: matrix.os == 'ubuntu-latest'
-        with: 
-          name: ubuntu/mlr
-          path: go/mlr
+      with: 
+        name: ubuntu/mlr
+        path: go/mlr
       if: matrix.os == 'macos-latest'
-        with: 
-          name: macos/mlr
-          path: go/mlr
+      with: 
+        name: macos/mlr
+        path: go/mlr
       if: matrix.os == 'windows-latest'
-        with: 
-          name: windows/mlr
-          path: go/mlr.exe
+      with: 
+        name: windows/mlr
+        path: go/mlr.exe
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,6 +36,6 @@ jobs:
       with:
         name: ${{ matrix.os }} /mlr
         if: matrix.config.os == 'windows-latest'
-          path: go/mlr.exe
+        path: go/mlr.exe
         if: matrix.config.os != 'windows-latest'
-          path: go/mlr
+        path: go/mlr

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,21 +33,21 @@ jobs:
 
     - name: UploadArtifactsUbuntu
       uses: actions/upload-artifact@v2
-      runs-on: ubuntu-latest
-      with:
-        name: ubuntu/mlr
-        path: go/mlr
+        runs-on: ubuntu-latest
+        with:
+          name: ubuntu/mlr
+          path: go/mlr
 
     - name: UploadArtifactsMacOS
       uses: actions/upload-artifact@v2
-      runs-on: macos-latest
-      with:
-        name: macos/mlr
-        path: go/mlr
+        runs-on: macos-latest
+        with:
+          name: macos/mlr
+          path: go/mlr
 
     - name: UploadArtifactsWindows
       uses: actions/upload-artifact@v2
-      runs-on: windows-latest
-      with:
-        name: windows/mlr.exe
-        path: go/mlr.exe
+        runs-on: windows-latest
+        with:
+          name: windows/mlr.exe
+          path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,21 +33,21 @@ jobs:
 
     - name: UploadArtifactsUbuntu
       uses: actions/upload-artifact@v2
-        runs-on: ubuntu-latest
-        with:
-          name: ubuntu/mlr
-          path: go/mlr
+      runs-on: ubuntu-latest
+      with:
+        name: ubuntu/mlr
+        path: go/mlr
 
     - name: UploadArtifactsMacOS
       uses: actions/upload-artifact@v2
-        runs-on: macos-latest
-        with:
-          name: macos/mlr
-          path: go/mlr
+      runs-on: macos-latest
+      with:
+        name: macos/mlr
+        path: go/mlr
 
     - name: UploadArtifactsWindows
       uses: actions/upload-artifact@v2
-        runs-on: windows-latest
-        with:
-          name: windows/mlr.exe
-          path: go/mlr.exe
+      runs-on: windows-latest
+      with:
+        name: windows/mlr.exe
+        path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,16 +33,18 @@ jobs:
 
     - name: UploadArtifacts
       uses: actions/upload-artifact@v2
-      with:
-        strategy:
-          matrix:
-            include:
-              - os: ubuntu-latest
+      strategy:
+        matrix:
+          include:
+            - os: ubuntu-latest
+              with:
                 name: ubuntu/mlr
                 path: go/mlr
-              - os: macos-latest
+            - os: macos-latest
+              with:
                 name: macos/mlr
                 path: go/mlr
-              - os: windows-latest
+            - os: windows-latest
+              with:
                 name: windows/mlr
                 path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,11 +31,23 @@ jobs:
       # and let the GitHub Actions re-run.
       run: cd go && go test -v ./... && ./mlr regtest -m ./mlr -vv
 
-    - name: UploadArtifacts
+    - name: UploadArtifactsUbuntu
       uses: actions/upload-artifact@v2
+      runs-on: ubuntu-latest
       with:
-        name: ${{ matrix.os }} /mlr
-        if: matrix.config.os == 'windows-latest'
-        path: go/mlr.exe
-        else:
+        name: ubuntu/mlr
         path: go/mlr
+
+    - name: UploadArtifactsMacOS
+      uses: actions/upload-artifact@v2
+      runs-on: macos-latest
+      with:
+        name: macos/mlr
+        path: go/mlr
+
+    - name: UploadArtifactsWindows
+      uses: actions/upload-artifact@v2
+      runs-on: windows-latest
+      with:
+        name: windows/mlr.exe
+        path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,22 +32,22 @@ jobs:
       run: cd go && go test -v ./... && ./mlr regtest -m ./mlr -vv
 
     - name: UploadArtifactsUbuntu
+      if: ${{ matrix.os } == ubuntu-latest
       uses: actions/upload-artifact@v2
-      runs-on: ubuntu-latest
       with:
         name: ubuntu/mlr
         path: go/mlr
 
     - name: UploadArtifactsMacOS
+      if: ${{ matrix.os } == macos-latest
       uses: actions/upload-artifact@v2
-      runs-on: macos-latest
       with:
         name: macos/mlr
         path: go/mlr
 
     - name: UploadArtifactsWindows
+      if: ${{ matrix.os } == windows-latest
       uses: actions/upload-artifact@v2
-      runs-on: windows-latest
       with:
         name: windows/mlr.exe
         path: go/mlr.exe

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exe: {macos-latest: "mlr", ubuntu-latest: "mlr", windows-latest: "mlr.exe"]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,3 +31,19 @@ jobs:
       # using `-v`, `-vv`, or `-vvv`. Commit changes to this file and re-push to GitHub
       # and let the GitHub Actions re-run.
       run: cd go && go test -v ./... && ./mlr regtest -m ./mlr -vv
+
+    - name: UploadArtifacts
+      uses: actions/upload-artifact@v2
+      if: matrix.os == 'ubuntu-latest'
+        with: 
+          name: ubuntu/mlr
+          path: go/mlr
+      if: matrix.os == 'macos-latest'
+        with: 
+          name: macos/mlr
+          path: go/mlr
+      if: matrix.os == 'windows-latest'
+        with: 
+          name: windows/mlr
+          path: go/mlr.exe
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exe: {macos-latest: "mlr", ubuntu-latest: "mlr", windows-latest: "mlr.exe"]
 
     steps:
     - uses: actions/checkout@v2

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -34,6 +34,7 @@ d windows mrpl colors -- ? checking isatty also -- ?
 
 ! upload artifacts
   https://github.com/actions/upload-artifact
+  https://forum.nim-lang.org/t/6371
 
 * PR-template etc checklists
 ----------------------------------------------------------------


### PR DESCRIPTION
Not quite right: Ubuntu/MacOS artifacts, one `mlr` replaces the other at https://github.com/johnkerl/miller/actions. However, `mlr.exe` has no name-collision and exists -- yay!