### PR TITLE
Add codespell. This identified a number of typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -31,3 +31,5 @@ jobs:
         with:
           check_filenames: true
           ignore_words_file: .codespellignore
+          exclude_file: docs/src/data/english-words.txt
+          

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,33 @@
+name: Codespell
+
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+# Start the job on all push #
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Set the Job #
+jobs:
+  build:
+    name: Codespell
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    # Load all steps #
+    steps:
+      # Checkout the code base #
+      - name: Checkout Code
+        uses: actions/checkout@v2.4.0
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      # Run Linter against code base #
+      - name: Codespell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          ignore_words_file: .codespellignore


### PR DESCRIPTION
This adds a workflow for running Codespell. 10 errors were flagged on my fork (fixes not included and should be reviewed).

Results are here: https://github.com/jauderho/miller/actions/runs/1644396411