### PR TITLE
Create release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+on: 
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  GO_VERSION: 1.17.5
+
+jobs:
+  release:
+    name: Release
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2.1.5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+
+      # https://github.com/marketplace/actions/cache
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # https://goreleaser.com/ci/actions/
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        #if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          version: latest
+          args: release -f .goreleaser.yml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is the action that will actually use the .goreleaser.yml file at the root to produce releases (see PR #821). It can trigger either by doing a release with a tag pattern of vX.X.X or manually triggering the workflow. 

Please note that you have to adjust the permissions of workflows to read/write to allow the workflow to upload binaries to the repo. Go to https://github.com/johnkerl/miller/settings/actions and set `Workflow permissions` to read & write.

