### PR TITLE
Enforce restrictions on CSV separators

### DIFF
--- a/docs6/src/manpage.md
+++ b/docs6/src/manpage.md
@@ -621,28 +621,11 @@ SEPARATOR FLAGS
        * You can set separators differently between Miller's input and output --
          hence `--ifs` and `--ofs`, etc.
 
-       TODO: auto-detect is still TBD for Miller 6.
-
        Notes about line endings:
 
-       * Default line endings (`--irs` and `--ors`) are "auto"
-         which means autodetect from the input file format, as long as the input
-         file(s) have lines ending in either LF (also known as linefeed, `\n`, `0x0a`, or Unix-style) or CRLF (also known as
-         carriage-return/linefeed pairs, `\r\n`, `0x0d 0x0a`, or
-         Windows-style).
-       * If both `irs` and `ors` are `auto` (which is
-         the default) then LF input will lead to LF output and CRLF input will lead to
-         CRLF output, regardless of the platform you're running on.
-       * The line-ending autodetector triggers on the first line ending detected in
-         the input stream. E.g. if you specify a CRLF-terminated file on the command
-         line followed by an LF-terminated file then autodetected line endings will be
-         CRLF.
-       * If you use `--ors {something else}` with (default or explicitly
-         specified) `--irs auto` then line endings are autodetected on input
-         and set to what you specify on output.
-       * If you use `--irs {something else}` with (default or explicitly
-         specified) `--ors auto` then the output line endings used are LF on
-         Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+       * Default line endings (`--irs` and `--ors`) are newline
+         which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+         for input, and to produce platform-appropriate line endings on output.
 
        Notes about all other separators:
 

--- a/docs6/src/manpage.txt
+++ b/docs6/src/manpage.txt
@@ -600,28 +600,11 @@ SEPARATOR FLAGS
        * You can set separators differently between Miller's input and output --
          hence `--ifs` and `--ofs`, etc.
 
-       TODO: auto-detect is still TBD for Miller 6.
-
        Notes about line endings:
 
-       * Default line endings (`--irs` and `--ors`) are "auto"
-         which means autodetect from the input file format, as long as the input
-         file(s) have lines ending in either LF (also known as linefeed, `\n`, `0x0a`, or Unix-style) or CRLF (also known as
-         carriage-return/linefeed pairs, `\r\n`, `0x0d 0x0a`, or
-         Windows-style).
-       * If both `irs` and `ors` are `auto` (which is
-         the default) then LF input will lead to LF output and CRLF input will lead to
-         CRLF output, regardless of the platform you're running on.
-       * The line-ending autodetector triggers on the first line ending detected in
-         the input stream. E.g. if you specify a CRLF-terminated file on the command
-         line followed by an LF-terminated file then autodetected line endings will be
-         CRLF.
-       * If you use `--ors {something else}` with (default or explicitly
-         specified) `--irs auto` then line endings are autodetected on input
-         and set to what you specify on output.
-       * If you use `--irs {something else}` with (default or explicitly
-         specified) `--ors auto` then the output line endings used are LF on
-         Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+       * Default line endings (`--irs` and `--ors`) are newline
+         which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+         for input, and to produce platform-appropriate line endings on output.
 
        Notes about all other separators:
 

--- a/docs6/src/record-heterogeneity.md
+++ b/docs6/src/record-heterogeneity.md
@@ -127,8 +127,6 @@ If you `mlr csv cat` this, you'll get an error message:
 <b>mlr --csv cat data/het/ragged.csv</b>
 </pre>
 <pre class="pre-non-highlight-in-pair">
-a,b,c
-1,2,3
 mlr :  mlr: CSV header/data length mismatch 3 != 2 at filename data/het/ragged.csv row 3.
 
 </pre>

--- a/docs6/src/reference-main-flag-list.md
+++ b/docs6/src/reference-main-flag-list.md
@@ -477,28 +477,11 @@ In brief:
 * You can set separators differently between Miller's input and output --
   hence `--ifs` and `--ofs`, etc.
 
-TODO: auto-detect is still TBD for Miller 6.
-
 Notes about line endings:
 
-* Default line endings (`--irs` and `--ors`) are "auto"
-  which means autodetect from the input file format, as long as the input
-  file(s) have lines ending in either LF (also known as linefeed, `\n`, `0x0a`, or Unix-style) or CRLF (also known as
-  carriage-return/linefeed pairs, `\r\n`, `0x0d 0x0a`, or
-  Windows-style).
-* If both `irs` and `ors` are `auto` (which is
-  the default) then LF input will lead to LF output and CRLF input will lead to
-  CRLF output, regardless of the platform you're running on.
-* The line-ending autodetector triggers on the first line ending detected in
-  the input stream. E.g. if you specify a CRLF-terminated file on the command
-  line followed by an LF-terminated file then autodetected line endings will be
-  CRLF.
-* If you use `--ors {something else}` with (default or explicitly
-  specified) `--irs auto` then line endings are autodetected on input
-  and set to what you specify on output.
-* If you use `--irs {something else}` with (default or explicitly
-  specified) `--ors auto` then the output line endings used are LF on
-  Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+* Default line endings (`--irs` and `--ors`) are newline
+  which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+  for input, and to produce platform-appropriate line endings on output.
 
 Notes about all other separators:
 

