### PR TITLE
Support DESTDIR when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ check:
 	go test -v
 
 install: build
-	cp mlr $(INSTALLDIR)
+	cp mlr $(DESTDIR)/$(INSTALLDIR)
 	make -C man install
 
 fmt:

--- a/man/Makefile
+++ b/man/Makefile
@@ -22,8 +22,8 @@ build: .always
 	cp mlr.1 ./man1
 
 install:
-	mkdir -p $(INSTALLDIR)
-	cp mlr.1 $(INSTALLDIR)/mlr.1
+	mkdir -p $(DESTDIR)/$(INSTALLDIR)
+	cp mlr.1 $(DESTDIR)/$(INSTALLDIR)/mlr.1
 
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
In autoconf-style builds, DESTDIR is used to install to somewhere
other than /; this is used in particular by packaging systems to
"install" to a staging area before archiving the package contents.

See https://www.gnu.org/prep/standards/html_node/DESTDIR.html for the
specification.

Signed-off-by: Stephen Kitt <steve@sk2.org>