### PR TITLE
Avoid assuming ./mlr is the mlr to test

### DIFF
--- a/internal/pkg/auxents/regtest/regtester.go
+++ b/internal/pkg/auxents/regtest/regtester.go
@@ -773,6 +773,7 @@ func (regtester *RegTester) loadFile(
 	contents := string(byteContents)
 	contents = strings.ReplaceAll(contents, "${CASEDIR}", caseDir)
 	contents = strings.ReplaceAll(contents, "${PATHSEP}", string(os.PathSeparator))
+	contents = strings.ReplaceAll(contents, "${MLR}", regtester.exeName)
 	return contents, nil
 }
 

--- a/test/cases-not-suitable-for-ci/verb-join-prepipe/0001/cmd
+++ b/test/cases-not-suitable-for-ci/verb-join-prepipe/0001/cmd
@@ -1,1 +1,1 @@
-mlr --prepipe '.${PATHSEP}mlr cat' --odkvp join -j a -f test/input/join-het.dkvp test/input/abixy-het
+mlr --prepipe '${MLR} cat' --odkvp join -j a -f test/input/join-het.dkvp test/input/abixy-het

--- a/test/cases-not-suitable-for-ci/verb-join-prepipe/0002/cmd
+++ b/test/cases-not-suitable-for-ci/verb-join-prepipe/0002/cmd
@@ -1,1 +1,1 @@
-mlr --odkvp join --prepipe '.${PATHSEP}mlr cat' -j a -f test/input/join-het.dkvp test/input/abixy-het
+mlr --odkvp join --prepipe '${MLR} cat' -j a -f test/input/join-het.dkvp test/input/abixy-het

--- a/test/cases-not-suitable-for-ci/verb-join-prepipe/0003/cmd
+++ b/test/cases-not-suitable-for-ci/verb-join-prepipe/0003/cmd
@@ -1,1 +1,1 @@
-mlr --prepipe '.${PATHSEP}mlr cat' --odkvp join --prepipe cat -j a -f test/input/join-het.dkvp test/input/abixy-het
+mlr --prepipe '${MLR} cat' --odkvp join --prepipe cat -j a -f test/input/join-het.dkvp test/input/abixy-het

--- a/test/cases/io-compressed-input/0001/cmd
+++ b/test/cases/io-compressed-input/0001/cmd
@@ -1,1 +1,1 @@
-mlr --csv --prepipe '.${PATHSEP}mlr --csv cat' cat test/input/rfc-csv/simple.csv-crlf
+mlr --csv --prepipe '${MLR} --csv cat' cat test/input/rfc-csv/simple.csv-crlf

--- a/test/cases/io-compressed-input/0002/cmd
+++ b/test/cases/io-compressed-input/0002/cmd
@@ -1,1 +1,1 @@
-mlr --dkvp --prepipe '.${PATHSEP}mlr cat' cat test/input/abixy
+mlr --dkvp --prepipe '${MLR} cat' cat test/input/abixy

--- a/test/cases/io-compressed-input/0003/cmd
+++ b/test/cases/io-compressed-input/0003/cmd
@@ -1,1 +1,1 @@
-mlr --csv --prepipe '.${PATHSEP}mlr --csv cat' cat < test/input/rfc-csv/simple.csv-crlf
+mlr --csv --prepipe '${MLR} --csv cat' cat < test/input/rfc-csv/simple.csv-crlf

--- a/test/cases/io-compressed-input/0004/cmd
+++ b/test/cases/io-compressed-input/0004/cmd
@@ -1,1 +1,1 @@
-mlr --dkvp --prepipe '.${PATHSEP}mlr cat' cat < test/input/abixy
+mlr --dkvp --prepipe '${MLR} cat' cat < test/input/abixy


### PR DESCRIPTION
In test cases, support a ${MLR} placeholder for the mlr binary under
test, instead of assuming it's ./mlr (or its equivalent on platforms
not using forward slashes).

This ensures that wrapped mlr invocations all use the same binary,
either the default or the binary specified by the user, avoiding
surprises when ./mlr doesn't exist or is a different version.

Signed-off-by: Stephen Kitt <steve@sk2.org>