### PR TITLE
Mlrval arrayval from []Mlrval to []*Mlrval

### DIFF
--- a/internal/pkg/bifs/cmp.go
+++ b/internal/pkg/bifs/cmp.go
@@ -243,7 +243,7 @@ func eq_b_aa(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 
 	// Same-length arrays: return false if any slot is not equal, else true.
 	for i := range a {
-		eq := BIF_equals(&a[i], &b[i])
+		eq := BIF_equals(a[i], b[i])
 		lib.InternalCodingErrorIf(eq.Type() != mlrval.MT_BOOL)
 		if eq.AcquireBoolValue() == false {
 			return mlrval.FALSE

--- a/internal/pkg/bifs/collections_test.go
+++ b/internal/pkg/bifs/collections_test.go
@@ -31,8 +31,8 @@ func TestBIF_depth(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, intval)
 
-	arrayval := make([]mlrval.Mlrval, 1)
-	arrayval[0] = *mlrval.FromString("value")
+	arrayval := make([]*mlrval.Mlrval, 1)
+	arrayval[0] = mlrval.FromString("value")
 	input1 = mlrval.FromArray(arrayval)
 	output = BIF_depth(input1)
 	intval, ok = output.GetIntValue()

--- a/internal/pkg/dsl/cst/collections.go
+++ b/internal/pkg/dsl/cst/collections.go
@@ -44,9 +44,9 @@ func (node *RootNode) BuildArrayLiteralNode(
 func (node *ArrayLiteralNode) Evaluate(
 	state *runtime.State,
 ) *mlrval.Mlrval {
-	mlrvals := make([]mlrval.Mlrval, len(node.evaluables))
+	mlrvals := make([]*mlrval.Mlrval, len(node.evaluables))
 	for i := range node.evaluables {
-		mlrvals[i] = *node.evaluables[i].Evaluate(state)
+		mlrvals[i] = node.evaluables[i].Evaluate(state)
 	}
 	return mlrval.FromArray(mlrvals)
 }
@@ -204,7 +204,7 @@ func (node *ArraySliceAccessNode) Evaluate(
 	upperZindex, _ := mlrval.UnaliasArrayIndex(&array, upperIndex)
 
 	if lowerZindex > upperZindex {
-		return mlrval.FromArray(make([]mlrval.Mlrval, 0))
+		return mlrval.FromEmptyArray()
 	}
 
 	// Semantics: say x=[1,2,3,4,5]. Then x[3:10] is [3,4,5].
@@ -221,13 +221,13 @@ func (node *ArraySliceAccessNode) Evaluate(
 	if lowerZindex < 0 {
 		lowerZindex = 0
 		if lowerZindex > upperZindex {
-			return mlrval.FromArray(make([]mlrval.Mlrval, 0))
+			return mlrval.FromEmptyArray()
 		}
 	}
 	if upperZindex > n-1 {
 		upperZindex = n - 1
 		if lowerZindex > upperZindex {
-			return mlrval.FromArray(make([]mlrval.Mlrval, 0))
+			return mlrval.FromEmptyArray()
 		}
 	}
 
@@ -235,11 +235,11 @@ func (node *ArraySliceAccessNode) Evaluate(
 	// Miller slices have inclusive lower bound, inclusive upper bound.
 	var m = upperZindex - lowerZindex + 1
 
-	retval := make([]mlrval.Mlrval, m)
+	retval := make([]*mlrval.Mlrval, m)
 
 	di := 0
 	for si := lowerZindex; si <= upperZindex; si++ {
-		retval[di] = *array[si].Copy()
+		retval[di] = array[si].Copy()
 		di++
 	}
 

--- a/internal/pkg/dsl/cst/for.go
+++ b/internal/pkg/dsl/cst/for.go
@@ -163,7 +163,7 @@ func (node *ForLoopOneVariableNode) Execute(state *runtime.State) (*BlockExitPay
 		state.Stack.PushStackFrame()
 		defer state.Stack.PopStackFrame()
 		for _, element := range arrayval {
-			err := state.Stack.SetAtScope(node.indexVariable, &element)
+			err := state.Stack.SetAtScope(node.indexVariable, element)
 			if err != nil {
 				return nil, err
 			}
@@ -356,7 +356,7 @@ func (node *ForLoopTwoVariableNode) Execute(state *runtime.State) (*BlockExitPay
 			if err != nil {
 				return nil, err
 			}
-			err = state.Stack.SetAtScope(node.valueIndexVariable, &element)
+			err = state.Stack.SetAtScope(node.valueIndexVariable, element)
 			if err != nil {
 				return nil, err
 			}
@@ -573,7 +573,7 @@ func (node *ForLoopMultivariableNode) executeOuter(
 				return nil, err
 			}
 
-			blockExitPayload, err := node.executeOuter(&element, keyIndexVariables[1:], state)
+			blockExitPayload, err := node.executeOuter(element, keyIndexVariables[1:], state)
 			if err != nil {
 				return nil, err
 			}
@@ -663,7 +663,7 @@ func (node *ForLoopMultivariableNode) executeInner(
 			if err != nil {
 				return nil, err
 			}
-			err = state.Stack.SetAtScope(node.valueIndexVariable, &element)
+			err = state.Stack.SetAtScope(node.valueIndexVariable, element)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/pkg/dsl/cst/hofs.go
+++ b/internal/pkg/dsl/cst/hofs.go
@@ -224,10 +224,10 @@ func selectArray(
 	udfCallsite := hofSpace.udfCallsite
 	argsArray := hofSpace.argsArray
 
-	outputArray := make([]mlrval.Mlrval, 0, len(inputArray))
+	outputArray := make([]*mlrval.Mlrval, 0, len(inputArray))
 
 	for i := range inputArray {
-		argsArray[0] = &inputArray[i]
+		argsArray[0] = inputArray[i]
 		mret := udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray)
 		bret, ok := mret.GetBoolValue()
 		if !ok {
@@ -239,7 +239,7 @@ func selectArray(
 			os.Exit(1)
 		}
 		if bret {
-			outputArray = append(outputArray, *inputArray[i].Copy())
+			outputArray = append(outputArray, inputArray[i].Copy())
 		}
 	}
 	return mlrval.FromArray(outputArray)
@@ -315,13 +315,14 @@ func applyArray(
 	udfCallsite := hofSpace.udfCallsite
 	argsArray := hofSpace.argsArray
 
-	outputArray := make([]mlrval.Mlrval, len(inputArray))
+	outputArray := make([]*mlrval.Mlrval, len(inputArray))
 
 	for i := range inputArray {
-		argsArray[0] = &inputArray[i]
-		retval := *(udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray))
-		isNonAbsentOrDie(&retval, "apply")
-		outputArray[i] = retval
+		argsArray[0] = inputArray[i]
+		outputArray[i] = isNonAbsentOrDie(
+			(udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray)),
+			"apply",
+		)
 	}
 	return mlrval.FromArray(outputArray)
 }
@@ -393,7 +394,7 @@ func reduceArray(
 
 	for i := 1; i < n; i++ {
 		argsArray[0] = accumulator
-		argsArray[1] = &inputArray[i]
+		argsArray[1] = inputArray[i]
 		accumulator = (udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray))
 		isNonAbsentOrDie(accumulator, "apply")
 	}
@@ -470,7 +471,7 @@ func foldArray(
 
 	for i := range inputArray {
 		argsArray[0] = accumulator
-		argsArray[1] = &inputArray[i]
+		argsArray[1] = inputArray[i]
 		accumulator = (udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray))
 		isNonAbsentOrDie(accumulator, "apply")
 	}
@@ -612,19 +613,19 @@ func sortA(
 	return output
 }
 
-func sortANumerical(array []mlrval.Mlrval, reverse bool) {
+func sortANumerical(array []*mlrval.Mlrval, reverse bool) {
 	if !reverse {
 		sort.Slice(array, func(i, j int) bool {
-			return mlrval.LessThan(&array[i], &array[j])
+			return mlrval.LessThan(array[i], array[j])
 		})
 	} else {
 		sort.Slice(array, func(i, j int) bool {
-			return mlrval.GreaterThan(&array[i], &array[j])
+			return mlrval.GreaterThan(array[i], array[j])
 		})
 	}
 }
 
-func sortALexical(array []mlrval.Mlrval, reverse bool) {
+func sortALexical(array []*mlrval.Mlrval, reverse bool) {
 	if !reverse {
 		sort.Slice(array, func(i, j int) bool {
 			return array[i].String() < array[j].String()
@@ -636,7 +637,7 @@ func sortALexical(array []mlrval.Mlrval, reverse bool) {
 	}
 }
 
-func sortACaseFold(array []mlrval.Mlrval, reverse bool) {
+func sortACaseFold(array []*mlrval.Mlrval, reverse bool) {
 	if !reverse {
 		sort.Slice(array, func(i, j int) bool {
 			return strings.ToLower(array[i].String()) < strings.ToLower(array[j].String())
@@ -761,8 +762,8 @@ func sortAF(
 	outputArray := mlrval.CopyMlrvalArray(inputArray)
 
 	sort.Slice(outputArray, func(i, j int) bool {
-		argsArray[0] = &outputArray[i]
-		argsArray[1] = &outputArray[j]
+		argsArray[0] = outputArray[i]
+		argsArray[1] = outputArray[j]
 		// Call the user's comparator function.
 		mret := udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray)
 		// Unpack the mlrval.Mlrval return value into a number.
@@ -865,7 +866,7 @@ func anyArray(
 
 	boolAny := false
 	for i := range inputArray {
-		argsArray[0] = &inputArray[i]
+		argsArray[0] = inputArray[i]
 		mret := udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray)
 		bret, ok := mret.GetBoolValue()
 		if !ok {
@@ -957,7 +958,7 @@ func everyArray(
 
 	boolEvery := true
 	for i := range inputArray {
-		argsArray[0] = &inputArray[i]
+		argsArray[0] = inputArray[i]
 		mret := udfCallsite.EvaluateWithArguments(state, udfCallsite.udf, argsArray)
 		bret, ok := mret.GetBoolValue()
 		if !ok {

--- a/internal/pkg/dsl/cst/lvalues.go
+++ b/internal/pkg/dsl/cst/lvalues.go
@@ -1016,7 +1016,7 @@ func (node *IndexedLvalueNode) Assign(
 	// This lets the user do '$y[ ["a", "b", "c"] ] = $x' in lieu of
 	// '$y["a"]["b"]["c"] = $x'.
 	if len(indices) == 1 && indices[0].IsArray() {
-		indices = mlrval.MakePointerArray(indices[0].GetArray())
+		indices = mlrval.CopyMlrvalArray(indices[0].GetArray())
 	}
 
 	return node.baseLvalue.AssignIndexed(rvalue, indices, state)

--- a/internal/pkg/mlrval/mlrmap_accessors.go
+++ b/internal/pkg/mlrval/mlrmap_accessors.go
@@ -343,7 +343,7 @@ func (mlrmap *Mlrmap) getWithMlrvalArrayIndex(index *Mlrval) (*Mlrval, error) {
 	array := index.arrayval
 	n := len(array)
 	for i, piece := range array {
-		next, err := current.GetWithMlrvalIndex(&piece)
+		next, err := current.GetWithMlrvalIndex(piece)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/mlrval/mlrmap_flatten_unflatten.go
+++ b/internal/pkg/mlrval/mlrmap_flatten_unflatten.go
@@ -143,7 +143,7 @@ func (mlrmap *Mlrmap) CopyUnflattened(
 			affectedBaseIndices[baseIndex] = true
 			// Use PutIndexed to assign $x["a"] = 7, or $x["b"] = 8, etc.
 			other.PutIndexed(
-				MakePointerArray(arrayOfIndices.arrayval),
+				CopyMlrvalArray(arrayOfIndices.arrayval),
 				unflattenTerminal(pe.Value).Copy(),
 			)
 		} else {
@@ -193,7 +193,7 @@ func (mlrmap *Mlrmap) CopyUnflattenFields(
 			if fieldNameSet[baseIndex] {
 				// Use PutIndexed to assign $x["a"] = 7, or $x["b"] = 8, etc.
 				other.PutIndexed(
-					MakePointerArray(arrayOfIndices.arrayval),
+					CopyMlrvalArray(arrayOfIndices.arrayval),
 					unflattenTerminal(pe.Value).Copy(),
 				)
 				affectedBaseIndices[baseIndex] = true
@@ -234,7 +234,7 @@ func unflattenTerminal(input *Mlrval) *Mlrval {
 		return FromMap(NewMlrmap())
 	}
 	if input.printrep == "[]" {
-		return FromArray(make([]Mlrval, 0))
+		return FromArray(make([]*Mlrval, 0))
 	}
 	return input
 }
@@ -244,10 +244,10 @@ func unflattenTerminal(input *Mlrval) *Mlrval {
 func SplitAXHelper(input string, separator string) *Mlrval {
 	fields := lib.SplitString(input, separator)
 
-	output := FromArray(make([]Mlrval, len(fields)))
+	output := FromArray(make([]*Mlrval, len(fields)))
 
 	for i, field := range fields {
-		output.arrayval[i] = *FromString(field)
+		output.arrayval[i] = FromString(field)
 	}
 
 	return output

--- a/internal/pkg/mlrval/mlrval_accessors.go
+++ b/internal/pkg/mlrval/mlrval_accessors.go
@@ -14,18 +14,14 @@ func (mv *Mlrval) GetArrayLength() (int, bool) {
 	}
 }
 
-func CopyMlrvalArray(input []Mlrval) []Mlrval {
-	output := make([]Mlrval, len(input))
-	for i, element := range input {
-		output[i] = *element.Copy()
-	}
-	return output
-}
-
-func CopyMlrvalPointerArray(input []*Mlrval) []*Mlrval {
+func CopyMlrvalArray(input []*Mlrval) []*Mlrval {
 	output := make([]*Mlrval, len(input))
 	for i, element := range input {
-		output[i] = element.Copy()
+		if element == nil {
+			output[i] = nil
+		} else {
+			output[i] = element.Copy()
+		}
 	}
 	return output
 }

--- a/internal/pkg/mlrval/mlrval_collections.go
+++ b/internal/pkg/mlrval/mlrval_collections.go
@@ -128,27 +128,26 @@ func (mv *Mlrval) ArrayPut(mindex *Mlrval, value *Mlrval) {
 }
 
 // ----------------------------------------------------------------
-func arrayGetAliased(array *[]Mlrval, mindex int) *Mlrval {
+func arrayGetAliased(array *[]*Mlrval, mindex int) *Mlrval {
 	zindex, ok := UnaliasArrayIndex(array, mindex)
 	if ok {
-		return &(*array)[zindex]
+		return (*array)[zindex]
 	} else {
 		return nil
 	}
 }
 
-func arrayPutAliased(array *[]Mlrval, mindex int, value *Mlrval) bool {
+func arrayPutAliased(array *[]*Mlrval, mindex int, value *Mlrval) bool {
 	zindex, ok := UnaliasArrayIndex(array, mindex)
 	if ok {
-		clone := value.Copy()
-		(*array)[zindex] = *clone
+		(*array)[zindex] = value.Copy()
 		return true
 	} else {
 		return false
 	}
 }
 
-func UnaliasArrayIndex(array *[]Mlrval, mindex int) (int, bool) {
+func UnaliasArrayIndex(array *[]*Mlrval, mindex int) (int, bool) {
 	n := int(len(*array))
 	return UnaliasArrayLengthIndex(n, mindex)
 }
@@ -214,7 +213,7 @@ func (mv *Mlrval) ArrayAppend(value *Mlrval) {
 		// Silent no-ops are not good UX ...
 		return
 	}
-	mv.arrayval = append(mv.arrayval, *value)
+	mv.arrayval = append(mv.arrayval, value)
 }
 
 // ================================================================
@@ -366,7 +365,7 @@ func putIndexedOnMap(baseMap *Mlrmap, indices []*Mlrval, rvalue *Mlrval) error {
 // ----------------------------------------------------------------
 // Helper function for Mlrval.PutIndexed, for mlrvals of array type.
 func putIndexedOnArray(
-	baseArray *[]Mlrval,
+	baseArray *[]*Mlrval,
 	indices []*Mlrval,
 	rvalue *Mlrval,
 ) error {
@@ -387,7 +386,7 @@ func putIndexedOnArray(
 	if numIndices == 1 {
 		// If last index, then assign.
 		if inBounds {
-			(*baseArray)[zindex] = *rvalue.Copy()
+			(*baseArray)[zindex] = rvalue.Copy()
 		} else if mindex.intval == 0 {
 			return errors.New("mlr: zero indices are not supported. Indices are 1-up.")
 		} else if mindex.intval < 0 {
@@ -397,7 +396,7 @@ func putIndexedOnArray(
 			// Given mindex is 4.
 			LengthenMlrvalArray(baseArray, mindex.intval)
 			zindex := mindex.intval - 1
-			(*baseArray)[zindex] = *rvalue.Copy()
+			(*baseArray)[zindex] = rvalue.Copy()
 		}
 		return nil
 
@@ -409,11 +408,11 @@ func putIndexedOnArray(
 			// Overwrite what's in this slot if it's the wrong type
 			if nextIndex.IsString() {
 				if !(*baseArray)[zindex].IsMap() {
-					(*baseArray)[zindex] = *FromEmptyMap()
+					(*baseArray)[zindex] = FromEmptyMap()
 				}
 			} else if nextIndex.IsInt() {
 				if !(*baseArray)[zindex].IsArray() {
-					(*baseArray)[zindex] = *FromEmptyArray()
+					(*baseArray)[zindex] = FromEmptyArray()
 				}
 			} else {
 				return errors.New(
@@ -497,7 +496,7 @@ func removeIndexedOnMap(baseMap *Mlrmap, indices []*Mlrval) error {
 // ----------------------------------------------------------------
 // Helper function for Mlrval.PutIndexed, for mlrvals of array type.
 func removeIndexedOnArray(
-	baseArray *[]Mlrval,
+	baseArray *[]*Mlrval,
 	indices []*Mlrval,
 ) error {
 	numIndices := len(indices)
@@ -539,18 +538,6 @@ func removeIndexedOnArray(
 	}
 
 	return nil
-}
-
-// ----------------------------------------------------------------
-// Used for API-matching in multi-index contexts.
-func MakePointerArray(
-	valueArray []Mlrval,
-) (pointerArray []*Mlrval) {
-	pointerArray = make([]*Mlrval, len(valueArray))
-	for i := range valueArray {
-		pointerArray[i] = &valueArray[i]
-	}
-	return pointerArray
 }
 
 // ----------------------------------------------------------------
@@ -693,10 +680,10 @@ func (mv *Mlrval) Arrayify() *Mlrval {
 		}
 
 		if convertible {
-			arrayval := make([]Mlrval, mv.mapval.FieldCount)
+			arrayval := make([]*Mlrval, mv.mapval.FieldCount)
 			i := 0
 			for pe := mv.mapval.Head; pe != nil; pe = pe.Next {
-				arrayval[i] = *pe.Value.Copy()
+				arrayval[i] = pe.Value.Copy()
 				i++
 			}
 			return FromArray(arrayval)
@@ -709,7 +696,7 @@ func (mv *Mlrval) Arrayify() *Mlrval {
 		// TODO: comment (or rethink) that this modifies its inputs!!
 		output := mv.Copy()
 		for i := range mv.arrayval {
-			output.arrayval[i] = *output.arrayval[i].Arrayify()
+			output.arrayval[i] = output.arrayval[i].Arrayify()
 		}
 		return output
 
@@ -718,7 +705,7 @@ func (mv *Mlrval) Arrayify() *Mlrval {
 	}
 }
 
-func LengthenMlrvalArray(array *[]Mlrval, newLength64 int) {
+func LengthenMlrvalArray(array *[]*Mlrval, newLength64 int) {
 	newLength := int(newLength64)
 	lib.InternalCodingErrorIf(newLength <= len(*array))
 
@@ -726,18 +713,18 @@ func LengthenMlrvalArray(array *[]Mlrval, newLength64 int) {
 		newArray := (*array)[:newLength]
 		for zindex := len(*array); zindex < newLength; zindex++ {
 			// TODO: comment why not MT_ABSENT or MT_VOID
-			newArray[zindex] = *NULL
+			newArray[zindex] = NULL
 		}
 		*array = newArray
 	} else {
-		newArray := make([]Mlrval, newLength, 2*newLength)
+		newArray := make([]*Mlrval, newLength, 2*newLength)
 		zindex := 0
 		for zindex = 0; zindex < len(*array); zindex++ {
 			newArray[zindex] = (*array)[zindex]
 		}
 		for zindex = len(*array); zindex < newLength; zindex++ {
 			// TODO: comment why not MT_ABSENT or MT_VOID
-			newArray[zindex] = *NULL
+			newArray[zindex] = NULL
 		}
 		*array = newArray
 	}

--- a/internal/pkg/mlrval/mlrval_get.go
+++ b/internal/pkg/mlrval/mlrval_get.go
@@ -63,7 +63,7 @@ func (mv *Mlrval) GetBoolValue() (boolValue bool, isBool bool) {
 	}
 }
 
-func (mv *Mlrval) GetArray() []Mlrval {
+func (mv *Mlrval) GetArray() []*Mlrval {
 	if mv.IsArray() {
 		return mv.arrayval
 	} else {
@@ -120,7 +120,7 @@ func (mv *Mlrval) AcquireBoolValue() bool {
 	return mv.boolval
 }
 
-func (mv *Mlrval) AcquireArrayValue() []Mlrval {
+func (mv *Mlrval) AcquireArrayValue() []*Mlrval {
 	lib.InternalCodingErrorIf(mv.mvtype != MT_ARRAY)
 	return mv.arrayval
 }

--- a/internal/pkg/mlrval/mlrval_is_test.go
+++ b/internal/pkg/mlrval/mlrval_is_test.go
@@ -19,7 +19,7 @@ func TestIsLegit(t *testing.T) {
 	assert.True(t, FromInt(123).IsLegit())
 	assert.True(t, FromFloat(123.4).IsLegit())
 	assert.True(t, FromBool(true).IsLegit())
-	assert.True(t, FromArray([]Mlrval{*FromInt(10)}).IsLegit())
+	assert.True(t, FromArray([]*Mlrval{FromInt(10)}).IsLegit())
 	assert.True(t, FromMap(NewMlrmap()).IsLegit())
 }
 

--- a/internal/pkg/mlrval/mlrval_new.go
+++ b/internal/pkg/mlrval/mlrval_new.go
@@ -213,7 +213,7 @@ func FromFunction(funcval interface{}, name string) *Mlrval {
 	}
 }
 
-func FromArray(arrayval []Mlrval) *Mlrval {
+func FromArray(arrayval []*Mlrval) *Mlrval {
 	return &Mlrval{
 		mvtype:        MT_ARRAY,
 		printrep:      "(bug-if-you-see-this:case-4)", // INVALID_PRINTREP,
@@ -223,7 +223,7 @@ func FromArray(arrayval []Mlrval) *Mlrval {
 }
 
 func FromEmptyArray() *Mlrval {
-	return FromArray(make([]Mlrval, 0))
+	return FromArray(make([]*Mlrval, 0))
 }
 
 func FromMap(mapval *Mlrmap) *Mlrval {

--- a/internal/pkg/mlrval/mlrval_new_test.go
+++ b/internal/pkg/mlrval/mlrval_new_test.go
@@ -128,7 +128,7 @@ func TestFromFunction(t *testing.T) {
 }
 
 func TestFromArray(t *testing.T) {
-	mv := FromArray([]Mlrval{*FromInt(10)})
+	mv := FromArray([]*Mlrval{FromInt(10)})
 	assert.Equal(t, MVType(MT_ARRAY), MVType(mv.mvtype))
 	assert.Equal(t, 1, len(mv.arrayval))
 }

--- a/internal/pkg/mlrval/mlrval_type.go
+++ b/internal/pkg/mlrval/mlrval_type.go
@@ -65,7 +65,7 @@ type Mlrval struct {
 	floatval      float64
 	boolval       bool
 
-	arrayval []Mlrval
+	arrayval []*Mlrval
 	mapval   *Mlrmap
 	// First-class-function literals from internal/pkg/dsl/cst.
 	// Interfaced here to avoid package-dependency cycles.

--- a/internal/pkg/transformers/utils/join-bucket-keeper.go
+++ b/internal/pkg/transformers/utils/join-bucket-keeper.go
@@ -466,7 +466,7 @@ func (keeper *JoinBucketKeeper) fillNextJoinBucket() {
 		os.Exit(1)
 	}
 
-	keeper.JoinBucket.leftFieldValues = mlrval.CopyMlrvalPointerArray(peekFieldValues)
+	keeper.JoinBucket.leftFieldValues = mlrval.CopyMlrvalArray(peekFieldValues)
 	keeper.JoinBucket.RecordsAndContexts.PushBack(keeper.peekRecordAndContext)
 	keeper.JoinBucket.WasPaired = false
 

--- a/scripts/chain-cmps.sh
+++ b/scripts/chain-cmps.sh
@@ -1,5 +1,5 @@
-#mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
-mlrs="mlr5 ./mlr"
+mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
+#mlrs="mlr5 ./mlr"
 
 #reps="1"
 reps="1 2 3"

--- a/scripts/chain-lengths.sh
+++ b/scripts/chain-lengths.sh
@@ -3,6 +3,7 @@ mlrs="mlr5 ~/tmp/miller/mlr ./mlr"
 
 #reps="1"
 reps="1 2 3"
+#reps="1 2 3 4 5 6 7 8 9 10"
 
 echo; for mlr in $mlrs; do
   for k in $reps; do

--- a/todo.txt
+++ b/todo.txt
@@ -14,7 +14,6 @@ FEATURES
     "5d18h53m20s" format in *dhms* commands, but what about "5-18:53:20"? This is
     a common format used by the SLURM resource manager.'
   o linked-to faqent w/ -f -s etc ...
-  o ... AND, if it's frequent then submit a feature request b/c other people probably also would like it! :)
 
 ----------------------------------------------------------------
 k better print-interpolate with {} etc
@@ -121,6 +120,11 @@ UX
 
 ================================================================
 DOC
+
+! slwin / unformat narrative:
+  o prototype in DSL
+  o mlr put -f / mlr -s
+  o and, if it's frequent then submit a feature request b/c other people probably also would like it! :)
 
 ! link to SE table ...
   https://github.com/johnkerl/miller/discussions/609#discussioncomment-1115715


### PR DESCRIPTION
This is entirely a code-neaten without external functional effects.

It also offers maybe a few percent performance increase in some cases but not others.

Context: mlrvals are throughout the code treated as `*Mlrval`, but, `arrayval` slots were `[]Mlrval` which is a bit of an asymmetry. On this PR those are all converted to `[]*Mlrval`.