### PR TITLE
Support unicode literals in the Miller DSL

### DIFF
--- a/internal/pkg/lib/unbackslash_test.go
+++ b/internal/pkg/lib/unbackslash_test.go
@@ -29,6 +29,9 @@ var dataForUnbackslash = []tDataForUnbackslash{
 	{`a\x42c`, `aBc`},
 	{`[\101\102\103]`, `[ABC]`},
 	{`[\x44\x45\x46]`, `[DEF]`},
+	{`\u2766`, `❦`},
+	{`\U00010877`, `𐡷`},
+	{`a\u0062c`, `abc`},
 }
 
 func TestUnbackslash(t *testing.T) {

--- a/internal/pkg/lib/unbackslash_test.go
+++ b/internal/pkg/lib/unbackslash_test.go
@@ -19,16 +19,16 @@ type tDataForUnbackslash struct {
 var dataForUnbackslash = []tDataForUnbackslash{
 	{"", ""},
 	{"abcde", "abcde"},
-	{"\\1", "\\1"},
-	{"a\\tb\\tc", "a\tb\tc"},
-	{"a\\fb\\rc", "a\fb\rc"},
-	{"a\"b\"c", "a\"b\"c"},
-	{"a\\\"b\\\"c", "a\"b\"c"},
-	{"a\\'b\\'c", "a'b'c"},
-	{"a\102c", "aBc"},
-	{"a\x42c", "aBc"},
-	{"[\101\102\103]", "[ABC]"},
-	{"[\x44\x45\x46]", "[DEF]"},
+	{`\1`, `\1`},
+	{`a\tb\tc`, "a\tb\tc"},
+	{`a\fb\rc`, "a\fb\rc"},
+	{`a"b"c`, `a"b"c`},
+	{`a\"b\"c`, `a"b"c`},
+	{`a\'b\'c`, `a'b'c`},
+	{`a\102c`, `aBc`},
+	{`a\x42c`, `aBc`},
+	{`[\101\102\103]`, `[ABC]`},
+	{`[\x44\x45\x46]`, `[DEF]`},
 }
 
 func TestUnbackslash(t *testing.T) {


### PR DESCRIPTION
Example:

```
$ mlr repl
Miller 6.0.0-dev REPL for darwin/amd64/go1.16.5
Docs: https://miller.readthedocs.io
Type ':h' or ':help' for online help; ':q' or ':quit' to quit.

[mlr] "a\x62c"
"abc"

[mlr] "a\u0062c"
"abc"

[mlr] "<\u2766>"
"<❦>"
```