### PR TITLE
Use raw strings to avoid escapes

### DIFF
--- a/internal/pkg/auxents/unhex.go
+++ b/internal/pkg/auxents/unhex.go
@@ -54,11 +54,7 @@ func unhexFile(istream *os.File, ostream *os.File) {
 	var scanValue int
 	byteArray := make([]byte, 1)
 
-	re, err := regexp.Compile("\\s+")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "mlr unhex: internal coding error detected.")
-		os.Exit(1)
-	}
+	re := regexp.MustCompile(`\s+`)
 
 	eof := false
 	for !eof {

--- a/internal/pkg/bifs/strings.go
+++ b/internal/pkg/bifs/strings.go
@@ -238,7 +238,7 @@ func BIF_collapse_whitespace_regexp(input1 *mlrval.Mlrval, whitespaceRegexp *reg
 }
 
 func WhitespaceRegexp() *regexp.Regexp {
-	return regexp.MustCompile("\\s+")
+	return regexp.MustCompile(`\s+`)
 }
 
 // ================================================================

--- a/internal/pkg/lib/regex.go
+++ b/internal/pkg/lib/regex.go
@@ -38,11 +38,11 @@ import (
 
 // captureDetector is used to see if a string literal interpolates previous
 // captures (like "\2:\1") or not (like "2:1").
-var captureDetector = regexp.MustCompile("\\\\[0-9]")
+var captureDetector = regexp.MustCompile(`\\[0-9]`)
 
 // captureSplitter is used to precompute an offsets matrix for strings like
 // "\2:\1" so they don't need to be recomputed on every record.
-var captureSplitter = regexp.MustCompile("(\\\\[0-9])")
+var captureSplitter = regexp.MustCompile(`(\\[0-9])`)
 
 // CompileMillerRegex wraps Go regex-compile with some Miller-specific syntax
 // which predate the port of Miller from C to Go.  Miller regexes use a final


### PR DESCRIPTION
Especially for regexes, raw strings improve readability since they
aren't escaped.

While we're at it, use MustCompile instead of handling the error and
exiting.

Signed-off-by: Stephen Kitt <steve@sk2.org>