--- a/docs6/src/reference-main-separators.md
+++ b/docs6/src/reference-main-separators.md
@@ -234,21 +234,22 @@ a:4;b:5;c:6;d:>>>,|||;<<<
 Notes:
 
 * If CSV field separator is tab, we have TSV; see more examples (ASV, USV, etc.) at in the [CSV section](file-formats.md#csvtsvasvusvetc).
+* CSV IRS and ORS must be newline, and CSV IFS must be a single character. (CSV-lite does not have these restrictions.)
 * JSON: ignores all separator flags from the command line.
 * Headerless CSV overlaps quite a bit with NIDX format using comma for IFS. See also the page on [CSV with and without headers](csv-with-and-without-headers.md).
 * For XTAB, the record separator is a repetition of the field separator. For example, if one record has `x=1,y=2` and the next has `x=3,y=4`, and OFS is newline, then output lines are `x 1`, then `y 2`, then an extra newline, then `x 3`, then `y 4`. This means: to customize XTAB, set `OFS` rather than `ORS`.
 
 |            | **RS**  | **FS**  | **PS**   |
 |------------|---------|---------|----------|
-| [**CSV and CSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *   | Default `,`    | None     |
-| [**TSV**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *  |  Default `\t`   | None     |
-| [**JSON**](file-formats.md#json)   | N/A; records are between `{` and `}` | `,` but  not alterable    | `:` but not alterable |
+| [**CSV**](file-formats.md#csvtsvasvusvetc)    | Always `\n`; not alterable * | Default `,`; must be single-character    | None     |
+| [**TSV**](file-formats.md#csvtsvasvusvetc)    | Always `\n`; not alterable * |  Default `\t`; must be single-character   | None     |
+| [**CSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *   | Default `,`    | None     |
+| [**TSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *  |  Default `\t`   | None     |
+| [**JSON**](file-formats.md#json)   | N/A; records are between `{` and `}` | Always `,`; not alterable    | Always `:`; not alterable |
 | [**DKVP**](file-formats.md#dkvp-key-value-pairs)   | Default `\n`    | Default `,`    | Default `=` |
 | [**NIDX**](file-formats.md#nidx-index-numbered-toolkit-style)   | Default `\n`    | Default space    | None     |
-| [**XTAB**](file-formats.md#xtab-vertical-tabular)   | `\n\n` **    | `\n` *    | Space with repeats  |
+| [**XTAB**](file-formats.md#xtab-vertical-tabular)   | Not used; records are separated by an extra FS    | `\n` *    | Default: space with repeats  |
 | [**PPRINT**](file-formats.md#pprint-pretty-printed-tabular) | Default `\n` *    | Space with repeats    | None     |
-| [**Markdown**](file-formats.md#markdown-tabular) | `\n` * but not alterable    | One or more spaces then `|` then one or more spaces; not alterable | None     |
+| [**Markdown**](file-formats.md#markdown-tabular) | Always `\n`; not alterable * | One or more spaces, then `|`, then one or more spaces; not alterable | None     |
 
 \* or `\r\n` on Windows
-
-\*\* or `\r\n\r\n` on Windows

--- a/docs6/src/reference-main-separators.md.in
+++ b/docs6/src/reference-main-separators.md.in
@@ -136,21 +136,22 @@ GENMD_EOF
 Notes:
 
 * If CSV field separator is tab, we have TSV; see more examples (ASV, USV, etc.) at in the [CSV section](file-formats.md#csvtsvasvusvetc).
+* CSV IRS and ORS must be newline, and CSV IFS must be a single character. (CSV-lite does not have these restrictions.)
 * JSON: ignores all separator flags from the command line.
 * Headerless CSV overlaps quite a bit with NIDX format using comma for IFS. See also the page on [CSV with and without headers](csv-with-and-without-headers.md).
 * For XTAB, the record separator is a repetition of the field separator. For example, if one record has `x=1,y=2` and the next has `x=3,y=4`, and OFS is newline, then output lines are `x 1`, then `y 2`, then an extra newline, then `x 3`, then `y 4`. This means: to customize XTAB, set `OFS` rather than `ORS`.
 
 |            | **RS**  | **FS**  | **PS**   |
 |------------|---------|---------|----------|
-| [**CSV and CSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *   | Default `,`    | None     |
-| [**TSV**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *  |  Default `\t`   | None     |
-| [**JSON**](file-formats.md#json)   | N/A; records are between `{` and `}` | `,` but  not alterable    | `:` but not alterable |
+| [**CSV**](file-formats.md#csvtsvasvusvetc)    | Always `\n`; not alterable * | Default `,`; must be single-character    | None     |
+| [**TSV**](file-formats.md#csvtsvasvusvetc)    | Always `\n`; not alterable * |  Default `\t`; must be single-character   | None     |
+| [**CSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *   | Default `,`    | None     |
+| [**TSV-lite**](file-formats.md#csvtsvasvusvetc)    | Default `\n` *  |  Default `\t`   | None     |
+| [**JSON**](file-formats.md#json)   | N/A; records are between `{` and `}` | Always `,`; not alterable    | Always `:`; not alterable |
 | [**DKVP**](file-formats.md#dkvp-key-value-pairs)   | Default `\n`    | Default `,`    | Default `=` |
 | [**NIDX**](file-formats.md#nidx-index-numbered-toolkit-style)   | Default `\n`    | Default space    | None     |
-| [**XTAB**](file-formats.md#xtab-vertical-tabular)   | `\n\n` **    | `\n` *    | Space with repeats  |
+| [**XTAB**](file-formats.md#xtab-vertical-tabular)   | Not used; records are separated by an extra FS    | `\n` *    | Default: space with repeats  |
 | [**PPRINT**](file-formats.md#pprint-pretty-printed-tabular) | Default `\n` *    | Space with repeats    | None     |
-| [**Markdown**](file-formats.md#markdown-tabular) | `\n` * but not alterable    | One or more spaces then `|` then one or more spaces; not alterable | None     |
+| [**Markdown**](file-formats.md#markdown-tabular) | Always `\n`; not alterable * | One or more spaces, then `|`, then one or more spaces; not alterable | None     |
 
 \* or `\r\n` on Windows
-
-\*\* or `\r\n\r\n` on Windows

--- a/go/regtest/cases/cli-csv-rs-environment-defaults/0002/cmd
+++ b/go/regtest/cases/cli-csv-rs-environment-defaults/0002/cmd
@@ -1,1 +1,1 @@
-mlr --csv --rs crlf cut -f a regtest/input/rfc-csv/simple.csv-crlf
+mlr --csv cut -f a regtest/input/rfc-csv/simple.csv-crlf

--- a/go/regtest/cases/io-multi-character-ixs/0011/cmd
+++ b/go/regtest/cases/io-multi-character-ixs/0011/cmd
@@ -1,1 +1,1 @@
-mlr --xtab --ifs crlf --ofs Z cut -x -f b regtest/input/truncated.xtab-crlf
+mlr --xtab --ofs Z cut -x -f b regtest/input/truncated.xtab-crlf

--- a/go/src/auxents/repl/session.go
+++ b/go/src/auxents/repl/session.go
@@ -18,7 +18,6 @@ package repl
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,14 +45,14 @@ func NewRepl(
 	options *cli.TOptions,
 ) (*Repl, error) {
 
-	recordReader := input.Create(&options.ReaderOptions)
-	if recordReader == nil {
-		return nil, errors.New("Input format not found: " + options.ReaderOptions.InputFileFormat)
+	recordReader, err := input.Create(&options.ReaderOptions)
+	if err != nil {
+		return nil, err
 	}
 
-	recordWriter := output.Create(&options.WriterOptions)
-	if recordWriter == nil {
-		return nil, errors.New("Output format not found: " + options.WriterOptions.OutputFileFormat)
+	recordWriter, err := output.Create(&options.WriterOptions)
+	if err != nil {
+		return nil, err
 	}
 	outputStream := os.Stdout
 

--- a/go/src/cli/option_parse.go
+++ b/go/src/cli/option_parse.go
@@ -98,7 +98,6 @@ var FLAG_TABLE = FlagTable{
 		&SeparatorFlagSection,
 		&FileFormatFlagSection,
 		&FormatConversionKeystrokeSaverFlagSection,
-		// TODO: &HelpFlags, here or in climain?
 		&JSONOnlyFlagSection,
 		&CSVOnlyFlagSection,
 		&PPRINTOnlyFlagSection,
@@ -136,29 +135,11 @@ In brief:
 * You can set separators differently between Miller's input and output --
   hence ` + "`--ifs`" + ` and ` + "`--ofs`" + `, etc.
 
-TODO: auto-detect is still TBD for Miller 6.
-
 Notes about line endings:
 
-* Default line endings (` + "`--irs`" + ` and ` + "`--ors`" + `) are "auto"
-  which means autodetect from the input file format, as long as the input
-  file(s) have lines ending in either LF (also known as linefeed, ` + "`\\n`" +
-		`, ` + "`0x0a`" + `, or Unix-style) or CRLF (also known as
-  carriage-return/linefeed pairs, ` + "`\\r\\n`" + `, ` + "`0x0d 0x0a`" + `, or
-  Windows-style).
-* If both ` + "`irs`" + ` and ` + "`ors`" + ` are ` + "`auto`" + ` (which is
-  the default) then LF input will lead to LF output and CRLF input will lead to
-  CRLF output, regardless of the platform you're running on.
-* The line-ending autodetector triggers on the first line ending detected in
-  the input stream. E.g. if you specify a CRLF-terminated file on the command
-  line followed by an LF-terminated file then autodetected line endings will be
-  CRLF.
-* If you use ` + "`--ors {something else}`" + ` with (default or explicitly
-  specified) ` + "`--irs auto`" + ` then line endings are autodetected on input
-  and set to what you specify on output.
-* If you use ` + "`--irs {something else}`" + ` with (default or explicitly
-  specified) ` + "`--ors auto`" + ` then the output line endings used are LF on
-  Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+* Default line endings (` + "`--irs`" + ` and ` + "`--ors`" + `) are newline
+  which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+  for input, and to produce platform-appropriate line endings on output.
 
 Notes about all other separators:
 
@@ -240,8 +221,13 @@ var SeparatorFlagSection = FlagSection{
 			help: "Specify FS for input.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
 				CheckArgCount(args, *pargi, argc, 2)
-				options.ReaderOptions.IFS = SeparatorFromArg(args[*pargi+1])
-				options.ReaderOptions.IFSWasSpecified = true
+				// Backward compatibility with Miller <= 5. Auto-inference of
+				// LF vs CR/LF line endings is handled within Go libraries so
+				// we needn't do anything ourselves.
+				if args[*pargi+1] != "auto" {
+					options.ReaderOptions.IFS = SeparatorFromArg(args[*pargi+1])
+					options.ReaderOptions.IFSWasSpecified = true
+				}
 				*pargi += 2
 			},
 		},

--- a/go/src/cli/option_types.go
+++ b/go/src/cli/option_types.go
@@ -102,7 +102,6 @@ type TWriterOptions struct {
 	//
 	//	quoting_t oquoting;
 
-	// TODO: centralize comments here & mlrcli_parse.go & repl/verbs.go; maybe to a README.md
 	// When we read things like
 	//
 	//   x:a=1,x:b=2

--- a/go/src/cli/separators.go
+++ b/go/src/cli/separators.go
@@ -78,7 +78,6 @@ var SEPARATOR_NAMES_TO_VALUES = map[string]string{
 // E.g. if IFS isn't specified, it's space for NIDX and comma for DKVP, etc.
 
 var defaultFSes = map[string]string{
-	// "gen" : // TODO
 	"csv":      ",",
 	"csvlite":  ",",
 	"dkvp":     ",",

--- a/go/src/entrypoint/entrypoint.go
+++ b/go/src/entrypoint/entrypoint.go
@@ -66,7 +66,7 @@ func processToStdout(
 ) {
 	err := stream.Stream(options.FileNames, &options, recordTransformers, os.Stdout, true)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, os.Args[0], ": ", err)
+		fmt.Fprintf(os.Stderr, "mlr: %v.\n", err)
 		os.Exit(1)
 	}
 }

--- a/go/src/input/pseudo_reader_gen.go
+++ b/go/src/input/pseudo_reader_gen.go
@@ -12,10 +12,10 @@ type PseudoReaderGen struct {
 	readerOptions *cli.TReaderOptions
 }
 
-func NewPseudoReaderGen(readerOptions *cli.TReaderOptions) *PseudoReaderGen {
+func NewPseudoReaderGen(readerOptions *cli.TReaderOptions) (*PseudoReaderGen, error) {
 	return &PseudoReaderGen{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 func (reader *PseudoReaderGen) Read(

--- a/go/src/input/record_reader_csvlite.go
+++ b/go/src/input/record_reader_csvlite.go
@@ -36,17 +36,17 @@ type RecordReaderCSVLite struct {
 }
 
 // ----------------------------------------------------------------
-func NewRecordReaderCSVLite(readerOptions *cli.TReaderOptions) *RecordReaderCSVLite {
+func NewRecordReaderCSVLite(readerOptions *cli.TReaderOptions) (*RecordReaderCSVLite, error) {
 	return &RecordReaderCSVLite{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------
-func NewRecordReaderPPRINT(readerOptions *cli.TReaderOptions) *RecordReaderCSVLite {
+func NewRecordReaderPPRINT(readerOptions *cli.TReaderOptions) (*RecordReaderCSVLite, error) {
 	return &RecordReaderCSVLite{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------

--- a/go/src/input/record_reader_dkvp.go
+++ b/go/src/input/record_reader_dkvp.go
@@ -14,10 +14,10 @@ type RecordReaderDKVP struct {
 	readerOptions *cli.TReaderOptions
 }
 
-func NewRecordReaderDKVP(readerOptions *cli.TReaderOptions) *RecordReaderDKVP {
+func NewRecordReaderDKVP(readerOptions *cli.TReaderOptions) (*RecordReaderDKVP, error) {
 	return &RecordReaderDKVP{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 func (reader *RecordReaderDKVP) Read(

--- a/go/src/input/record_reader_factory.go
+++ b/go/src/input/record_reader_factory.go
@@ -1,10 +1,13 @@
 package input
 
 import (
+	"errors"
+	"fmt"
+
 	"mlr/src/cli"
 )
 
-func Create(readerOptions *cli.TReaderOptions) IRecordReader {
+func Create(readerOptions *cli.TReaderOptions) (IRecordReader, error) {
 	switch readerOptions.InputFileFormat {
 	case "csv":
 		return NewRecordReaderCSV(readerOptions)
@@ -23,6 +26,6 @@ func Create(readerOptions *cli.TReaderOptions) IRecordReader {
 	case "gen":
 		return NewPseudoReaderGen(readerOptions)
 	default:
-		return nil
+		return nil, errors.New(fmt.Sprintf("input file format \"%s\" not found", readerOptions.InputFileFormat))
 	}
 }

--- a/go/src/input/record_reader_json.go
+++ b/go/src/input/record_reader_json.go
@@ -18,10 +18,10 @@ type RecordReaderJSON struct {
 	readerOptions *cli.TReaderOptions
 }
 
-func NewRecordReaderJSON(readerOptions *cli.TReaderOptions) *RecordReaderJSON {
+func NewRecordReaderJSON(readerOptions *cli.TReaderOptions) (*RecordReaderJSON, error) {
 	return &RecordReaderJSON{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 func (reader *RecordReaderJSON) Read(

--- a/go/src/input/record_reader_nidx.go
+++ b/go/src/input/record_reader_nidx.go
@@ -14,10 +14,10 @@ type RecordReaderNIDX struct {
 	readerOptions *cli.TReaderOptions
 }
 
-func NewRecordReaderNIDX(readerOptions *cli.TReaderOptions) *RecordReaderNIDX {
+func NewRecordReaderNIDX(readerOptions *cli.TReaderOptions) (*RecordReaderNIDX, error) {
 	return &RecordReaderNIDX{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 func (reader *RecordReaderNIDX) Read(

--- a/go/src/input/record_reader_xtab.go
+++ b/go/src/input/record_reader_xtab.go
@@ -13,14 +13,14 @@ import (
 
 type RecordReaderXTAB struct {
 	readerOptions *cli.TReaderOptions
-	// TODO: parameterize IRS vs IFS correctly (XTAB is different)
+	// Note: XTAB uses two consecutive IFS in place of an IRS; IRS is ignored
 }
 
 // ----------------------------------------------------------------
-func NewRecordReaderXTAB(readerOptions *cli.TReaderOptions) *RecordReaderXTAB {
+func NewRecordReaderXTAB(readerOptions *cli.TReaderOptions) (*RecordReaderXTAB, error) {
 	return &RecordReaderXTAB{
 		readerOptions: readerOptions,
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------
@@ -72,9 +72,7 @@ func (reader *RecordReaderXTAB) processHandle(
 ) {
 	context.UpdateForStartOfFile(filename)
 
-	// TODO: parameterize IRS vs IFS correctly (XTAB is different)
-	//scanner := NewLineScanner(handle, "\n\n")
-	scanner := NewLineScanner(handle, "\n")
+	scanner := NewLineScanner(handle, reader.readerOptions.IFS)
 
 	linesForRecord := list.New()
 
@@ -116,7 +114,7 @@ func (reader *RecordReaderXTAB) processHandle(
 		// Check for comments-in-data feature
 		if strings.HasPrefix(line, reader.readerOptions.CommentString) {
 			if reader.readerOptions.CommentHandling == cli.PassComments {
-				inputChannel <- types.NewOutputString(line+"\n", context)
+				inputChannel <- types.NewOutputString(line+reader.readerOptions.IFS, context)
 				continue
 			} else if reader.readerOptions.CommentHandling == cli.SkipComments {
 				continue

--- a/go/src/output/file-output-handlers.go
+++ b/go/src/output/file-output-handlers.go
@@ -345,11 +345,9 @@ func (handler *FileOutputHandler) setUpRecordWriter() error {
 		return nil
 	}
 
-	recordWriter := Create(handler.recordWriterOptions)
-	if recordWriter == nil {
-		return errors.New(
-			"Output format not found: " + handler.recordWriterOptions.OutputFileFormat,
-		)
+	recordWriter, err := Create(handler.recordWriterOptions)
+	if err != nil {
+		return err
 	}
 	handler.recordWriter = recordWriter
 

--- a/go/src/output/record_writer_csv.go
+++ b/go/src/output/record_writer_csv.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/csv"
+	"errors"
 	"io"
 	"strings"
 
@@ -19,13 +20,16 @@ type RecordWriterCSV struct {
 	justWroteEmptyLine bool
 }
 
-func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) *RecordWriterCSV {
+func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
+	if writerOptions.ORS != "\n" {
+		return nil, errors.New("CSV ORS can only be newline")
+	}
 	return &RecordWriterCSV{
 		writerOptions:      writerOptions,
 		csvWriter:          nil, // will be set on first Write() wherein we have the ostream
 		lastJoinedHeader:   nil,
 		justWroteEmptyLine: false,
-	}
+	}, nil
 }
 
 func (writer *RecordWriterCSV) Write(

--- a/go/src/output/record_writer_csvlite.go
+++ b/go/src/output/record_writer_csvlite.go
@@ -18,12 +18,12 @@ type RecordWriterCSVLite struct {
 	justWroteEmptyLine bool
 }
 
-func NewRecordWriterCSVLite(writerOptions *cli.TWriterOptions) *RecordWriterCSVLite {
+func NewRecordWriterCSVLite(writerOptions *cli.TWriterOptions) (*RecordWriterCSVLite, error) {
 	return &RecordWriterCSVLite{
 		writerOptions:      writerOptions,
 		lastJoinedHeader:   nil,
 		justWroteEmptyLine: false,
-	}
+	}, nil
 }
 
 func (writer *RecordWriterCSVLite) Write(

--- a/go/src/output/record_writer_dkvp.go
+++ b/go/src/output/record_writer_dkvp.go
@@ -13,10 +13,10 @@ type RecordWriterDKVP struct {
 	writerOptions *cli.TWriterOptions
 }
 
-func NewRecordWriterDKVP(writerOptions *cli.TWriterOptions) *RecordWriterDKVP {
+func NewRecordWriterDKVP(writerOptions *cli.TWriterOptions) (*RecordWriterDKVP, error) {
 	return &RecordWriterDKVP{
 		writerOptions: writerOptions,
-	}
+	}, nil
 }
 
 func (writer *RecordWriterDKVP) Write(

--- a/go/src/output/record_writer_factory.go
+++ b/go/src/output/record_writer_factory.go
@@ -1,10 +1,13 @@
 package output
 
 import (
+	"errors"
+	"fmt"
+
 	"mlr/src/cli"
 )
 
-func Create(writerOptions *cli.TWriterOptions) IRecordWriter {
+func Create(writerOptions *cli.TWriterOptions) (IRecordWriter, error) {
 	switch writerOptions.OutputFileFormat {
 	case "csv":
 		return NewRecordWriterCSV(writerOptions)
@@ -23,6 +26,6 @@ func Create(writerOptions *cli.TWriterOptions) IRecordWriter {
 	case "xtab":
 		return NewRecordWriterXTAB(writerOptions)
 	default:
-		return nil
+		return nil, errors.New(fmt.Sprintf("output file format \"%s\" not found", writerOptions.OutputFileFormat))
 	}
 }

--- a/go/src/output/record_writer_json.go
+++ b/go/src/output/record_writer_json.go
@@ -21,7 +21,7 @@ type RecordWriterJSON struct {
 }
 
 // ----------------------------------------------------------------
-func NewRecordWriterJSON(writerOptions *cli.TWriterOptions) *RecordWriterJSON {
+func NewRecordWriterJSON(writerOptions *cli.TWriterOptions) (*RecordWriterJSON, error) {
 	var jsonFormatting types.TJSONFormatting = types.JSON_SINGLE_LINE
 	if writerOptions.JSONOutputMultiline {
 		jsonFormatting = types.JSON_MULTILINE
@@ -30,7 +30,7 @@ func NewRecordWriterJSON(writerOptions *cli.TWriterOptions) *RecordWriterJSON {
 		writerOptions:  writerOptions,
 		jsonFormatting: jsonFormatting,
 		onFirst:        true,
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------

--- a/go/src/output/record_writer_markdown.go
+++ b/go/src/output/record_writer_markdown.go
@@ -19,13 +19,13 @@ type RecordWriterMarkdown struct {
 	lastJoinedHeader     string
 }
 
-func NewRecordWriterMarkdown(writerOptions *cli.TWriterOptions) *RecordWriterMarkdown {
+func NewRecordWriterMarkdown(writerOptions *cli.TWriterOptions) (*RecordWriterMarkdown, error) {
 	return &RecordWriterMarkdown{
 		writerOptions: writerOptions,
 
 		numHeaderLinesOutput: 0,
 		lastJoinedHeader:     "",
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------

--- a/go/src/output/record_writer_nidx.go
+++ b/go/src/output/record_writer_nidx.go
@@ -14,10 +14,10 @@ type RecordWriterNIDX struct {
 	ors           string
 }
 
-func NewRecordWriterNIDX(writerOptions *cli.TWriterOptions) *RecordWriterNIDX {
+func NewRecordWriterNIDX(writerOptions *cli.TWriterOptions) (*RecordWriterNIDX, error) {
 	return &RecordWriterNIDX{
 		writerOptions: writerOptions,
-	}
+	}, nil
 }
 
 func (writer *RecordWriterNIDX) Write(

--- a/go/src/output/record_writer_pprint.go
+++ b/go/src/output/record_writer_pprint.go
@@ -23,14 +23,14 @@ type RecordWriterPPRINT struct {
 	batch            *list.List
 }
 
-func NewRecordWriterPPRINT(writerOptions *cli.TWriterOptions) *RecordWriterPPRINT {
+func NewRecordWriterPPRINT(writerOptions *cli.TWriterOptions) (*RecordWriterPPRINT, error) {
 	return &RecordWriterPPRINT{
 		writerOptions: writerOptions,
 		records:       list.New(),
 
 		lastJoinedHeader: nil,
 		batch:            list.New(),
-	}
+	}, nil
 }
 
 // ----------------------------------------------------------------

--- a/go/src/output/record_writer_xtab.go
+++ b/go/src/output/record_writer_xtab.go
@@ -29,16 +29,17 @@ import (
 
 type RecordWriterXTAB struct {
 	writerOptions *cli.TWriterOptions
-	opslen        int
-	onFirst       bool
+	// Note: XTAB uses two consecutive OFS in place of an ORS; ORS is ignored
+	opslen  int
+	onFirst bool
 }
 
-func NewRecordWriterXTAB(writerOptions *cli.TWriterOptions) *RecordWriterXTAB {
+func NewRecordWriterXTAB(writerOptions *cli.TWriterOptions) (*RecordWriterXTAB, error) {
 	return &RecordWriterXTAB{
 		writerOptions: writerOptions,
 		opslen:        utf8.RuneCountInString(writerOptions.OPS),
 		onFirst:       true,
-	}
+	}, nil
 }
 
 func (writer *RecordWriterXTAB) Write(

--- a/go/src/stream/stream.go
+++ b/go/src/stream/stream.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,15 +55,15 @@ func Stream(
 	)
 
 	// Instantiate the record-reader
-	recordReader := input.Create(&options.ReaderOptions)
-	if recordReader == nil {
-		return errors.New("Input format not found: " + options.ReaderOptions.InputFileFormat)
+	recordReader, err := input.Create(&options.ReaderOptions)
+	if err != nil {
+		return err
 	}
 
 	// Instantiate the record-writer
-	recordWriter := output.Create(&options.WriterOptions)
-	if recordWriter == nil {
-		return errors.New("Output format not found: " + options.WriterOptions.OutputFileFormat)
+	recordWriter, err := output.Create(&options.WriterOptions)
+	if err != nil {
+		return err
 	}
 
 	// Set up the reader-to-transformer and transformer-to-writer channels.

--- a/go/src/transformers/join.go
+++ b/go/src/transformers/join.go
@@ -2,7 +2,6 @@ package transformers
 
 import (
 	"container/list"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -451,12 +450,9 @@ func (tr *TransformerJoin) ingestLeftFile() {
 	readerOpts := &tr.opts.joinFlagOptions.ReaderOptions
 
 	// Instantiate the record-reader
-	recordReader := input.Create(readerOpts)
+	recordReader, err := input.Create(readerOpts)
 	if recordReader == nil {
-		fmt.Fprintln(
-			os.Stderr,
-			errors.New("Input format not found: "+readerOpts.InputFileFormat),
-		)
+		fmt.Fprintf(os.Stderr, "mlr join: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/go/src/transformers/utils/join-bucket-keeper.go
+++ b/go/src/transformers/utils/join-bucket-keeper.go
@@ -165,14 +165,9 @@ func NewJoinBucketKeeper(
 ) *JoinBucketKeeper {
 
 	// Instantiate the record-reader
-	recordReader := input.Create(joinReaderOptions)
-	if recordReader == nil {
-		fmt.Fprintf(
-			os.Stderr,
-			"%s join: Input format %s not found.\n",
-			"mlr",
-			joinReaderOptions.InputFileFormat,
-		)
+	recordReader, err := input.Create(joinReaderOptions)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mlr join: %v", err)
 		os.Exit(1)
 	}
 

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -42,9 +42,9 @@ PUNCHDOWN LIST
 * olh
   o kw olh for func and funct both
   o better help-searching:
-    ? mlr -f foo ?
-    ? mlr -F foo ?
-    ? mlr help w approx incl flags?
+    ? mlr help search foo -- including flag-search
+    ? mlr -f foo
+    ? mlr -F foo == mlr help function foo
 
 * pre-release:
   o draft release w/ m6 binaries YYYYMMDD -- ?
@@ -60,7 +60,6 @@ PUNCHDOWN LIST
   o new-in-miller-6: missings:
     - dump syntax -- ?
     - emittable constraints -- ?
-  o strings: single-quote & backtick have no meaning in the miller dsl (diffs w/r/t other langs)
   o wut h1 spacing before/after ...
   o document re auto in nim6.in
   o shell-commands: while-read example from issues

--- a/go/todo.txt
+++ b/go/todo.txt
@@ -9,14 +9,6 @@ PUNCHDOWN LIST
   o mapexcept ...
   o fmtnum "%3d%%" -- ?
 
-* separators:
-  o xtab crlf & non-std irs generally ...
-  o check all formats for when/when not multi-char (or any non-LF) IRS
-  o csv force ifslen==1
-  o csv force irs == "\n"
-  o csv force ors == "\n"
-  o xtab ifs/irs
-
 * cases/dsl-min-max-types: cmp-matrices need to be fixed to follow the advertised rule for mixed types
   NUMERICS < BOOL < VOID < STRING
 

--- a/man6/manpage.txt
+++ b/man6/manpage.txt
@@ -600,28 +600,11 @@ SEPARATOR FLAGS
        * You can set separators differently between Miller's input and output --
          hence `--ifs` and `--ofs`, etc.
 
-       TODO: auto-detect is still TBD for Miller 6.
-
        Notes about line endings:
 
-       * Default line endings (`--irs` and `--ors`) are "auto"
-         which means autodetect from the input file format, as long as the input
-         file(s) have lines ending in either LF (also known as linefeed, `\n`, `0x0a`, or Unix-style) or CRLF (also known as
-         carriage-return/linefeed pairs, `\r\n`, `0x0d 0x0a`, or
-         Windows-style).
-       * If both `irs` and `ors` are `auto` (which is
-         the default) then LF input will lead to LF output and CRLF input will lead to
-         CRLF output, regardless of the platform you're running on.
-       * The line-ending autodetector triggers on the first line ending detected in
-         the input stream. E.g. if you specify a CRLF-terminated file on the command
-         line followed by an LF-terminated file then autodetected line endings will be
-         CRLF.
-       * If you use `--ors {something else}` with (default or explicitly
-         specified) `--irs auto` then line endings are autodetected on input
-         and set to what you specify on output.
-       * If you use `--irs {something else}` with (default or explicitly
-         specified) `--ors auto` then the output line endings used are LF on
-         Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+       * Default line endings (`--irs` and `--ors`) are newline
+         which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+         for input, and to produce platform-appropriate line endings on output.
 
        Notes about all other separators:
 

--- a/man6/mlr6.1
+++ b/man6/mlr6.1
@@ -743,28 +743,11 @@ In brief:
 * You can set separators differently between Miller's input and output --
   hence `--ifs` and `--ofs`, etc.
 
-TODO: auto-detect is still TBD for Miller 6.
-
 Notes about line endings:
 
-* Default line endings (`--irs` and `--ors`) are "auto"
-  which means autodetect from the input file format, as long as the input
-  file(s) have lines ending in either LF (also known as linefeed, `\en`, `0x0a`, or Unix-style) or CRLF (also known as
-  carriage-return/linefeed pairs, `\er\en`, `0x0d 0x0a`, or
-  Windows-style).
-* If both `irs` and `ors` are `auto` (which is
-  the default) then LF input will lead to LF output and CRLF input will lead to
-  CRLF output, regardless of the platform you're running on.
-* The line-ending autodetector triggers on the first line ending detected in
-  the input stream. E.g. if you specify a CRLF-terminated file on the command
-  line followed by an LF-terminated file then autodetected line endings will be
-  CRLF.
-* If you use `--ors {something else}` with (default or explicitly
-  specified) `--irs auto` then line endings are autodetected on input
-  and set to what you specify on output.
-* If you use `--irs {something else}` with (default or explicitly
-  specified) `--ors auto` then the output line endings used are LF on
-  Unix/Linux/BSD/MacOSX, and CRLF on Windows.
+* Default line endings (`--irs` and `--ors`) are newline
+  which is interpreted to accept carriage-return/newline files (e.g. on Windows)
+  for input, and to produce platform-appropriate line endings on output.
 
 Notes about all other separators:
 


### PR DESCRIPTION
https://johnkerl.org/miller6/reference-main-separators/#which-separators-apply-to-which-file-formats