### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
 
   # Maintain dependencies for Go 
   - package-ecosystem: "gomod"
-    directory: /go
+    directory: /
     schedule:
       interval: "daily"


### PR DESCRIPTION
Change the directory path to check for Go dependencies from /go to / now that the Go codebase has moved