### PR TITLE
Clarify source for printf-style formatting

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -544,9 +544,10 @@ MISCELLANEOUS FLAGS
        --nr-progress-mod {m}    With m a positive integer: print filename and record
                                 count to os.Stderr every m input records.
        --ofmt {format}          E.g. `%.18f`, `%.0f`, `%9.6e`. Please use
-                                sprintf-style codes for floating-point numbers. If
-                                not specified, default formatting is used. See also
-                                the `fmtnum` function and the `format-values` verb.
+                                sprintf-style codes (https://pkg.go.dev/fmt) for
+                                floating-point numbers. If not specified, default
+                                formatting is used. See also the `fmtnum` function
+                                and the `format-values` verb.
        --records-per-batch {n}  This is an internal parameter for maximum number of
                                 records in a batch size. Normally this does not need
                                 to be modified.
@@ -2139,7 +2140,7 @@ FUNCTIONS FOR FILTER/PUT
         (class=math #args=1) Floor: nearest integer at or below.
 
    fmtnum
-        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string, e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
+        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
 
    fold
         (class=higher-order-functions #args=3) Given a map or array as first argument and a function as second argument, accumulates entries into a final output -- for example, sum or product. For arrays, the function should take two arguments, for accumulated value and array element. For maps, it should take four arguments, for accumulated key and value, and map-element key and value; it should return the updated accumulator as a new key-value pair (i.e. a single-entry map). The start value for the accumulator is taken from the third argument.
@@ -3090,5 +3091,5 @@ SEE ALSO
 
 
 
-                                  2022-01-24                         MILLER(1)
+                                  2022-01-25                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -523,9 +523,10 @@ MISCELLANEOUS FLAGS
        --nr-progress-mod {m}    With m a positive integer: print filename and record
                                 count to os.Stderr every m input records.
        --ofmt {format}          E.g. `%.18f`, `%.0f`, `%9.6e`. Please use
-                                sprintf-style codes for floating-point numbers. If
-                                not specified, default formatting is used. See also
-                                the `fmtnum` function and the `format-values` verb.
+                                sprintf-style codes (https://pkg.go.dev/fmt) for
+                                floating-point numbers. If not specified, default
+                                formatting is used. See also the `fmtnum` function
+                                and the `format-values` verb.
        --records-per-batch {n}  This is an internal parameter for maximum number of
                                 records in a batch size. Normally this does not need
                                 to be modified.
@@ -2118,7 +2119,7 @@ FUNCTIONS FOR FILTER/PUT
         (class=math #args=1) Floor: nearest integer at or below.
 
    fmtnum
-        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string, e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
+        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
 
    fold
         (class=higher-order-functions #args=3) Given a map or array as first argument and a function as second argument, accumulates entries into a final output -- for example, sum or product. For arrays, the function should take two arguments, for accumulated value and array element. For maps, it should take four arguments, for accumulated key and value, and map-element key and value; it should return the updated accumulator as a new key-value pair (i.e. a single-entry map). The start value for the accumulator is taken from the third argument.
@@ -3069,4 +3070,4 @@ SEE ALSO
 
 
 
-                                  2022-01-24                         MILLER(1)
+                                  2022-01-25                         MILLER(1)

--- a/docs/src/reference-dsl-builtin-functions.md
+++ b/docs/src/reference-dsl-builtin-functions.md
@@ -487,7 +487,7 @@ float  (class=conversion #args=1) Convert int/float/bool/string to float.
 
 ### fmtnum
 <pre class="pre-non-highlight-non-pair">
-fmtnum  (class=conversion #args=2) Convert int/float/bool to string using printf-style format string, e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
+fmtnum  (class=conversion #args=2) Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
 </pre>
 
 

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -266,7 +266,7 @@ These are flags which don't fit into any other category.
 * `--no-fflush`: Let buffered output not be written after every output record. The default is flush output after every record if the output is to the terminal, or less often if the output is to a file or a pipe. The default is a significant performance optimization for large files.  Use this flag to allow less-frequent updates when output is to the terminal. This is unlikely to be a noticeable performance improvement, since direct-to-screen output for large files has its own overhead.
 * `--no-hash-records`: See --hash-records.
 * `--nr-progress-mod {m}`: With m a positive integer: print filename and record count to os.Stderr every m input records.
-* `--ofmt {format}`: E.g. `%.18f`, `%.0f`, `%9.6e`. Please use sprintf-style codes for floating-point numbers. If not specified, default formatting is used.  See also the `fmtnum` function and the `format-values` verb.
+* `--ofmt {format}`: E.g. `%.18f`, `%.0f`, `%9.6e`. Please use sprintf-style codes (https://pkg.go.dev/fmt) for floating-point numbers. If not specified, default formatting is used.  See also the `fmtnum` function and the `format-values` verb.
 * `--records-per-batch {n}`: This is an internal parameter for maximum number of records in a batch size. Normally this does not need to be modified.
 * `--seed {n}`: with `n` of the form `12345678` or `0xcafefeed`. For `put`/`filter` `urand`, `urandint`, and `urand32`.
 * `--tz {timezone}`: Specify timezone, overriding `$TZ` environment variable (if any).

--- a/docs/src/reference-main-number-formatting.md
+++ b/docs/src/reference-main-number-formatting.md
@@ -24,7 +24,11 @@ The command-line option `--ofmt {format string}` is the global number format for
 --ofmt %.9e --ofmt %.6f --ofmt %.0f
 </pre>
 
-These are just familiar `printf` formats. Additionally, if you use leading width (e.g. `%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr --opprint`) to column-align numerical data.
+These are just familiar `printf` formats -- as of Miller 6.0.0, supported options are those at
+[https://pkg.go.dev/fmt](https://pkg.go.dev/fmt).  Additionally, if you use leading width (e.g.
+`%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you
+pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr
+--opprint`) to column-align numerical data.
 
 <pre class="pre-highlight-in-pair">
 <b>echo 'x=3.1,y=4.3' | mlr --ofmt '%8.3f' cat</b>

--- a/docs/src/reference-main-number-formatting.md.in
+++ b/docs/src/reference-main-number-formatting.md.in
@@ -8,7 +8,11 @@ GENMD-CARDIFY
 --ofmt %.9e --ofmt %.6f --ofmt %.0f
 GENMD-EOF
 
-These are just familiar `printf` formats. Additionally, if you use leading width (e.g. `%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr --opprint`) to column-align numerical data.
+These are just familiar `printf` formats -- as of Miller 6.0.0, supported options are those at
+[https://pkg.go.dev/fmt](https://pkg.go.dev/fmt).  Additionally, if you use leading width (e.g.
+`%18.12f`) then the output will contain embedded whitespace, which may not be what you want if you
+pipe the output to something else, particularly CSV. I use Miller's pretty-print format (`mlr
+--opprint`) to column-align numerical data.
 
 GENMD-RUN-COMMAND
 echo 'x=3.1,y=4.3' | mlr --ofmt '%8.3f' cat

--- a/internal/pkg/cli/option_parse.go
+++ b/internal/pkg/cli/option_parse.go
@@ -2751,7 +2751,7 @@ var MiscFlagSection = FlagSection{
 		{
 			name: "--ofmt",
 			arg:  "{format}",
-			help: "E.g. `%.18f`, `%.0f`, `%9.6e`. Please use sprintf-style codes for floating-point numbers. If not specified, default formatting is used.  See also the `fmtnum` function and the `format-values` verb.",
+			help: "E.g. `%.18f`, `%.0f`, `%9.6e`. Please use sprintf-style codes (https://pkg.go.dev/fmt) for floating-point numbers. If not specified, default formatting is used.  See also the `fmtnum` function and the `format-values` verb.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
 				CheckArgCount(args, *pargi, argc, 2)
 				options.WriterOptions.FPOFMT = args[*pargi+1]

--- a/internal/pkg/dsl/cst/builtin_function_manager.go
+++ b/internal/pkg/dsl/cst/builtin_function_manager.go
@@ -1395,7 +1395,7 @@ strftime_local.`,
 		{
 			name:  "fmtnum",
 			class: FUNC_CLASS_CONVERSION,
-			help: `Convert int/float/bool to string using printf-style format string, e.g.
+			help: `Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g.
 '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.`,
 			binaryFunc: bifs.BIF_fmtnum,
 		},

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -523,9 +523,10 @@ MISCELLANEOUS FLAGS
        --nr-progress-mod {m}    With m a positive integer: print filename and record
                                 count to os.Stderr every m input records.
        --ofmt {format}          E.g. `%.18f`, `%.0f`, `%9.6e`. Please use
-                                sprintf-style codes for floating-point numbers. If
-                                not specified, default formatting is used. See also
-                                the `fmtnum` function and the `format-values` verb.
+                                sprintf-style codes (https://pkg.go.dev/fmt) for
+                                floating-point numbers. If not specified, default
+                                formatting is used. See also the `fmtnum` function
+                                and the `format-values` verb.
        --records-per-batch {n}  This is an internal parameter for maximum number of
                                 records in a batch size. Normally this does not need
                                 to be modified.
@@ -2118,7 +2119,7 @@ FUNCTIONS FOR FILTER/PUT
         (class=math #args=1) Floor: nearest integer at or below.
 
    fmtnum
-        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string, e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
+        (class=conversion #args=2) Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
 
    fold
         (class=higher-order-functions #args=3) Given a map or array as first argument and a function as second argument, accumulates entries into a final output -- for example, sum or product. For arrays, the function should take two arguments, for accumulated value and array element. For maps, it should take four arguments, for accumulated key and value, and map-element key and value; it should return the updated accumulator as a new key-value pair (i.e. a single-entry map). The start value for the accumulator is taken from the third argument.
@@ -3069,4 +3070,4 @@ SEE ALSO
 
 
 
-                                  2022-01-24                         MILLER(1)
+                                  2022-01-25                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2022-01-24
+.\"      Date: 2022-01-25
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2022-01-24" "\ \&" "\ \&"
+.TH "MILLER" "1" "2022-01-25" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -634,9 +634,10 @@ These are flags which don't fit into any other category.
 --nr-progress-mod {m}    With m a positive integer: print filename and record
                          count to os.Stderr every m input records.
 --ofmt {format}          E.g. `%.18f`, `%.0f`, `%9.6e`. Please use
-                         sprintf-style codes for floating-point numbers. If
-                         not specified, default formatting is used. See also
-                         the `fmtnum` function and the `format-values` verb.
+                         sprintf-style codes (https://pkg.go.dev/fmt) for
+                         floating-point numbers. If not specified, default
+                         formatting is used. See also the `fmtnum` function
+                         and the `format-values` verb.
 --records-per-batch {n}  This is an internal parameter for maximum number of
                          records in a batch size. Normally this does not need
                          to be modified.
@@ -2955,7 +2956,7 @@ Two-argument version: flatten($*, ".") is the same as flatten("", ".", $*).
 .RS 0
 .\}
 .nf
- (class=conversion #args=2) Convert int/float/bool to string using printf-style format string, e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
+ (class=conversion #args=2) Convert int/float/bool to string using printf-style format string (https://pkg.go.dev/fmt), e.g. '$s = fmtnum($n, "%08d")' or '$t = fmtnum($n, "%.6e")'.
 .fi
 .if n \{\
 .RE


### PR DESCRIPTION
In the C implementation (pre Miller 6) `fmtnum` used the C library's `sprintf`. In the Go implementation, it uses the Go library's `fmt.Sprintf`. These needs to be clear in the documentation, as there are a few differences between what the two libraries support.