### PR TITLE
Fix operator-precedence doc table to match DSL grammar

### DIFF
--- a/docs/src/reference-dsl-operators.md
+++ b/docs/src/reference-dsl-operators.md
@@ -28,9 +28,9 @@ Operators are listed in order of decreasing precedence, highest first.
 |-------------------------------|---------------|
 | `()` `{}` `[]`                | left to right |
 | `**`                          | right to left |
-| `!` `~` unary`+` unary`-` `&` | right to left |
-| binary`*` `/` `//` `%`        | left to right |
+| `!` `~` unary`+` unary`-`     | right to left |
 | `.`                           | left to right |
+| `*` `/` `//` `%`              | left to right |
 | binary`+` binary`-`           | left to right |
 | `<<` `>>` `>>>`               | left to right |
 | `&`                           | left to right |

--- a/docs/src/reference-dsl-operators.md.in
+++ b/docs/src/reference-dsl-operators.md.in
@@ -12,9 +12,9 @@ Operators are listed in order of decreasing precedence, highest first.
 |-------------------------------|---------------|
 | `()` `{}` `[]`                | left to right |
 | `**`                          | right to left |
-| `!` `~` unary`+` unary`-` `&` | right to left |
-| binary`*` `/` `//` `%`        | left to right |
+| `!` `~` unary`+` unary`-`     | right to left |
 | `.`                           | left to right |
+| `*` `/` `//` `%`              | left to right |
 | binary`+` binary`-`           | left to right |
 | `<<` `>>` `>>>`               | left to right |
 | `&`                           | left to right |


### PR DESCRIPTION
For #909 and #906

Reference info:

https://github.com/johnkerl/miller/blob/main/internal/pkg/parsing/mlr.bnf#L1462

```
$ mlr5 -n put -v 'a = b / c . d'
RAW AST:

AST ROOT:
text="block", type=STATEMENT_BLOCK:
    text="=", type=NONINDEXED_LOCAL_ASSIGNMENT:
        text="a", type=NONINDEXED_LOCAL_VARIABLE.
        text=".", type=OPERATOR:
            text="/", type=OPERATOR:
                text="b", type=NONINDEXED_LOCAL_VARIABLE.
                text="c", type=NONINDEXED_LOCAL_VARIABLE.
            text="d", type=NONINDEXED_LOCAL_VARIABLE.
```

```
$ mlr -n put -v 'a = b / c . d'
DSL EXPRESSION:
a = b / c . d

AST:
* statement block
    * assignment "="
        * local variable "a"
        * operator "/"
            * local variable "b"
            * dot operator "."
                * local variable "c"
                * local variable "d"
```
