### PR TITLE
Ensure regression-test has a binary to test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ bench-input:
 # for debugging.  TL;DR is for CI jobs, we have 'go test -v'; for
 # interactive use, instead of 'go test -v' simply use 'mlr regtest
 # -vvv' or 'mlr regtest -s 20'. See also internal/pkg/auxents/regtest.
-regression-test:
+regression-test: build
 	go test -v regression_test.go
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
"make regression-test" assumes that ./mlr is the binary to test. To
ensure that ./mlr is available, make "build" a pre-requisite of
"regression-test"; otherwise "make regression-test" will test whatever
version of mlr is on the PATH if ./mlr doesn't exist.

Signed-off-by: Stephen Kitt <steve@sk2.org>