### PR TITLE
Update perf-docs to include XTAB I/O improvement on #799

### DIFF
--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -470,7 +470,7 @@ See the [seprators page](reference-main-separators.md) regarding how to specify 
 
 ## NIDX: Index-numbered (toolkit style)
 
-With `--inidx --ifs ' ' --repifs`, Miller splits lines on whitespace and assigns integer field names starting with 1.
+With `--inidx --ifs ' ' --repifs`, Miller splits lines on spaces and assigns integer field names starting with 1.
 
 This recapitulates Unix-toolkit behavior.
 

--- a/docs/src/new-in-miller-6.md
+++ b/docs/src/new-in-miller-6.md
@@ -280,7 +280,7 @@ For the [first benchmark](https://github.com/johnkerl/miller/blob/main/scripts/t
 | CSV-lite | 1.671    | 1.428    | 1.17x   |
 | DKVP     | 2.485    | 2.040    | 1.22x   |
 | NIDX     | 1.638    | 1.468    | 1.12x   |
-| XTAB     | 5.147    | 6.252    | 0.82x   |
+| XTAB     | 5.147    | 2.184    | 2.35x   |
 | JSON     | 12.457   | 12.416   | 1.00x   |
 
 For the [second benchmark](https://github.com/johnkerl/miller/blob/main/scripts/chain-cmps.sh), the operations are varied:
@@ -308,7 +308,6 @@ For the [third benchmark](https://github.com/johnkerl/miller/blob/main/scripts/c
 Notes:
 
 * CSV processing is particularly improved in Miller 6.
-* Record I/O is improved for all but XTAB.
-* JSON continues to be a CPU-intensive format.
+* Record I/O is improved across the board, except that JSON continues to be a CPU-intensive format.
 * Miller 6's `sort` merits more performance analysis.
 * Longer then-chains benefit from Miller 6's [multicore approach](cpu.md).

--- a/docs/src/new-in-miller-6.md.in
+++ b/docs/src/new-in-miller-6.md.in
@@ -238,7 +238,7 @@ For the [first benchmark](https://github.com/johnkerl/miller/blob/main/scripts/t
 | CSV-lite | 1.671    | 1.428    | 1.17x   |
 | DKVP     | 2.485    | 2.040    | 1.22x   |
 | NIDX     | 1.638    | 1.468    | 1.12x   |
-| XTAB     | 5.147    | 6.252    | 0.82x   |
+| XTAB     | 5.147    | 2.184    | 2.35x   |
 | JSON     | 12.457   | 12.416   | 1.00x   |
 
 For the [second benchmark](https://github.com/johnkerl/miller/blob/main/scripts/chain-cmps.sh), the operations are varied:
@@ -266,7 +266,6 @@ For the [third benchmark](https://github.com/johnkerl/miller/blob/main/scripts/c
 Notes:
 
 * CSV processing is particularly improved in Miller 6.
-* Record I/O is improved for all but XTAB.
-* JSON continues to be a CPU-intensive format.
+* Record I/O is improved across the board, except that JSON continues to be a CPU-intensive format.
 * Miller 6's `sort` merits more performance analysis.
 * Longer then-chains benefit from Miller 6's [multicore approach](cpu.md).

--- a/docs/src/reference-main-number-formatting.md
+++ b/docs/src/reference-main-number-formatting.md
@@ -24,7 +24,7 @@ The command-line option `--ofmt {format string}` is the global number format for
 --ofmt %.9e --ofmt %.6f --ofmt %.0f
 </pre>
 
-These are just familiar `printf` formats.  (TODO: write about type-checking once that's implemented.) Additionally, if you use leading width (e.g. `%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr --opprint`) to column-align numerical data.
+These are just familiar `printf` formats. Additionally, if you use leading width (e.g. `%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr --opprint`) to column-align numerical data.
 
 <pre class="pre-highlight-in-pair">
 <b>echo 'x=3.1,y=4.3' | mlr --ofmt '%8.3f' cat</b>

--- a/todo.txt
+++ b/todo.txt
@@ -10,8 +10,6 @@ PUNCHDOWN LIST
   - 0b1011 olh/webdoc
   ? array/map fields: marshal as JSON_SINGLE_LINE
 
-* red-PR cmd/mprofs
-
 * shebang
   - olh -s & --norc; --version & --bare-version; --
   - maybe multiple -s -- ? []args would continue growing during parse ...


### PR DESCRIPTION
XTAB ingest is now notably faster than Miller 5 (~2.3x on my Mac).