### PR TITLE
Goreleaser binary names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ builds:
         goarch: s390x
     dir: .
     main: ./cmd/mlr
+    binary: mlr
     flags:
       - -trimpath
     #ldflags:

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,11 @@
 ================================================================
 PUNCHDOWN LIST
 
+* post-release:
+  ! go-releaser .tar.gz files have a `miller` exe not a `mlr` exe :( -- debug
+  ! windows should have a .zip not just a .tar.gz -- probably a manual step still (copy from GH artifacts)
+  w installing-miller.md.in
+
 * document cloudthings, e.g.
   o go.yml
   o codespell.yml
@@ -15,9 +20,6 @@ PUNCHDOWN LIST
   brew macports chocolatey
   ubuntu debian fedora gentoo prolinux archlinux
   netbsd freebsd
-
-* post-release:
-  w installing-miller.md.in
 
 ================================================================
 NON-BLOCKERS


### PR DESCRIPTION
@jauderho I think this is correct to get binaries named `mlr` ... do you know how to trigger go-releaser to run for an already published tag?

(My mistake for not having caught this sooner on `6.0.0.rc1` :( )

```
$ tar ztf miller_6.0.0_darwin_amd64.tar.gz
LICENSE.txt
README-RPM.md
README-docs.md
README-go-port.md
README-profiling.md
README.md
miller   <------- should be mlr
```