### PR TITLE
Fix mlrmap.Equals FieldCount comparison

### DIFF
--- a/internal/pkg/mlrval/mlrmap_accessors.go
+++ b/internal/pkg/mlrval/mlrmap_accessors.go
@@ -414,7 +414,7 @@ func (mlrmap *Mlrmap) RemoveWithPositionalIndex(position int) {
 
 // ----------------------------------------------------------------
 func (mlrmap *Mlrmap) Equals(other *Mlrmap) bool {
-	if mlrmap.FieldCount != mlrmap.FieldCount {
+	if mlrmap.FieldCount != other.FieldCount {
 		return false
 	}
 	if !mlrmap.Contains(other) {


### PR DESCRIPTION
This should compare mlrmap to other, not mlrmap to itself.

Signed-off-by: Stephen Kitt <steve@sk2.org>