### PR TITLE
Copy-reduction performance in Mlrval.String()

### DIFF
--- a/internal/pkg/mlrval/mlrval_output.go
+++ b/internal/pkg/mlrval/mlrval_output.go
@@ -7,8 +7,11 @@ import (
 )
 
 // Must have non-pointer receiver in order to implement the fmt.Stringer
-// interface to make this printable via fmt.Println et al.
-func (mv Mlrval) String() string {
+// interface to make this printable via fmt.Println et al.  However, that
+// results in a needless copy of the Mlrval. So, we intentionally use pointer
+// receiver, and if we need to print to stdout, we can fmt.Printf with "%s" and
+// mv.String().
+func (mv *Mlrval) String() string {
 	// TODO: comment re deferral -- important perf effect!
 	// if mv.IsFloat() && floatOutputFormatter != nil
 	// if mv.mvtype == MT_FLOAT && floatOutputFormatter != nil {

--- a/scripts/chain-cmps.sh
+++ b/scripts/chain-cmps.sh
@@ -1,41 +1,9 @@
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    check \
-  | md5sum
-done
+mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
 
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    cat \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    head \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    tail \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    tac \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    sort -f shape \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "./mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    sort -n quantity \
-  | md5sum;
-done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv check |  md5sum;  done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv cat   |  md5sum;  done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv head  |  md5sum;  done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv tail  |  md5sum;  done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv tac   |  md5sum;  done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv sort -f shape    | md5sum; done
+echo; for mlr in $mlrs; do justtime $mlr --csv --from ~/tmp/big.csv sort -n quantity | md5sum; done

--- a/scripts/chain-lengths.sh
+++ b/scripts/chain-lengths.sh
@@ -1,36 +1,28 @@
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
+mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
+
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
     then put -f scripts/chain-1.mlr \
   | md5sum;
 done
 
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    then put -f scripts/chain-1.mlr \
-    then put -f scripts/chain-1.mlr \
-  | md5sum;
-done
-
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    then put -f scripts/chain-1.mlr \
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
   | md5sum;
 done
 
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    then put -f scripts/chain-1.mlr \
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
   | md5sum;
 done
 
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
-    then put -f scripts/chain-1.mlr \
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
@@ -38,8 +30,18 @@ echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
   | md5sum;
 done
 
-echo; for m in mlr5 ~/tmp/miller/mlr "mlr -S" mlr; do
-  justtime $m --csv --from ~/tmp/big.csv \
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
+    then put -f scripts/chain-1.mlr \
+    then put -f scripts/chain-1.mlr \
+    then put -f scripts/chain-1.mlr \
+    then put -f scripts/chain-1.mlr \
+    then put -f scripts/chain-1.mlr \
+  | md5sum;
+done
+
+echo; for mlr in $mlrs; do
+  justtime $mlr --csv --from ~/tmp/big.csv \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \
     then put -f scripts/chain-1.mlr \

--- a/scripts/time-big-files
+++ b/scripts/time-big-files
@@ -2,37 +2,12 @@
 
 ourdir=$(dirname $0)
 
-$ourdir/time-big-file dkvp    mlr5
-$ourdir/time-big-file dkvp    ~/tmp/miller/mlr
-$ourdir/time-big-file dkvp    'mlr -S'
-$ourdir/time-big-file dkvp    mlr
-echo
+mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
 
-$ourdir/time-big-file nidx    mlr5
-$ourdir/time-big-file nidx    ~/tmp/miller/mlr
-$ourdir/time-big-file nidx    'mlr -S'
-$ourdir/time-big-file nidx    mlr
-echo
+echo; for mlr in $mlrs; do $ourdir/time-big-file csv     $mlr; done
+echo; for mlr in $mlrs; do $ourdir/time-big-file csvlite $mlr; done
+echo; for mlr in $mlrs; do $ourdir/time-big-file dkvp    $mlr; done
+echo; for mlr in $mlrs; do $ourdir/time-big-file nidx    $mlr; done
+echo; for mlr in $mlrs; do $ourdir/time-big-file xtab    $mlr; done
+echo; for mlr in $mlrs; do $ourdir/time-big-file json    $mlr; done
 
-$ourdir/time-big-file xtab    mlr5
-$ourdir/time-big-file xtab    ~/tmp/miller/mlr
-$ourdir/time-big-file xtab    'mlr -S'
-$ourdir/time-big-file xtab    mlr
-echo
-
-$ourdir/time-big-file csv     mlr5
-$ourdir/time-big-file csv     ~/tmp/miller/mlr
-$ourdir/time-big-file csv     'mlr -S'
-$ourdir/time-big-file csv     mlr
-echo
-
-$ourdir/time-big-file csvlite mlr5
-$ourdir/time-big-file csvlite ~/tmp/miller/mlr
-$ourdir/time-big-file csvlite 'mlr -S'
-$ourdir/time-big-file csvlite mlr
-echo
-
-$ourdir/time-big-file json    mlr5
-$ourdir/time-big-file json    ~/tmp/miller/mlr
-$ourdir/time-big-file json    'mlr -S'
-$ourdir/time-big-file json    mlr

--- a/todo.txt
+++ b/todo.txt
@@ -2,6 +2,7 @@
 PUNCHDOWN LIST
 
 * blockers:
+  - more linux perf checks
   - mlr -O / abor!
   - --ifs-regex & --ips-regex -- guessing is not safe as evidence by '.' and '|'
   - big-picture item @ Rmd (csv memes; and beyond); also webdoc intro page


### PR DESCRIPTION
This is about another 20% performance improvement for anything with full-sized output -- e.g. `mlr --csv cat`.