### PR TITLE
Fix Makefile for empty prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check: unit-test regression-test
 # DESTDIR is for package installs; nominally blank when this is run interactively.
 # See also https://www.gnu.org/prep/standards/html_node/DESTDIR.html
 install: build
-        mkdir -p $(DESTDIR)/$(INSTALLDIR)
+	mkdir -p $(DESTDIR)/$(INSTALLDIR)
 	cp mlr $(DESTDIR)/$(INSTALLDIR)/
 	make -C man install
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ check: unit-test regression-test
 # DESTDIR is for package installs; nominally blank when this is run interactively.
 # See also https://www.gnu.org/prep/standards/html_node/DESTDIR.html
 install: build
-	cp mlr $(DESTDIR)/$(INSTALLDIR)
+        mkdir -p $(DESTDIR)/$(INSTALLDIR)
+	cp mlr $(DESTDIR)/$(INSTALLDIR)/
 	make -C man install
 
 # ================================================================


### PR DESCRIPTION
Previously, `make install` would name the `mlr` binary `bin`, directly in the prefix if there was no `bin` directory. It now behaves as expected.