### PR TITLE
Performance improvement for CSV-lite and DKVP

### DIFF
--- a/internal/pkg/input/record_reader_dkvp.go
+++ b/internal/pkg/input/record_reader_dkvp.go
@@ -124,13 +124,12 @@ func (reader *RecordReaderDKVP) recordFromDKVPLine(
 	for i, pair := range pairs {
 		var kv []string
 		if reader.readerOptions.IPSRegex == nil { // e.g. --no-ips-regex
-			kv = strings.SplitN(line, reader.readerOptions.IPS, 2)
+			kv = strings.SplitN(pair, reader.readerOptions.IPS, 2)
 		} else {
 			kv = lib.RegexSplitString(reader.readerOptions.IPSRegex, pair, 2)
 		}
 
-		// TODO check length 0. also, check input is empty since "".split() -> [""] not []
-		if len(kv) == 0 {
+		if len(kv) == 0 || (len(kv) == 1 && kv[0] == "") {
 			// Ignore. This is expected when splitting with repeated IFS.
 		} else if len(kv) == 1 {
 			// E.g the pair has no equals sign: "a" rather than "a=1" or

--- a/todo.txt
+++ b/todo.txt
@@ -55,6 +55,7 @@ PUNCHDOWN LIST
       k also prototyped for no-transformer case
       > how to structure this for the transformers?
       > do that after hiding
+    ! have an extra eye on CSV-reader perf
     - mprof split-reader getenv something
     - hide app-level scan/format under sys-level read/write: also batched
       easier/line-oriented:


### PR DESCRIPTION
DKVP before:

```$ justtime tmlr cat ~/tmp/big.dkvp | md5sum
TIME IN SECONDS 8.439 -- tmlr cat /Users/kerl/tmp/big.dkvp
c58c621055443f591f1ea914c3c5421f  -
```

DKVP after:

```
$ justtime mlr cat ~/tmp/big.dkvp | md5sum
TIME IN SECONDS 4.487 -- mlr cat /Users/kerl/tmp/big.dkvp
c58c621055443f591f1ea914c3c5421f  -
```

CSV-lite before:

```
$ justtime tmlr --csvlite cat ~/tmp/big.csv | md5sum
TIME IN SECONDS 5.661 -- tmlr --csvlite cat /Users/kerl/tmp/big.csv
8b9a5667759672170169a199653153b8  -
```

CSV-lite after:

```
$ justtime mlr --csvlite cat ~/tmp/big.csv | md5sum
TIME IN SECONDS 4.399 -- mlr --csvlite cat /Users/kerl/tmp/big.csv
8b9a5667759672170169a199653153b8  -
```