### PR TITLE
Continue #856

### DIFF
--- a/internal/pkg/parsing/errors/errors.go
+++ b/internal/pkg/parsing/errors/errors.go
@@ -52,7 +52,7 @@ func (e *Error) Error() string {
 	w := new(strings.Builder)
 	fmt.Fprintf(
 		w,
-		"Parse error on token \"%s\" at line %d columnn %d.\n",
+		"Parse error on token \"%s\" at line %d column %d.\n",
 		string(e.ErrorToken.Lit),
 		e.ErrorToken.Pos.Line,
 		e.ErrorToken.Pos.Column,

--- a/test/cases/dsl-lashed-emitp-singles/0057/experr
+++ b/test/cases/dsl-lashed-emitp-singles/0057/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "." at line 1 columnn 8.
+Parse error on token "." at line 1 column 8.
 Please check for missing semicolon.
 Expected one of:
   $ ; ,

--- a/test/cases/dsl-lashed-emitp-singles/0063/experr
+++ b/test/cases/dsl-lashed-emitp-singles/0063/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "." at line 1 columnn 10.
+Parse error on token "." at line 1 column 10.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/0068/experr
+++ b/test/cases/dsl-lashed-emitp-singles/0068/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 44.
+Parse error on token "(" at line 1 column 44.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/0074/experr
+++ b/test/cases/dsl-lashed-emitp-singles/0074/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 52.
+Parse error on token "(" at line 1 column 52.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0013/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0013/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 3 columnn 11.
+Parse error on token "[" at line 3 column 11.
 Please check for missing semicolon.
 Expected one of:
   ; } ,

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0014/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0014/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 3 columnn 12.
+Parse error on token "[" at line 3 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0024/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0024/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0026/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0026/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0027/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0027/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0029/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0029/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0031/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0031/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0032/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0032/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0033/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0033/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 10 columnn 11.
+Parse error on token "[" at line 10 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0037/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0037/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0038/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0038/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0039/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0039/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0040/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0040/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 11.
+Parse error on token "[" at line 4 column 11.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0041/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0041/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 10 columnn 12.
+Parse error on token "[" at line 10 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0045/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0045/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0046/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0046/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0047/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0047/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0048/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0048/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 4 columnn 12.
+Parse error on token "[" at line 4 column 12.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0060/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0060/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 34.
+Parse error on token "(" at line 1 column 34.
 Please check for missing semicolon.
 Expected one of:
   $ ; ,

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0062/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0062/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 42.
+Parse error on token "(" at line 1 column 42.
 Please check for missing semicolon.
 Expected one of:
   $ ; ,

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0080/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0080/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 52.
+Parse error on token "(" at line 1 column 52.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0086/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0086/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 52.
+Parse error on token "(" at line 1 column 52.
 Expected one of:
   , )
 

--- a/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0092/experr
+++ b/test/cases/dsl-lashed-emitp-singles/dsl-lashed-emitp-singles/0092/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "(" at line 1 columnn 53.
+Parse error on token "(" at line 1 column 53.
 Expected one of:
   , )
 

--- a/test/cases/dsl-parameterized-emit/0048/experr
+++ b/test/cases/dsl-parameterized-emit/0048/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 1 columnn 24.
+Parse error on token "[" at line 1 column 24.
 Please check for missing semicolon.
 Expected one of:
   ; } ,

--- a/test/cases/dsl-parameterized-emit/0056/experr
+++ b/test/cases/dsl-parameterized-emit/0056/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "[" at line 1 columnn 28.
+Parse error on token "[" at line 1 column 28.
 Please check for missing semicolon.
 Expected one of:
   ; } ,

--- a/test/cases/dsl-parse/0113/experr
+++ b/test/cases/dsl-parse/0113/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "`" at line 20 columnn 3.
+Parse error on token "`" at line 20 column 3.
 Please check for missing semicolon.
 Expected one of:
   ; { } unset filter print printn eprint eprintn dump edump tee emitf emit1

