### PR TITLE
Re-index mvtype to match sort-order

### DIFF
--- a/internal/pkg/bifs/arithmetic.go
+++ b/internal/pkg/bifs/arithmetic.go
@@ -10,17 +10,17 @@ import (
 // Unary plus operator
 
 var upos_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ _erro1,
 	/*INT    */ _1u___,
 	/*FLOAT  */ _1u___,
 	/*BOOL   */ _erro1,
+	/*VOID   */ _void1,
+	/*STRING */ _erro1,
 	/*ARRAY  */ _absn1,
 	/*MAP    */ _absn1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_plus_unary(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -39,17 +39,17 @@ func uneg_f_f(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var uneg_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ _erro1,
 	/*INT    */ uneg_i_i,
 	/*FLOAT  */ uneg_f_f,
 	/*BOOL   */ _erro1,
+	/*VOID   */ _void1,
+	/*STRING */ _erro1,
 	/*ARRAY  */ _absn1,
 	/*MAP    */ _absn1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_minus_unary(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -96,18 +96,18 @@ func plus_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var plus_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT        FLOAT      BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _null, _erro, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, plus_n_ii, plus_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, plus_f_fi, plus_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT        FLOAT      BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {plus_n_ii, plus_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {plus_f_fi, plus_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,     _erro,     _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,     _void,     _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,     _erro,     _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,     _absn,     _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,     _absn,     _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,     _erro,     _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,     _erro,     _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,     _2___,     _erro, _erro, _erro, _absn, _absn, _erro, _erro, _null, _absn},
+/*ABSENT */ {_2___,     _2___,     _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_plus_binary(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -154,18 +154,18 @@ func minus_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var minus_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT         FLOAT       BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _null, _erro, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, minus_n_ii, minus_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, minus_f_fi, minus_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT         FLOAT       BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {minus_n_ii, minus_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {minus_f_fi, minus_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,      _void,      _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,      _erro,      _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,      _2___,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _null, _absn},
+/*ABSENT */ {_2___,      _2___,      _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_minus_binary(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -228,18 +228,18 @@ func times_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var times_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT         FLOAT       BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _null, _erro, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, times_n_ii, times_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, times_f_fi, times_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT         FLOAT       BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {times_n_ii, times_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {times_f_fi, times_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,      _void,      _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,      _erro,      _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,      _2___,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _null, _absn},
+/*ABSENT */ {_2___,      _2___,      _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_times(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -299,18 +299,18 @@ func divide_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var divide_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT          FLOAT        BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, divide_n_ii, divide_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, divide_f_fi, divide_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT          FLOAT        BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {divide_n_ii, divide_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {divide_f_fi, divide_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,       _void,       _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,       _absn,       _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,       _absn,       _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,       _erro,       _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_i0__,       _f0__,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,       _f0__,       _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_divide(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -360,18 +360,18 @@ func int_divide_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var int_divide_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT              FLOAT            BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, int_divide_n_ii, int_divide_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, int_divide_f_fi, int_divide_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT              FLOAT            BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {int_divide_n_ii, int_divide_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {int_divide_f_fi, int_divide_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,           _void,           _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,           _absn,           _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,           _absn,           _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,           _erro,           _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,           _f0__,           _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_int_divide(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -396,18 +396,18 @@ func dotplus_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dot_plus_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT           FLOAT         BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _null, _erro, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, dotplus_i_ii, dotplus_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, dotplus_f_fi, dotplus_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT           FLOAT         BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dotplus_i_ii, dotplus_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {dotplus_f_fi, dotplus_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,        _void,        _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,        _absn,        _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,        _absn,        _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,        _erro,        _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,        _2___,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _null, _absn},
+/*ABSENT */ {_2___,        _2___,        _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_dot_plus(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -432,18 +432,18 @@ func dotminus_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dotminus_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT            FLOAT          BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _n2__, _n2__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _null, _erro, _erro, _n2__, _n2__, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, dotminus_i_ii, dotminus_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, dotminus_f_fi, dotminus_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT            FLOAT          BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dotminus_i_ii, dotminus_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {dotminus_f_fi, dotminus_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,         _void,         _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,         _absn,         _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,         _absn,         _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,         _erro,         _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_n2__,         _n2__,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _null, _absn},
+/*ABSENT */ {_n2__,         _n2__,         _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_dot_minus(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -468,18 +468,18 @@ func dottimes_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dottimes_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT            FLOAT          BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _void, _erro, dottimes_i_ii, dottimes_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _void, _erro, dottimes_f_fi, dottimes_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT            FLOAT          BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dottimes_i_ii, dottimes_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {dottimes_f_fi, dottimes_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,         _void,         _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,         _absn,         _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,         _absn,         _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,         _erro,         _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,         _erro,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,         _2___,         _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,         _2___,         _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_dot_times(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -504,18 +504,18 @@ func dotdivide_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dotdivide_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT             FLOAT           BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, dotdivide_i_ii, dotdivide_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, dotdivide_f_fi, dotdivide_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT             FLOAT           BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dotdivide_i_ii, dotdivide_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {dotdivide_f_fi, dotdivide_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,          _erro,          _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,          _void,          _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,          _erro,          _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,          _absn,          _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,          _absn,          _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,          _erro,          _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,          _erro,          _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,          _erro,          _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,          _2___,          _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_dot_divide(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -565,18 +565,18 @@ func dotidivide_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dotidivide_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT              FLOAT            BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _erro, _absn, _erro, _2___, _2___, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, dotidivide_i_ii, dotidivide_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, dotidivide_f_fi, dotidivide_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT              FLOAT            BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dotidivide_i_ii, dotidivide_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {dotidivide_f_fi, dotidivide_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,           _void,           _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,           _absn,           _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,           _absn,           _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,           _erro,           _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,           _erro,           _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,           _2___,           _erro, _absn, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
 }
 
 func BIF_dot_int_divide(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -629,18 +629,18 @@ func modulus_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var modulus_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT           FLOAT         BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, modulus_i_ii, modulus_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, modulus_f_fi, modulus_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT           FLOAT         BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {modulus_i_ii, modulus_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {modulus_f_fi, modulus_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,        _void,        _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,        _absn,        _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,        _absn,        _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,        _erro,        _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,        _erro,        _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,        _f0__,        _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_modulus(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -801,18 +801,18 @@ func min_s_ss(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var min_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING    INT       FLOAT     BOOL      ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _null, _2___, _2___, _2___, _2___, _2___, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _null, _null, _2___, _2___, _2___, _2___, _2___, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _1___, _1___, _void, _void, _2___, _2___, _2___, _absn, _absn, _erro},
-	/*STRING */ {_erro, _1___, _1___, _void, min_s_ss, _2___, _2___, _2___, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _1___, _1___, _1___, min_i_ii, min_f_if, _1___, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _1___, _1___, _1___, min_f_fi, min_f_ff, _1___, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _1___, _1___, _1___, _1___, _2___, _2___, min_b_bb, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT       FLOAT     BOOL      VOID   STRING    ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {min_i_ii, min_f_if, _1___,    _1___, _1___,    _absn, _absn, _erro, _erro, _1___, _1___},
+/*FLOAT  */ {min_f_fi, min_f_ff, _1___,    _1___, _1___,    _absn, _absn, _erro, _erro, _1___, _1___},
+/*BOOL   */ {_2___,    _2___,    min_b_bb, _1___, _1___,    _absn, _absn, _erro, _erro, _1___, _1___},
+/*VOID   */ {_2___,    _2___,    _2___,    _void, _void,    _absn, _absn, _erro, _erro, _1___, _1___},
+/*STRING */ {_2___,    _2___,    _2___,    _void, min_s_ss, _absn, _absn, _erro, _erro, _1___, _1___},
+/*ARRAY  */ {_absn,    _absn,    _absn,    _absn, _absn,    _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,    _absn,    _absn,    _absn, _absn,    _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,    _erro,    _erro,    _erro, _erro,    _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,    _erro,    _erro,    _erro, _erro,    _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_2___,    _2___,    _2___,    _2___, _2___,    _absn, _absn, _erro, _erro, _null, _null},
+/*ABSENT */ {_2___,    _2___,    _2___,    _2___, _2___,    _absn, _absn, _erro, _erro, _null, _absn},
 }
 
 func BIF_min_binary(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -885,18 +885,18 @@ func max_s_ss(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var max_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING    INT       FLOAT     BOOL      ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _null, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _2___, _2___, _2___, _2___, _2___, _absn, _absn, _erro},
-	/*NULL   */ {_null, _absn, _null, _null, _null, _null, _null, _null, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _1___, _null, _void, _2___, _1___, _1___, _1___, _absn, _absn, _erro},
-	/*STRING */ {_erro, _1___, _null, _1___, max_s_ss, _1___, _1___, _1___, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _null, _2___, _2___, max_i_ii, max_f_if, _2___, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _null, _2___, _2___, max_f_fi, max_f_ff, _2___, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _1___, _null, _2___, _2___, _1___, _1___, max_b_bb, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT       FLOAT     BOOL      VOID   STRING    ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {max_i_ii, max_f_if, _2___,    _2___, _2___,    _absn, _absn, _erro, _erro, _null, _1___},
+/*FLOAT  */ {max_f_fi, max_f_ff, _2___,    _2___, _2___,    _absn, _absn, _erro, _erro, _null, _1___},
+/*BOOL   */ {_1___,    _1___,    max_b_bb, _2___, _2___,    _absn, _absn, _erro, _erro, _null, _1___},
+/*VOID   */ {_1___,    _1___,    _1___,    _void, _2___,    _absn, _absn, _erro, _erro, _null, _1___},
+/*STRING */ {_1___,    _1___,    _1___,    _1___, max_s_ss, _absn, _absn, _erro, _erro, _null, _1___},
+/*ARRAY  */ {_absn,    _absn,    _absn,    _absn, _absn,    _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,    _absn,    _absn,    _absn, _absn,    _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,    _erro,    _erro,    _erro, _erro,    _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,    _erro,    _erro,    _erro, _erro,    _absn, _absn, _erro, _erro, _null, _erro},
+/*NULL   */ {_null,    _null,    _null,    _null, _null,    _absn, _absn, _erro, _null, _null, _absn},
+/*ABSENT */ {_2___,    _2___,    _2___,    _2___, _2___,    _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_max_binary(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/bifs/bits.go
+++ b/internal/pkg/bifs/bits.go
@@ -12,17 +12,17 @@ func bitwise_not_i_i(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var bitwise_not_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ _erro1,
 	/*INT    */ bitwise_not_i_i,
 	/*FLOAT  */ _erro1,
 	/*BOOL   */ _erro1,
+	/*VOID   */ _void1,
+	/*STRING */ _erro1,
 	/*ARRAY  */ _absn1,
 	/*MAP    */ _absn1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_bitwise_not(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -52,17 +52,17 @@ func bitcount_i_i(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var bitcount_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _zero1,
-	/*VOID   */ _void1,
-	/*STRING */ _erro1,
 	/*INT    */ bitcount_i_i,
 	/*FLOAT  */ _erro1,
 	/*BOOL   */ _erro1,
+	/*VOID   */ _void1,
+	/*STRING */ _erro1,
 	/*ARRAY  */ _absn1,
 	/*MAP    */ _absn1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _zero1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_bitcount(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -77,18 +77,18 @@ func bitwise_and_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var bitwise_and_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT               FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, bitwise_and_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT               FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {bitwise_and_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,            _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,            _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,            _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,            _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,            _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,            _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,            _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_bitwise_and(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -103,18 +103,18 @@ func bitwise_or_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var bitwise_or_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT              FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, bitwise_or_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT              FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {bitwise_or_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,           _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,           _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,           _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,           _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,           _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,           _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,           _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,           _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,           _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,           _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_bitwise_or(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -129,18 +129,18 @@ func bitwise_xor_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var bitwise_xor_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT               FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, bitwise_xor_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT               FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {bitwise_xor_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,            _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,            _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,            _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*MAP    */ {_absn,            _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _absn, _absn},
+/*FUNC   */ {_erro,            _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,            _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,            _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,            _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_bitwise_xor(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -155,18 +155,18 @@ func lsh_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var left_shift_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT       FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, lsh_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT       FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {lsh_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,    _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,    _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,    _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,    _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,    _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,    _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,    _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,    _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,    _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,    _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_left_shift(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -181,18 +181,18 @@ func srsh_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var signed_right_shift_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT        FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, srsh_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT        FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {srsh_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,     _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,     _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,     _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,     _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,     _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,     _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,     _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_signed_right_shift(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -210,18 +210,18 @@ func ursh_i_ii(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var unsigned_right_shift_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT        FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _2___, _erro, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, ursh_i_ii, _erro, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _erro, _erro, _void, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT        FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {ursh_i_ii, _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {_erro,     _erro, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*BOOL   */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,     _void, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,     _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,     _absn, _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,     _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,     _erro, _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,     _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_2___,     _erro, _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_unsigned_right_shift(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/bifs/booleans.go
+++ b/internal/pkg/bifs/booleans.go
@@ -271,109 +271,109 @@ var eq_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{}
 
 func init() {
 	eq_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-		//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY    MAP FUNC
+		//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY    MAP      FUNC    ERROR   NULL   ABSENT
+		/*INT    */ {eq_b_ii, eq_b_if, _fals, eq_b_xs, eq_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+		/*FLOAT  */ {eq_b_fi, eq_b_ff, _fals, eq_b_xs, eq_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+		/*BOOL   */ {_fals, _fals, eq_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _fals, _absn},
+		/*VOID   */ {eq_b_sx, eq_b_sx, _fals, eq_b_ss, eq_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+		/*STRING */ {eq_b_sx, eq_b_sx, _fals, eq_b_ss, eq_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+		/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, eq_b_aa, _fals, _erro, _erro, _fals, _absn},
+		/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, eq_b_mm, _erro, _erro, _fals, _absn},
+		/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
 		/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-		/*ABSENT */ {_erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-		/*NULL   */ {_erro, _absn, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _erro},
-		/*VOID   */ {_erro, _absn, _fals, eq_b_ss, eq_b_ss, eq_b_sx, eq_b_sx, _fals, _fals, _fals, _erro},
-		/*STRING */ {_erro, _absn, _fals, eq_b_ss, eq_b_ss, eq_b_sx, eq_b_sx, _fals, _fals, _fals, _erro},
-		/*INT    */ {_erro, _absn, _fals, eq_b_xs, eq_b_xs, eq_b_ii, eq_b_if, _fals, _fals, _fals, _erro},
-		/*FLOAT  */ {_erro, _absn, _fals, eq_b_xs, eq_b_xs, eq_b_fi, eq_b_ff, _fals, _fals, _fals, _erro},
-		/*BOOL   */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, eq_b_bb, _fals, _fals, _erro},
-		/*ARRAY  */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, eq_b_aa, _fals, _erro},
-		/*MAP    */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _fals, eq_b_mm, _erro},
-		/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+		/*NULL   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _true, _absn},
+		/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _absn, _absn},
 	}
 }
 
 var ne_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY    MAP FUNC
+	//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY    MAP      FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {ne_b_ii, ne_b_if, _true, ne_b_xs, ne_b_xs, _true, _true, _erro, _erro, _true, _absn},
+	/*FLOAT  */ {ne_b_fi, ne_b_ff, _true, ne_b_xs, ne_b_xs, _true, _true, _erro, _erro, _true, _absn},
+	/*BOOL   */ {_true, _true, ne_b_bb, _true, _true, _true, _true, _erro, _erro, _true, _absn},
+	/*VOID   */ {ne_b_sx, ne_b_sx, _true, ne_b_ss, ne_b_ss, _true, _true, _erro, _erro, _true, _absn},
+	/*STRING */ {ne_b_sx, ne_b_sx, _true, ne_b_ss, ne_b_ss, _true, _true, _erro, _erro, _true, _absn},
+	/*ARRAY  */ {_true, _true, _true, _true, _true, ne_b_aa, _true, _erro, _erro, _true, _absn},
+	/*MAP    */ {_true, _true, _true, _true, _true, _true, ne_b_mm, _erro, _erro, _true, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
 	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _fals, _true, _true, _true, _true, _true, _true, _true, _erro},
-	/*VOID   */ {_erro, _absn, _true, ne_b_ss, ne_b_ss, ne_b_sx, ne_b_sx, _true, _true, _true, _erro},
-	/*STRING */ {_erro, _absn, _true, ne_b_ss, ne_b_ss, ne_b_sx, ne_b_sx, _true, _true, _true, _erro},
-	/*INT    */ {_erro, _absn, _true, ne_b_xs, ne_b_xs, ne_b_ii, ne_b_if, _true, _true, _true, _erro},
-	/*FLOAT  */ {_erro, _absn, _true, ne_b_xs, ne_b_xs, ne_b_fi, ne_b_ff, _true, _true, _true, _erro},
-	/*BOOL   */ {_erro, _absn, _true, _true, _true, _true, _true, ne_b_bb, _true, _true, _erro},
-	/*ARRAY  */ {_erro, _absn, _true, _true, _true, _true, _true, _true, ne_b_aa, _true, _erro},
-	/*MAP    */ {_erro, _absn, _true, _true, _true, _true, _true, _true, _true, ne_b_mm, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*NULL   */ {_true, _true, _true, _true, _true, _true, _true, _erro, _erro, _fals, _absn},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 var gt_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP FUNC
-	/*ERROR  */ {_erro, _erro, _fals, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _true, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_true, _fals, _fals, _true, _true, _true, _true, _true, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _fals, gt_b_ss, gt_b_ss, gt_b_sx, gt_b_sx, _fals, _fals, _fals, _erro},
-	/*STRING */ {_erro, _absn, _fals, gt_b_ss, gt_b_ss, gt_b_sx, gt_b_sx, _fals, _fals, _fals, _erro},
-	/*INT    */ {_erro, _absn, _fals, gt_b_xs, gt_b_xs, gt_b_ii, gt_b_if, _fals, _fals, _fals, _erro},
-	/*FLOAT  */ {_erro, _absn, _fals, gt_b_xs, gt_b_xs, gt_b_fi, gt_b_ff, _fals, _fals, _fals, _erro},
-	/*BOOL   */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, gt_b_bb, _fals, _fals, _erro},
-	/*ARRAY  */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro},
-	/*MAP    */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {gt_b_ii, gt_b_if, _fals, gt_b_xs, gt_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*FLOAT  */ {gt_b_fi, gt_b_ff, _fals, gt_b_xs, gt_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*BOOL   */ {_fals, _fals, gt_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*VOID   */ {gt_b_sx, gt_b_sx, _fals, gt_b_ss, gt_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*STRING */ {gt_b_sx, gt_b_sx, _fals, gt_b_ss, gt_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro, _erro, _fals, _absn},
+	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _erro, _fals, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _fals, _erro},
+	/*NULL   */ {_true, _true, _true, _true, _true, _absn, _absn, _erro, _true, _fals, _fals},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _true, _absn},
 }
 
 var ge_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _fals, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _true, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_true, _fals, _true, _true, _true, _true, _true, _true, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _fals, ge_b_ss, ge_b_ss, ge_b_sx, ge_b_sx, _fals, _fals, _fals, _erro},
-	/*STRING */ {_erro, _absn, _fals, ge_b_ss, ge_b_ss, ge_b_sx, ge_b_sx, _fals, _fals, _fals, _erro},
-	/*INT    */ {_erro, _absn, _fals, ge_b_xs, ge_b_xs, ge_b_ii, ge_b_if, _fals, _fals, _fals, _erro},
-	/*FLOAT  */ {_erro, _absn, _fals, ge_b_xs, ge_b_xs, ge_b_fi, ge_b_ff, _fals, _fals, _fals, _erro},
-	/*BOOL   */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, ge_b_bb, _fals, _fals, _erro},
-	/*ARRAY  */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro},
-	/*MAP    */ {_erro, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {ge_b_ii, ge_b_if, _fals, ge_b_xs, ge_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*FLOAT  */ {ge_b_fi, ge_b_ff, _fals, ge_b_xs, ge_b_xs, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*BOOL   */ {_fals, _fals, ge_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*VOID   */ {ge_b_sx, ge_b_sx, _fals, ge_b_ss, ge_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*STRING */ {ge_b_sx, ge_b_sx, _fals, ge_b_ss, ge_b_ss, _fals, _fals, _erro, _erro, _fals, _absn},
+	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro, _erro, _fals, _absn},
+	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _erro, _fals, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _fals, _erro},
+	/*NULL   */ {_true, _true, _true, _true, _true, _absn, _absn, _erro, _true, _true, _fals},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _true, _absn},
 }
 
 var lt_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _true, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _fals, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _true, lt_b_ss, lt_b_ss, lt_b_sx, lt_b_sx, _fals, _fals, _fals, _erro},
-	/*STRING */ {_erro, _absn, _true, lt_b_ss, lt_b_ss, lt_b_sx, lt_b_sx, _fals, _fals, _fals, _erro},
-	/*INT    */ {_erro, _absn, _true, lt_b_xs, lt_b_xs, lt_b_ii, lt_b_if, _fals, _fals, _fals, _erro},
-	/*FLOAT  */ {_erro, _absn, _true, lt_b_xs, lt_b_xs, lt_b_fi, lt_b_ff, _fals, _fals, _fals, _erro},
-	/*BOOL   */ {_erro, _absn, _true, _fals, _fals, _fals, _fals, lt_b_bb, _fals, _fals, _erro},
-	/*ARRAY  */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro},
-	/*MAP    */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {lt_b_ii, lt_b_if, _fals, lt_b_xs, lt_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*FLOAT  */ {lt_b_fi, lt_b_ff, _fals, lt_b_xs, lt_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*BOOL   */ {_fals, _fals, lt_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _true, _absn},
+	/*VOID   */ {lt_b_sx, lt_b_sx, _fals, lt_b_ss, lt_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*STRING */ {lt_b_sx, lt_b_sx, _fals, lt_b_ss, lt_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro, _erro, _absn, _absn},
+	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _erro, _absn, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _true, _erro},
+	/*NULL   */ {_fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro, _fals, _fals, _true},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _fals, _absn},
 }
 
 var le_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _true, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _fals, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_fals, _true, _true, _fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _true, le_b_ss, le_b_ss, le_b_sx, le_b_sx, _fals, _fals, _fals, _erro},
-	/*STRING */ {_erro, _absn, _true, le_b_ss, le_b_ss, le_b_sx, le_b_sx, _fals, _fals, _fals, _erro},
-	/*INT    */ {_erro, _absn, _true, le_b_xs, le_b_xs, le_b_ii, le_b_if, _fals, _fals, _fals, _erro},
-	/*FLOAT  */ {_erro, _absn, _true, le_b_xs, le_b_xs, le_b_fi, le_b_ff, _fals, _fals, _fals, _erro},
-	/*BOOL   */ {_erro, _absn, _true, _fals, _fals, _fals, _fals, le_b_bb, _fals, _fals, _erro},
-	/*ARRAY  */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro},
-	/*MAP    */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {le_b_ii, le_b_if, _fals, le_b_xs, le_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*FLOAT  */ {le_b_fi, le_b_ff, _fals, le_b_xs, le_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*BOOL   */ {_fals, _fals, le_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _true, _absn},
+	/*VOID   */ {le_b_sx, le_b_sx, _fals, le_b_ss, le_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*STRING */ {le_b_sx, le_b_sx, _fals, le_b_ss, le_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro, _erro, _absn, _absn},
+	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _erro, _absn, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _true, _erro},
+	/*NULL   */ {_fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro, _fals, _true, _true},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _fals, _absn},
 }
 
 var cmp_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID      STRING    INT       FLOAT     BOOL      ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _true, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _fals, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*NULL   */ {_fals, _true, _true, _fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _absn, _true, cmp_b_ss, cmp_b_ss, cmp_b_sx, cmp_b_sx, _fals, _fals, _fals, _erro},
-	/*STRING */ {_erro, _absn, _true, cmp_b_ss, cmp_b_ss, cmp_b_sx, cmp_b_sx, _fals, _fals, _fals, _erro},
-	/*INT    */ {_erro, _absn, _true, cmp_b_xs, cmp_b_xs, cmp_b_ii, cmp_b_if, _fals, _fals, _fals, _erro},
-	/*FLOAT  */ {_erro, _absn, _true, cmp_b_xs, cmp_b_xs, cmp_b_fi, cmp_b_ff, _fals, _fals, _fals, _erro},
-	/*BOOL   */ {_erro, _absn, _true, _fals, _fals, _fals, _fals, cmp_b_bb, _fals, _fals, _erro},
-	/*ARRAY  */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro},
-	/*MAP    */ {_erro, _absn, _absn, _fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	//       .  INT       FLOAT     BOOL      VOID      STRING    ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+	/*INT    */ {cmp_b_ii, cmp_b_if, _fals, cmp_b_xs, cmp_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*FLOAT  */ {cmp_b_fi, cmp_b_ff, _fals, cmp_b_xs, cmp_b_xs, _fals, _fals, _erro, _erro, _true, _absn},
+	/*BOOL   */ {_fals, _fals, cmp_b_bb, _fals, _fals, _fals, _fals, _erro, _erro, _true, _absn},
+	/*VOID   */ {cmp_b_sx, cmp_b_sx, _fals, cmp_b_ss, cmp_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*STRING */ {cmp_b_sx, cmp_b_sx, _fals, cmp_b_ss, cmp_b_ss, _fals, _fals, _erro, _erro, _true, _absn},
+	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _erro, _fals, _erro, _erro, _absn, _absn},
+	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _erro, _erro, _erro, _absn, _absn},
+	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _true, _erro},
+	/*NULL   */ {_fals, _fals, _fals, _fals, _fals, _absn, _absn, _erro, _fals, _true, _true},
+	/*ABSENT */ {_absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _fals, _absn},
 }
 
 func BIF_equals(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -396,54 +396,6 @@ func BIF_less_than_or_equals(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 func BIF_cmp(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	return cmp_dispositions[input1.Type()][input2.Type()](input1, input2)
-}
-
-// For Go's sort.Slice.
-func BIF_less_than_as_bool(input1, input2 *mlrval.Mlrval) bool {
-	// TODO refactor to avoid copy
-	// This is a hot path for sort GC and is worth significant hand-optimization
-	mretval := lt_dispositions[input1.Type()][input2.Type()](input1, input2)
-	retval, ok := mretval.GetBoolValue()
-	lib.InternalCodingErrorIf(!ok)
-	return retval
-}
-
-// For Go's sort.Slice.
-func BIF_less_than_or_equals_as_bool(input1, input2 *mlrval.Mlrval) bool {
-	// TODO refactor to avoid copy
-	// This is a hot path for sort GC and is worth significant hand-optimization
-	mretval := le_dispositions[input1.Type()][input2.Type()](input1, input2)
-	retval, ok := mretval.GetBoolValue()
-	lib.InternalCodingErrorIf(!ok)
-	return retval
-}
-
-// For top-keeper
-func BIF_greater_than_as_bool(input1, input2 *mlrval.Mlrval) bool {
-	// TODO refactor to avoid copy
-	// This is a hot path for sort GC and is worth significant hand-optimization
-	mretval := gt_dispositions[input1.Type()][input2.Type()](input1, input2)
-	retval, ok := mretval.GetBoolValue()
-	lib.InternalCodingErrorIf(!ok)
-	return retval
-}
-
-// For top-keeper
-func BIF_greater_than_or_equals_as_bool(input1, input2 *mlrval.Mlrval) bool {
-	// TODO refactor to avoid copy
-	// This is a hot path for sort GC and is worth significant hand-optimization
-	mretval := ge_dispositions[input1.Type()][input2.Type()](input1, input2)
-	retval, ok := mretval.GetBoolValue()
-	lib.InternalCodingErrorIf(!ok)
-	return retval
-}
-
-// Convenience wrapper for non-DSL callsites that just want a bool
-func BIF_equals_as_bool(input1, input2 *mlrval.Mlrval) bool {
-	mretval := eq_dispositions[input1.Type()][input2.Type()](input1, input2)
-	retval, ok := mretval.GetBoolValue()
-	lib.InternalCodingErrorIf(!ok)
-	return retval
 }
 
 // ----------------------------------------------------------------

--- a/internal/pkg/bifs/collections.go
+++ b/internal/pkg/bifs/collections.go
@@ -71,17 +71,17 @@ var depth_dispositions = [mlrval.MT_DIM]UnaryFunc{}
 
 func init() {
 	depth_dispositions = [mlrval.MT_DIM]UnaryFunc{
-		/*ERROR  */ _erro1,
-		/*ABSENT */ _absn1,
-		/*NULL   */ _zero1,
-		/*VOID   */ depth_from_scalar,
-		/*STRING */ depth_from_scalar,
 		/*INT    */ depth_from_scalar,
 		/*FLOAT  */ depth_from_scalar,
 		/*BOOL   */ depth_from_scalar,
+		/*VOID   */ depth_from_scalar,
+		/*STRING */ depth_from_scalar,
 		/*ARRAY  */ depth_from_array,
 		/*MAP    */ depth_from_map,
 		/*FUNC   */ _erro1,
+		/*ERROR  */ _erro1,
+		/*NULL   */ _zero1,
+		/*ABSENT */ _absn1,
 	}
 }
 
@@ -139,17 +139,17 @@ func leafcount_from_scalar(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var leafcount_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _zero1,
-	/*VOID   */ leafcount_from_scalar,
-	/*STRING */ leafcount_from_scalar,
 	/*INT    */ leafcount_from_scalar,
 	/*FLOAT  */ leafcount_from_scalar,
 	/*BOOL   */ leafcount_from_scalar,
+	/*VOID   */ leafcount_from_scalar,
+	/*STRING */ leafcount_from_scalar,
 	/*ARRAY  */ leafcount_from_array,
 	/*MAP    */ leafcount_from_map,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _zero1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_leafcount(input1 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/bifs/mathlib.go
+++ b/internal/pkg/bifs/mathlib.go
@@ -45,17 +45,17 @@ func math_unary_f_f(input1 *mlrval.Mlrval, f mathLibUnaryFunc) *mlrval.Mlrval {
 
 // Disposition vector for unary mathlib functions
 var mudispo = [mlrval.MT_DIM]mathLibUnaryFuncWrapper{
-	/*ERROR  */ _math_unary_erro1,
-	/*ABSENT */ _math_unary_absn1,
-	/*NULL   */ _math_unary_null1,
-	/*VOID   */ _math_unary_void1,
-	/*STRING */ _math_unary_erro1,
 	/*INT    */ math_unary_f_i,
 	/*FLOAT  */ math_unary_f_f,
 	/*BOOL   */ _math_unary_erro1,
+	/*VOID   */ _math_unary_void1,
+	/*STRING */ _math_unary_erro1,
 	/*ARRAY  */ _math_unary_absn1,
 	/*MAP    */ _math_unary_absn1,
 	/*FUNC   */ _math_unary_erro1,
+	/*ERROR  */ _math_unary_erro1,
+	/*NULL   */ _math_unary_null1,
+	/*ABSENT */ _math_unary_absn1,
 }
 
 func BIF_acos(input1 *mlrval.Mlrval) *mlrval.Mlrval { return mudispo[input1.Type()](input1, math.Acos) }
@@ -100,17 +100,17 @@ func BIF_tanh(input1 *mlrval.Mlrval) *mlrval.Mlrval { return mudispo[input1.Type
 
 // Disposition vector for unary mathlib functions which are int-preserving
 var imudispo = [mlrval.MT_DIM]mathLibUnaryFuncWrapper{
-	/*ERROR  */ _math_unary_erro1,
-	/*ABSENT */ _math_unary_absn1,
-	/*NULL   */ _math_unary_null1,
-	/*VOID   */ _math_unary_void1,
-	/*STRING */ _math_unary_erro1,
 	/*INT    */ math_unary_i_i,
 	/*FLOAT  */ math_unary_f_f,
 	/*BOOL   */ _math_unary_erro1,
+	/*VOID   */ _math_unary_void1,
+	/*STRING */ _math_unary_erro1,
 	/*ARRAY  */ _math_unary_absn1,
 	/*MAP    */ _math_unary_absn1,
 	/*FUNC   */ _math_unary_erro1,
+	/*ERROR  */ _math_unary_erro1,
+	/*NULL   */ _math_unary_null1,
+	/*ABSENT */ _math_unary_absn1,
 }
 
 // Int-preserving
@@ -151,18 +151,18 @@ func pow_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var pow_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT       FLOAT     BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, pow_f_ii, pow_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, pow_f_fi, pow_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT       FLOAT     BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {pow_f_ii, pow_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {pow_f_fi, pow_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,    _erro,    _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,    _void,    _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,    _erro,    _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,    _absn,    _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,    _absn,    _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,    _erro,    _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,    _erro,    _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,    _erro,    _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,    _f0__,    _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_pow(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -184,18 +184,18 @@ func atan2_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var atan2_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT         FLOAT       BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, atan2_f_ii, atan2_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, atan2_f_fi, atan2_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT         FLOAT       BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {atan2_f_ii, atan2_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {atan2_f_fi, atan2_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,      _void,      _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,      _absn,      _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,      _erro,      _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,      _erro,      _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,      _erro,      _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,      _f0__,      _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_atan2(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -221,18 +221,18 @@ func roundm_f_ff(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var roundm_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT          FLOAT        BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _erro, _i0__, _f0__, _erro, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _void, _erro, _void, _void, _erro, _absn, _absn, _erro},
-	/*STRING */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*INT    */ {_erro, _1___, _erro, _void, _erro, roundm_f_ii, roundm_f_if, _erro, _absn, _absn, _erro},
-	/*FLOAT  */ {_erro, _1___, _erro, _void, _erro, roundm_f_fi, roundm_f_ff, _erro, _absn, _absn, _erro},
-	/*BOOL   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ARRAY  */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*MAP    */ {_absn, _absn, _erro, _absn, _absn, _absn, _absn, _absn, _absn, _absn, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT          FLOAT        BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {roundm_f_ii, roundm_f_if, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*FLOAT  */ {roundm_f_fi, roundm_f_ff, _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _1___},
+/*BOOL   */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*VOID   */ {_void,       _void,       _erro, _void, _erro, _absn, _absn, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*ARRAY  */ {_absn,       _absn,       _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*MAP    */ {_absn,       _absn,       _absn, _absn, _absn, _absn, _absn, _erro, _absn, _erro, _absn},
+/*FUNC   */ {_erro,       _erro,       _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,       _erro,       _erro, _erro, _erro, _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro,       _erro,       _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_i0__,       _f0__,       _erro, _absn, _erro, _absn, _absn, _erro, _erro, _absn, _absn},
 }
 
 func BIF_roundm(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/bifs/sort.go
+++ b/internal/pkg/bifs/sort.go
@@ -168,18 +168,18 @@ func _xcmp(input1, input2 *mlrval.Mlrval) int {
 
 // typed_cmp_dispositions is the disposition matrix for numerical sorting of Mlrvals.
 var typed_cmp_typedpositions = [mlrval.MT_DIM][mlrval.MT_DIM]ComparatorFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING INT    FLOAT  BOOL   ARRAY  MAP     FUNC
-	/*ERROR  */ {_zero, _neg1, _neg1, _pos1, _pos1, _pos1, _pos1, _pos1, _zero, _zero, _xcmp},
-	/*ABSENT */ {_pos1, _zero, _pos1, _pos1, _pos1, _pos1, _pos1, _pos1, _zero, _zero, _xcmp},
-	/*NULL   */ {_pos1, _neg1, _zero, _pos1, _pos1, _pos1, _pos1, _pos1, _pos1, _pos1, _xcmp},
-	/*VOID   */ {_neg1, _neg1, _neg1, _scmp, _scmp, _pos1, _pos1, _pos1, _zero, _zero, _xcmp},
-	/*STRING */ {_neg1, _neg1, _neg1, _scmp, _scmp, _pos1, _pos1, _pos1, _zero, _zero, _xcmp},
-	/*INT    */ {_neg1, _neg1, _neg1, _neg1, _neg1, iicmp, ifcmp, _neg1, _zero, _zero, _xcmp},
-	/*FLOAT  */ {_neg1, _neg1, _neg1, _neg1, _neg1, ficmp, ffcmp, _neg1, _zero, _zero, _xcmp},
-	/*BOOL   */ {_neg1, _neg1, _neg1, _neg1, _neg1, _pos1, _pos1, bbcmp, _zero, _zero, _xcmp},
-	/*ARRAY  */ {_zero, _zero, _neg1, _zero, _zero, _zero, _zero, _zero, _zero, _zero, _xcmp},
-	/*MAP    */ {_zero, _zero, _neg1, _zero, _zero, _zero, _zero, _zero, _zero, _zero, _xcmp},
-	/*FUNC    */ {_xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp},
+//       .  INT    FLOAT  BOOL   VOID   STRING ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {iicmp, ifcmp, _neg1, _neg1, _neg1, _zero, _zero, _xcmp, _neg1, _neg1, _neg1},
+/*FLOAT  */ {ficmp, ffcmp, _neg1, _neg1, _neg1, _zero, _zero, _xcmp, _neg1, _neg1, _neg1},
+/*BOOL   */ {_pos1, _pos1, bbcmp, _neg1, _neg1, _zero, _zero, _xcmp, _neg1, _neg1, _neg1},
+/*VOID   */ {_pos1, _pos1, _pos1, _scmp, _scmp, _zero, _zero, _xcmp, _neg1, _neg1, _neg1},
+/*STRING */ {_pos1, _pos1, _pos1, _scmp, _scmp, _zero, _zero, _xcmp, _neg1, _neg1, _neg1},
+/*ARRAY  */ {_zero, _zero, _zero, _zero, _zero, _zero, _zero, _xcmp, _zero, _neg1, _zero},
+/*MAP    */ {_zero, _zero, _zero, _zero, _zero, _zero, _zero, _xcmp, _zero, _neg1, _zero},
+/*FUNC   */ {_xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp, _xcmp},
+/*ERROR  */ {_pos1, _pos1, _pos1, _pos1, _pos1, _zero, _zero, _xcmp, _zero, _neg1, _neg1},
+/*NULL   */ {_pos1, _pos1, _pos1, _pos1, _pos1, _pos1, _pos1, _xcmp, _pos1, _zero, _neg1},
+/*ABSENT */ {_pos1, _pos1, _pos1, _pos1, _pos1, _zero, _zero, _xcmp, _pos1, _pos1, _zero},
 }
 
 // NumericAscendingComparator is for "numerical" sort: it uses Mlrval sorting

--- a/internal/pkg/bifs/strings.go
+++ b/internal/pkg/bifs/strings.go
@@ -43,18 +43,18 @@ func dot_s_xx(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var dot_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING    INT       FLOAT     BOOL      ARRAY  MAP     FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _absn, _absn, _erro},
-	/*ABSENT */ {_erro, _absn, _null, _void, _2___, _s2__, _s2__, _s2__, _absn, _absn, _erro},
-	/*NULL   */ {_erro, _null, _null, _void, _2___, _s2__, _s2__, _s2__, _absn, _absn, _erro},
-	/*VOID   */ {_erro, _void, _void, _void, _2___, _s2__, _s2__, _s2__, _absn, _absn, _erro},
-	/*STRING */ {_erro, _1___, _1___, _1___, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, _erro, _erro, _erro},
-	/*INT    */ {_erro, _s1__, _1___, _s1__, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, _erro, _erro, _erro},
-	/*FLOAT  */ {_erro, _s1__, _1___, _s1__, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, _erro, _erro, _erro},
-	/*BOOL   */ {_erro, _s1__, _1___, _s1__, dot_s_xx, dot_s_xx, dot_s_xx, dot_s_xx, _erro, _erro, _erro},
-	/*ARRAY  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*MAP    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*FUNC    */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT       FLOAT     BOOL      VOID   STRING    ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {dot_s_xx, dot_s_xx, dot_s_xx, _s1__, dot_s_xx, _erro, _erro, _erro, _erro, _1___, _s1__},
+/*FLOAT  */ {dot_s_xx, dot_s_xx, dot_s_xx, _s1__, dot_s_xx, _erro, _erro, _erro, _erro, _1___, _s1__},
+/*BOOL   */ {dot_s_xx, dot_s_xx, dot_s_xx, _s1__, dot_s_xx, _erro, _erro, _erro, _erro, _1___, _s1__},
+/*VOID   */ {_s2__,    _s2__,    _s2__,    _void, _2___,    _absn, _absn, _erro, _erro, _void, _void},
+/*STRING */ {dot_s_xx, dot_s_xx, dot_s_xx, _1___, dot_s_xx, _erro, _erro, _erro, _erro, _1___, _1___},
+/*ARRAY  */ {_erro,    _erro,    _erro,    _erro, _erro,    _erro, _erro, _erro, _erro, _erro, _erro},
+/*MAP    */ {_erro,    _erro,    _erro,    _erro, _erro,    _erro, _erro, _erro, _erro, _erro, _erro},
+/*FUNC   */ {_erro,    _erro,    _erro,    _erro, _erro,    _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro,    _erro,    _erro,    _erro, _erro,    _absn, _absn, _erro, _erro, _erro, _erro},
+/*NULL   */ {_s2__,    _s2__,    _s2__,    _void, _2___,    _absn, _absn, _erro, _erro, _null, _null},
+/*ABSENT */ {_s2__,    _s2__,    _s2__,    _void, _2___,    _absn, _absn, _erro, _erro, _null, _absn},
 }
 
 func BIF_dot(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -331,18 +331,18 @@ func fmtnum_bs(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var fmtnum_dispositions = [mlrval.MT_DIM][mlrval.MT_DIM]BinaryFunc{
-	//       .  ERROR   ABSENT NULL   VOID   STRING     INT    FLOAT  BOOL   ARRAY  MAP    FUNC
-	/*ERROR  */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ABSENT */ {_erro, _absn, _absn, _absn, _absn, _absn, _absn, _erro, _erro, _erro, _erro},
-	/*NULL   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*VOID   */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*STRING */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*INT    */ {_erro, _absn, _erro, _erro, fmtnum_is, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*FLOAT  */ {_erro, _absn, _erro, _erro, fmtnum_fs, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*BOOL   */ {_erro, _absn, _erro, _erro, fmtnum_bs, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*ARRAY  */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*MAP    */ {_erro, _absn, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
-	/*FUNC   */ {_erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro, _erro},
+//       .  INT    FLOAT  BOOL   VOID   STRING     ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {_erro, _erro, _erro, _erro, fmtnum_is, _erro, _erro, _erro, _erro, _erro, _absn},
+/*FLOAT  */ {_erro, _erro, _erro, _erro, fmtnum_fs, _erro, _erro, _erro, _erro, _erro, _absn},
+/*BOOL   */ {_erro, _erro, _erro, _erro, fmtnum_bs, _erro, _erro, _erro, _erro, _erro, _absn},
+/*VOID   */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _absn},
+/*STRING */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _absn},
+/*ARRAY  */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _absn},
+/*MAP    */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _absn},
+/*FUNC   */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _erro},
+/*ERROR  */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _erro},
+/*NULL   */ {_erro, _erro, _erro, _erro, _erro,     _erro, _erro, _erro, _erro, _erro, _absn},
+/*ABSENT */ {_absn, _absn, _erro, _absn, _absn,     _erro, _erro, _erro, _erro, _absn, _absn},
 }
 
 func BIF_fmtnum(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/bifs/types.go
+++ b/internal/pkg/bifs/types.go
@@ -37,17 +37,17 @@ func bool_to_int(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var to_int_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ string_to_int,
 	/*INT    */ _1u___,
 	/*FLOAT  */ float_to_int,
 	/*BOOL   */ bool_to_int,
+	/*VOID   */ _void1,
+	/*STRING */ string_to_int,
 	/*ARRAY  */ _erro1,
 	/*MAP    */ _erro1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_int(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -77,17 +77,17 @@ func bool_to_float(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var to_float_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ string_to_float,
 	/*INT    */ int_to_float,
 	/*FLOAT  */ _1u___,
 	/*BOOL   */ bool_to_float,
+	/*VOID   */ _void1,
+	/*STRING */ string_to_float,
 	/*ARRAY  */ _erro1,
 	/*MAP    */ _erro1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_float(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -113,17 +113,17 @@ func float_to_bool(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 }
 
 var to_boolean_dispositions = [mlrval.MT_DIM]UnaryFunc{
-	/*ERROR  */ _erro1,
-	/*ABSENT */ _absn1,
-	/*NULL   */ _null1,
-	/*VOID   */ _void1,
-	/*STRING */ string_to_boolean,
 	/*INT    */ int_to_bool,
 	/*FLOAT  */ float_to_bool,
 	/*BOOL   */ _1u___,
+	/*VOID   */ _void1,
+	/*STRING */ string_to_boolean,
 	/*ARRAY  */ _erro1,
 	/*MAP    */ _erro1,
 	/*FUNC   */ _erro1,
+	/*ERROR  */ _erro1,
+	/*NULL   */ _null1,
+	/*ABSENT */ _absn1,
 }
 
 func BIF_boolean(input1 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/internal/pkg/mlrval/mlrval_cmp.go
+++ b/internal/pkg/mlrval/mlrval_cmp.go
@@ -332,108 +332,108 @@ var eq_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{}
 
 func init() {
 	eq_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-		//       .  ERROR   ABSENT  NULL    VOID     STRING   INT      FLOAT    BOOL     ARRAY    MAP      FUNC
-		/*ERROR  */ {_true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-		/*ABSENT */ {_fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-		/*NULL   */ {_fals, _fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-		/*VOID   */ {_fals, _fals, _fals, eq_b_ss, eq_b_ss, eq_b_sx, eq_b_sx, _fals, _fals, _fals, _fals},
-		/*STRING */ {_fals, _fals, _fals, eq_b_ss, eq_b_ss, eq_b_sx, eq_b_sx, _fals, _fals, _fals, _fals},
-		/*INT    */ {_fals, _fals, _fals, eq_b_xs, eq_b_xs, eq_b_ii, eq_b_if, _fals, _fals, _fals, _fals},
-		/*FLOAT  */ {_fals, _fals, _fals, eq_b_xs, eq_b_xs, eq_b_fi, eq_b_ff, _fals, _fals, _fals, _fals},
-		/*BOOL   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, eq_b_bb, _fals, _fals, _fals},
-		/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, eq_b_aa, _fals, _fals},
-		/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, eq_b_mm, _fals},
-		/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
-	}
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY    MAP      FUNC    ERROR   NULL   ABSENT
+/*INT    */ {eq_b_ii, eq_b_if, _fals,   eq_b_xs, eq_b_xs, _fals,   _fals,   _fals, _fals, _fals, _fals},
+/*FLOAT  */ {eq_b_fi, eq_b_ff, _fals,   eq_b_xs, eq_b_xs, _fals,   _fals,   _fals, _fals, _fals, _fals},
+/*BOOL   */ {_fals,   _fals,   eq_b_bb, _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals},
+/*VOID   */ {eq_b_sx, eq_b_sx, _fals,   eq_b_ss, eq_b_ss, _fals,   _fals,   _fals, _fals, _fals, _fals},
+/*STRING */ {eq_b_sx, eq_b_sx, _fals,   eq_b_ss, eq_b_ss, _fals,   _fals,   _fals, _fals, _fals, _fals},
+/*ARRAY  */ {_fals,   _fals,   _fals,   _fals,   _fals,   eq_b_aa, _fals,   _fals, _fals, _fals, _fals},
+/*MAP    */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   eq_b_mm, _fals, _fals, _fals, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals, _true, _fals, _fals},
+/*NULL   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _true, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true},
+}
 }
 
 var ne_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY    MAP      FUNC
-	/*ERROR  */ {_true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*ABSENT */ {_fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*NULL   */ {_fals, _fals, _fals, _true, _true, _true, _true, _true, _true, _true, _fals},
-	/*VOID   */ {_fals, _fals, _true, ne_b_ss, ne_b_ss, ne_b_sx, ne_b_sx, _true, _true, _true, _fals},
-	/*STRING */ {_fals, _fals, _true, ne_b_ss, ne_b_ss, ne_b_sx, ne_b_sx, _true, _true, _true, _fals},
-	/*INT    */ {_fals, _fals, _true, ne_b_xs, ne_b_xs, ne_b_ii, ne_b_if, _true, _true, _true, _fals},
-	/*FLOAT  */ {_fals, _fals, _true, ne_b_xs, ne_b_xs, ne_b_fi, ne_b_ff, _true, _true, _true, _fals},
-	/*BOOL   */ {_fals, _fals, _true, _true, _true, _true, _true, ne_b_bb, _true, _true, _fals},
-	/*ARRAY  */ {_fals, _fals, _true, _true, _true, _true, _true, _true, ne_b_aa, _true, _fals},
-	/*MAP    */ {_fals, _fals, _true, _true, _true, _true, _true, _true, _true, ne_b_mm, _fals},
-	/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY    MAP      FUNC    ERROR   NULL   ABSENT
+/*INT    */ {ne_b_ii, ne_b_if, _true,   ne_b_xs, ne_b_xs, _true,   _true,   _fals, _fals, _true, _fals},
+/*FLOAT  */ {ne_b_fi, ne_b_ff, _true,   ne_b_xs, ne_b_xs, _true,   _true,   _fals, _fals, _true, _fals},
+/*BOOL   */ {_true,   _true,   ne_b_bb, _true,   _true,   _true,   _true,   _fals, _fals, _true, _fals},
+/*VOID   */ {ne_b_sx, ne_b_sx, _true,   ne_b_ss, ne_b_ss, _true,   _true,   _fals, _fals, _true, _fals},
+/*STRING */ {ne_b_sx, ne_b_sx, _true,   ne_b_ss, ne_b_ss, _true,   _true,   _fals, _fals, _true, _fals},
+/*ARRAY  */ {_true,   _true,   _true,   _true,   _true,   ne_b_aa, _true,   _fals, _fals, _true, _fals},
+/*MAP    */ {_true,   _true,   _true,   _true,   _true,   _true,   ne_b_mm, _fals, _fals, _true, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals, _true, _fals, _fals},
+/*NULL   */ {_true,   _true,   _true,   _true,   _true,   _true,   _true,   _fals, _fals, _fals, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true},
 }
 
 var gt_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP    FUNC
-	/*ERROR  */ {_true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*ABSENT */ {_fals, _true, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*NULL   */ {_true, _fals, _fals, _true, _true, _true, _true, _true, _fals, _fals, _fals},
-	/*VOID   */ {_fals, _fals, _fals, gt_b_ss, gt_b_ss, gt_b_sx, gt_b_sx, _fals, _fals, _fals, _fals},
-	/*STRING */ {_fals, _fals, _fals, gt_b_ss, gt_b_ss, gt_b_sx, gt_b_sx, _fals, _fals, _fals, _fals},
-	/*INT    */ {_fals, _fals, _fals, gt_b_xs, gt_b_xs, gt_b_ii, gt_b_if, _fals, _fals, _fals, _fals},
-	/*FLOAT  */ {_fals, _fals, _fals, gt_b_xs, gt_b_xs, gt_b_fi, gt_b_ff, _fals, _fals, _fals, _fals},
-	/*BOOL   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, gt_b_bb, _fals, _fals, _fals},
-	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {gt_b_ii, gt_b_if, _fals,   gt_b_xs, gt_b_xs, _fals, _fals, _fals, _fals, _fals, _fals},
+/*FLOAT  */ {gt_b_fi, gt_b_ff, _fals,   gt_b_xs, gt_b_xs, _fals, _fals, _fals, _fals, _fals, _fals},
+/*BOOL   */ {_fals,   _fals,   gt_b_bb, _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*VOID   */ {gt_b_sx, gt_b_sx, _fals,   gt_b_ss, gt_b_ss, _fals, _fals, _fals, _fals, _fals, _fals},
+/*STRING */ {gt_b_sx, gt_b_sx, _fals,   gt_b_ss, gt_b_ss, _fals, _fals, _fals, _fals, _fals, _fals},
+/*ARRAY  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*MAP    */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true, _fals, _fals},
+/*NULL   */ {_true,   _true,   _true,   _true,   _true,   _fals, _fals, _fals, _true, _fals, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _true, _true},
 }
 
 var ge_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP    FUNC
-	/*ERROR  */ {_true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*ABSENT */ {_fals, _true, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*NULL   */ {_true, _fals, _true, _true, _true, _true, _true, _true, _fals, _fals, _fals},
-	/*VOID   */ {_fals, _fals, _fals, ge_b_ss, ge_b_ss, ge_b_sx, ge_b_sx, _fals, _fals, _fals, _fals},
-	/*STRING */ {_fals, _fals, _fals, ge_b_ss, ge_b_ss, ge_b_sx, ge_b_sx, _fals, _fals, _fals, _fals},
-	/*INT    */ {_fals, _fals, _fals, ge_b_xs, ge_b_xs, ge_b_ii, ge_b_if, _fals, _fals, _fals, _fals},
-	/*FLOAT  */ {_fals, _fals, _fals, ge_b_xs, ge_b_xs, ge_b_fi, ge_b_ff, _fals, _fals, _fals, _fals},
-	/*BOOL   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, ge_b_bb, _fals, _fals, _fals},
-	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {ge_b_ii, ge_b_if, _fals,   ge_b_xs, ge_b_xs, _fals, _fals, _fals, _fals, _fals, _fals},
+/*FLOAT  */ {ge_b_fi, ge_b_ff, _fals,   ge_b_xs, ge_b_xs, _fals, _fals, _fals, _fals, _fals, _fals},
+/*BOOL   */ {_fals,   _fals,   ge_b_bb, _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*VOID   */ {ge_b_sx, ge_b_sx, _fals,   ge_b_ss, ge_b_ss, _fals, _fals, _fals, _fals, _fals, _fals},
+/*STRING */ {ge_b_sx, ge_b_sx, _fals,   ge_b_ss, ge_b_ss, _fals, _fals, _fals, _fals, _fals, _fals},
+/*ARRAY  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*MAP    */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true, _fals, _fals},
+/*NULL   */ {_true,   _true,   _true,   _true,   _true,   _fals, _fals, _fals, _true, _true, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _true, _true},
 }
 
 var lt_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP    FUNC
-	/*ERROR  */ {_true, _fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*ABSENT */ {_fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*NULL   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*VOID   */ {_fals, _fals, _true, lt_b_ss, lt_b_ss, lt_b_sx, lt_b_sx, _fals, _fals, _fals, _fals},
-	/*STRING */ {_fals, _fals, _true, lt_b_ss, lt_b_ss, lt_b_sx, lt_b_sx, _fals, _fals, _fals, _fals},
-	/*INT    */ {_fals, _fals, _true, lt_b_xs, lt_b_xs, lt_b_ii, lt_b_if, _fals, _fals, _fals, _fals},
-	/*FLOAT  */ {_fals, _fals, _true, lt_b_xs, lt_b_xs, lt_b_fi, lt_b_ff, _fals, _fals, _fals, _fals},
-	/*BOOL   */ {_fals, _fals, _true, _fals, _fals, _fals, _fals, lt_b_bb, _fals, _fals, _fals},
-	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {lt_b_ii, lt_b_if, _fals,   lt_b_xs, lt_b_xs, _fals, _fals, _fals, _fals, _true, _fals},
+/*FLOAT  */ {lt_b_fi, lt_b_ff, _fals,   lt_b_xs, lt_b_xs, _fals, _fals, _fals, _fals, _true, _fals},
+/*BOOL   */ {_fals,   _fals,   lt_b_bb, _fals,   _fals,   _fals, _fals, _fals, _fals, _true, _fals},
+/*VOID   */ {lt_b_sx, lt_b_sx, _fals,   lt_b_ss, lt_b_ss, _fals, _fals, _fals, _fals, _true, _fals},
+/*STRING */ {lt_b_sx, lt_b_sx, _fals,   lt_b_ss, lt_b_ss, _fals, _fals, _fals, _fals, _true, _fals},
+/*ARRAY  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*MAP    */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true, _true, _fals},
+/*NULL   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _true},
 }
 
 var le_dispositions = [MT_DIM][MT_DIM]CmpFuncBool{
-	//       .  ERROR   ABSENT NULL   VOID     STRING   INT      FLOAT    BOOL     ARRAY  MAP    FUNC
-	/*ERROR  */ {_true, _fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*ABSENT */ {_fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*NULL   */ {_fals, _fals, _true, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*VOID   */ {_fals, _fals, _true, le_b_ss, le_b_ss, le_b_sx, le_b_sx, _fals, _fals, _fals, _fals},
-	/*STRING */ {_fals, _fals, _true, le_b_ss, le_b_ss, le_b_sx, le_b_sx, _fals, _fals, _fals, _fals},
-	/*INT    */ {_fals, _fals, _true, le_b_xs, le_b_xs, le_b_ii, le_b_if, _fals, _fals, _fals, _fals},
-	/*FLOAT  */ {_fals, _fals, _true, le_b_xs, le_b_xs, le_b_fi, le_b_ff, _fals, _fals, _fals, _fals},
-	/*BOOL   */ {_fals, _fals, _true, _fals, _fals, _fals, _fals, le_b_bb, _fals, _fals, _fals},
-	/*ARRAY  */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*MAP    */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals},
-	/*FUNC   */ {_fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _fals, _true},
+//       .  INT      FLOAT    BOOL     VOID     STRING   ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {le_b_ii, le_b_if, _fals,   le_b_xs, le_b_xs, _fals, _fals, _fals, _fals, _true, _fals},
+/*FLOAT  */ {le_b_fi, le_b_ff, _fals,   le_b_xs, le_b_xs, _fals, _fals, _fals, _fals, _true, _fals},
+/*BOOL   */ {_fals,   _fals,   le_b_bb, _fals,   _fals,   _fals, _fals, _fals, _fals, _true, _fals},
+/*VOID   */ {le_b_sx, le_b_sx, _fals,   le_b_ss, le_b_ss, _fals, _fals, _fals, _fals, _true, _fals},
+/*STRING */ {le_b_sx, le_b_sx, _fals,   le_b_ss, le_b_ss, _fals, _fals, _fals, _fals, _true, _fals},
+/*ARRAY  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*MAP    */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _fals},
+/*FUNC   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _true, _fals, _fals, _fals},
+/*ERROR  */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _true, _true, _fals},
+/*NULL   */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _true, _fals},
+/*ABSENT */ {_fals,   _fals,   _fals,   _fals,   _fals,   _fals, _fals, _fals, _fals, _fals, _true},
 }
 
 // TODO: flesh these out for array and map
 var cmp_dispositions = [MT_DIM][MT_DIM]CmpFuncInt{
-	//       .  ERROR   ABSENT NULL   VOID      STRING    INT       FLOAT     BOOL      ARRAY  MAP    FUNC
-	/*ERROR  */ {_i0__, _i0__, _n1__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
-	/*ABSENT */ {_i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
-	/*NULL   */ {_i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
-	/*VOID   */ {_i0__, _i0__, _n1__, cmp_b_ss, cmp_b_ss, cmp_b_sx, cmp_b_sx, _i0__, _i0__, _i0__, _i0__},
-	/*STRING */ {_i0__, _i0__, _n1__, cmp_b_ss, cmp_b_ss, cmp_b_sx, cmp_b_sx, _i0__, _i0__, _i0__, _i0__},
-	/*INT    */ {_i0__, _i0__, _n1__, cmp_b_xs, cmp_b_xs, cmp_b_ii, cmp_b_if, _i0__, _i0__, _i0__, _i0__},
-	/*FLOAT  */ {_i0__, _i0__, _n1__, cmp_b_xs, cmp_b_xs, cmp_b_fi, cmp_b_ff, _i0__, _i0__, _i0__, _i0__},
-	/*BOOL   */ {_i0__, _i0__, _n1__, _i0__, _i0__, _i0__, _i0__, cmp_b_bb, _i0__, _i0__, _i0__},
-	/*ARRAY  */ {_i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
-	/*MAP    */ {_i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
-	/*FUNC   */ {_i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
+//       .  INT       FLOAT     BOOL      VOID      STRING    ARRAY  MAP    FUNC    ERROR   NULL   ABSENT
+/*INT    */ {cmp_b_ii, cmp_b_if, _i0__,    cmp_b_xs, cmp_b_xs, _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*FLOAT  */ {cmp_b_fi, cmp_b_ff, _i0__,    cmp_b_xs, cmp_b_xs, _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*BOOL   */ {_i0__,    _i0__,    cmp_b_bb, _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*VOID   */ {cmp_b_sx, cmp_b_sx, _i0__,    cmp_b_ss, cmp_b_ss, _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*STRING */ {cmp_b_sx, cmp_b_sx, _i0__,    cmp_b_ss, cmp_b_ss, _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*ARRAY  */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
+/*MAP    */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
+/*FUNC   */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
+/*ERROR  */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _n1__, _i0__},
+/*NULL   */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
+/*ABSENT */ {_i0__,    _i0__,    _i0__,    _i0__,    _i0__,    _i0__, _i0__, _i0__, _i0__, _i0__, _i0__},
 }

--- a/internal/pkg/mlrval/mlrval_is.go
+++ b/internal/pkg/mlrval/mlrval_is.go
@@ -9,7 +9,8 @@ import (
 // information.
 
 func (mv *Mlrval) IsLegit() bool {
-	return mv.Type() >= MT_VOID
+	t := mv.Type()
+	return MT_INT <= t && t < MT_ERROR
 }
 
 // TODO: comment no JIT-infer here -- absent is non-inferrable and we needn't take the expense of JIT.

--- a/internal/pkg/mlrval/mlrval_type.go
+++ b/internal/pkg/mlrval/mlrval_type.go
@@ -89,9 +89,35 @@ type MVType int
 // Important: the values of these enums are used to index into disposition
 // matrices. If they are changed, it will break the disposition matrices, or
 // they will all need manual re-indexing.
+//
+// Also note the ordering of types reflects the sort order for mixed types,
+// with the exception that ints and floats sort numerically. So 1 < "abc" and 1
+// < "1", and 7 < true; but 1 < 1.1 < 2 < 2.2.
 const (
-	// Type not yet determined: during JSON decode or TODO comment.
+	// Type not yet determined: during JSON decode, or for JIT-data from file
+	// data whose type doesn't need to be determined yet. For example, when we
+	// operate only on columns 15 & 17 of a 20-column CSV file, those two
+	// columns get type-inferred during processing but the rest keep their
+	// printrep and type MT_PENDING. This is a significant performance
+	// optimization.
 	MT_PENDING MVType = -1
+
+	MT_INT = 0
+
+	MT_FLOAT = 1
+
+	MT_BOOL = 2
+
+	// Key present in input record with empty value, e.g. input data '$x=,$y=2'
+	MT_VOID = 3
+
+	MT_STRING = 4
+
+	MT_ARRAY = 5
+
+	MT_MAP = 6
+
+	MT_FUNC = 7
 
 	// E.g. error encountered in one eval & it propagates up the AST at
 	// evaluation time.  Various runtime errors, such as file-not-found, result
@@ -99,32 +125,15 @@ const (
 	// are intended to result in "(error)"-valued output rather than a crash.
 	// This is analogous to the way that IEEE-754 arithmetic carries around
 	// Inf and NaN through computation chains.
-	MT_ERROR = 0
-
-	// Key not present in input record, e.g. 'foo = $nosuchkey'
-	MT_ABSENT = 1
+	MT_ERROR = 8
 
 	// Used only for JSON null, and for 'empty' slots when an array is
 	// auto-extended by assigning to an index having a gap from the last index.
 	// E.g. x=[1,2,3] then x[5]=5; now x[4] is null
-	MT_NULL = 2
+	MT_NULL = 9
 
-	// Key present in input record with empty value, e.g. input data '$x=,$y=2'
-	MT_VOID = 3
-
-	MT_STRING = 4
-
-	MT_INT = 5
-
-	MT_FLOAT = 6
-
-	MT_BOOL = 7
-
-	MT_ARRAY = 8
-
-	MT_MAP = 9
-
-	MT_FUNC = 10
+	// Key not present in input record, e.g. 'foo = $nosuchkey'
+	MT_ABSENT = 10
 
 	// Not a type -- this is a dimension for disposition vectors and
 	// disposition matrices. For example, when we want to add two mlrvals,
@@ -135,34 +144,35 @@ const (
 )
 
 var TYPE_NAMES = [MT_DIM]string{
-	"error",
-	"absent",
-	"null",
-	"empty", // For backward compatiblity with the C impl: this is user-visible
-	"string",
 	"int",
 	"float",
 	"bool",
+	"empty", // For backward compatiblity with the C impl: this is user-visible
+	"string",
 	"array",
 	"map",
 	"funct",
+	"error",
+	"null",
+	"absent",
 }
 
 // For typed assignments in the DSL
 
 // TODO: comment more re typedecls
-const MT_TYPE_MASK_STRING = (1 << MT_STRING) | (1 << MT_VOID)
 const MT_TYPE_MASK_INT = 1 << MT_INT
 const MT_TYPE_MASK_FLOAT = 1 << MT_FLOAT
 const MT_TYPE_MASK_NUM = (1 << MT_INT) | (1 << MT_FLOAT)
 const MT_TYPE_MASK_BOOL = 1 << MT_BOOL
+const MT_TYPE_MASK_STRING = (1 << MT_STRING) | (1 << MT_VOID)
 const MT_TYPE_MASK_ARRAY = 1 << MT_ARRAY
 const MT_TYPE_MASK_MAP = 1 << MT_MAP
-const MT_TYPE_MASK_VAR = (1 << MT_VOID) |
-	(1 << MT_STRING) |
+const MT_TYPE_MASK_VAR =
 	(1 << MT_INT) |
 	(1 << MT_FLOAT) |
 	(1 << MT_BOOL) |
+	(1 << MT_VOID) |
+	(1 << MT_STRING) |
 	(1 << MT_ARRAY) |
 	(1 << MT_MAP)
 const MT_TYPE_MASK_FUNC = 1 << MT_FUNC
@@ -172,16 +182,16 @@ const MT_TYPE_MASK_ANY = (1 << MT_ERROR) | (1 << MT_ABSENT) | MT_TYPE_MASK_VAR |
 
 // TODO: const these throughout
 var typeNameToMaskMap = map[string]int{
-	"var":   MT_TYPE_MASK_VAR,
-	"str":   MT_TYPE_MASK_STRING,
 	"int":   MT_TYPE_MASK_INT,
 	"float": MT_TYPE_MASK_FLOAT,
 	"num":   MT_TYPE_MASK_NUM,
 	"bool":  MT_TYPE_MASK_BOOL,
+	"str":   MT_TYPE_MASK_STRING,
 	"arr":   MT_TYPE_MASK_ARRAY,
 	"map":   MT_TYPE_MASK_MAP,
-	"any":   MT_TYPE_MASK_ANY,
 	"funct": MT_TYPE_MASK_FUNC,
+	"var":   MT_TYPE_MASK_VAR,
+	"any":   MT_TYPE_MASK_ANY,
 }
 
 func TypeNameToMask(typeName string) (mask int, present bool) {

--- a/todo.txt
+++ b/todo.txt
@@ -3,6 +3,24 @@ PUNCHDOWN LIST
 
 * blockers:
   - cmp-matrices
+    > X_as_bool del
+    > mvcmp mix
+
+      internal/pkg/bifs/arithmetic.go
+      internal/pkg/bifs/bits.go
+      internal/pkg/bifs/booleans.go
+      internal/pkg/bifs/collections.go
+      internal/pkg/bifs/mathlib.go
+      internal/pkg/bifs/sort.go
+      internal/pkg/bifs/strings.go
+      internal/pkg/bifs/types.go
+
+      internal/pkg/mlrval/mlrval_cmp.go
+      internal/pkg/mlrval/mlrval_cmp_test.go
+      internal/pkg/mlrval/mlrval_constants.go
+      internal/pkg/mlrval/mlrval_is.go
+      internal/pkg/mlrval/mlrval_type.go
+
   - docs re mods contact
 
 * cases/dsl-min-max-types: cmp-matrices need to be fixed to follow the advertised rule for mixed types

--- a/todo.txt
+++ b/todo.txt
@@ -3,6 +3,7 @@ PUNCHDOWN LIST
 
 * blockers:
   - cmp-matrices
+  - docs re mods contact
 
 * cases/dsl-min-max-types: cmp-matrices need to be fixed to follow the advertised rule for mixed types
   NUMERICS < BOOL < VOID < STRING


### PR DESCRIPTION
This is entirely code-internal with no external effects. It's a prep PR which will make it easier to add some more unit-test cases to the type-specific function-pointer tables for `==`, `<`, `<=`, etc.