--- a/test/cases/dsl-parse/0114/experr
+++ b/test/cases/dsl-parse/0114/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "x" at line 20 columnn 5.
+Parse error on token "x" at line 20 column 5.
 Please check for missing semicolon.
 Expected one of:
   ; { } = > >> | ( ||= ^^= &&= ??= ???= |= &= ^= <<= >>= >>>= += .= -= *=

--- a/test/cases/dsl-subr/0002/experr
+++ b/test/cases/dsl-subr/0002/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "" at line 2 columnn 1.
+Parse error on token "" at line 2 column 1.
 Expected one of:
   (
 

--- a/test/cases/dsl-subr/0008/experr
+++ b/test/cases/dsl-subr/0008/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "" at line 2 columnn 1.
+Parse error on token "" at line 2 column 1.
 Expected one of:
   {
 

--- a/test/cases/dsl-trailing-commas/0003/experr
+++ b/test/cases/dsl-trailing-commas/0003/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 35.
+Parse error on token "," at line 1 column 35.
 Expected one of:
   { ( ) field_name $[ braced_field_name $[[ $[[[ full_srec oosvar_name @[
   braced_oosvar_name full_oosvar all non_sigil_name float int + - .+ .- !

--- a/test/cases/dsl-trailing-commas/0005/experr
+++ b/test/cases/dsl-trailing-commas/0005/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 10.
+Parse error on token "," at line 1 column 10.
 Expected one of:
   ) non_sigil_name arr bool float int map num str var funct
 

--- a/test/cases/dsl-trailing-commas/0007/experr
+++ b/test/cases/dsl-trailing-commas/0007/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 14.
+Parse error on token "," at line 1 column 14.
 Expected one of:
   ) non_sigil_name arr bool float int map num str var funct
 

--- a/test/cases/dsl-trailing-commas/0009/experr
+++ b/test/cases/dsl-trailing-commas/0009/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 37.
+Parse error on token "," at line 1 column 37.
 Expected one of:
   { ( ) field_name $[ braced_field_name $[[ $[[[ full_srec oosvar_name @[
   braced_oosvar_name full_oosvar all non_sigil_name float int + - .+ .- !

--- a/test/cases/dsl-trailing-commas/0011/experr
+++ b/test/cases/dsl-trailing-commas/0011/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 10.
+Parse error on token "," at line 1 column 10.
 Expected one of:
   ) non_sigil_name arr bool float int map num str var funct
 

--- a/test/cases/dsl-trailing-commas/0013/experr
+++ b/test/cases/dsl-trailing-commas/0013/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 14.
+Parse error on token "," at line 1 column 14.
 Expected one of:
   ) non_sigil_name arr bool float int map num str var funct
 

--- a/test/cases/dsl-trailing-commas/0016/experr
+++ b/test/cases/dsl-trailing-commas/0016/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 13.
+Parse error on token "," at line 1 column 13.
 Expected one of:
   { ( ) field_name $[ braced_field_name $[[ $[[[ full_srec oosvar_name @[
   braced_oosvar_name full_oosvar all non_sigil_name float int + - .+ .- !

--- a/test/cases/dsl-trailing-commas/0017/experr
+++ b/test/cases/dsl-trailing-commas/0017/experr
@@ -1,5 +1,5 @@
 mlr: cannot parse DSL expression.
-Parse error on token "," at line 1 columnn 10.
+Parse error on token "," at line 1 column 10.
 Expected one of:
   { ( ) field_name $[ braced_field_name $[[ $[[[ full_srec oosvar_name @[
   braced_oosvar_name full_oosvar all non_sigil_name float int + - .+ .- !


### PR DESCRIPTION
#856 touched source file `internal/pkg/parsing/errors.go.template`, which is copied to `internal/pkg/parsing/errors.go` only infrequently by https://github.com/johnkerl/miller/blob/main/tools/build-dsl such as on PR #864.