### PR TITLE
Add :resetblocks / :rb to REPL

### DIFF
--- a/internal/pkg/auxents/repl/verbs.go
+++ b/internal/pkg/auxents/repl/verbs.go
@@ -54,6 +54,7 @@ func init() {
 		{verbNames: []string{":e", ":end"}, handlerFunc: handleEnd, usageFunc: usageEnd},
 		{verbNames: []string{":astprint"}, handlerFunc: handleASTPrint, usageFunc: usageASTPrint},
 		{verbNames: []string{":blocks"}, handlerFunc: handleBlocks, usageFunc: usageBlocks},
+		{verbNames: []string{":rb", ":resetblocks"}, handlerFunc: handleResetBlocks, usageFunc: usageResetBlocks},
 		{verbNames: []string{":q", ":quit"}, handlerFunc: nil, usageFunc: usageQuit},
 		{verbNames: []string{":h", ":help"}, handlerFunc: handleHelp, usageFunc: usageHelp},
 	}
@@ -108,11 +109,16 @@ func (repl *Repl) handleNonDSLLine(trimmedLine string) bool {
 
 	// TODO: describe me
 	if strings.HasPrefix(verbName, "??") {
-		handleHelpFindSingle(repl, verbName[2:])
-		return true
-	}
-	if strings.HasPrefix(verbName, "?") {
-		handleHelpSingle(repl, verbName[1:])
+		if verbName[2:] != "" {
+			handleHelpFindSingle(repl, verbName[2:])
+			return true
+		}
+	} else if strings.HasPrefix(verbName, "?") {
+		if verbName[1:] != "" {
+			handleHelpSingle(repl, verbName[1:])
+		} else {
+			usageHelp(repl)
+		}
 		return true
 	}
 
@@ -815,6 +821,21 @@ func handleBlocks(repl *Repl, args []string) bool {
 		return false
 	}
 	repl.cstRootNode.ShowBlockReport()
+	return true
+}
+
+// ----------------------------------------------------------------
+func usageResetBlocks(repl *Repl) {
+	fmt.Println(":resetblocks with no arguments.")
+	fmt.Println("Clears out all begin, main, and end blocks that have been loaded.")
+
+}
+func handleResetBlocks(repl *Repl, args []string) bool {
+	args = args[1:] // strip off verb
+	if len(args) != 0 {
+		return false
+	}
+	repl.cstRootNode.ResetBlocksForREPL()
 	return true
 }
 

--- a/internal/pkg/dsl/cst/root.go
+++ b/internal/pkg/dsl/cst/root.go
@@ -501,3 +501,10 @@ func (root *RootNode) ShowBlockReport() {
 	fmt.Printf("#main  %d\n", len(root.mainBlock.executables))
 	fmt.Printf("#end   %d\n", len(root.endBlocks))
 }
+
+// This is for the REPL's resetblocks command.
+func (root *RootNode) ResetBlocksForREPL() {
+	root.beginBlocks = make([]*StatementBlockNode, 0)
+	root.mainBlock.executables = make([]IExecutable, 0)
+	root.endBlocks = make([]*StatementBlockNode, 0)
+}


### PR DESCRIPTION
This is for https://github.com/johnkerl/miller/issues/918

```
$ rlwrap mlr repl
Miller 6.0.0-dev REPL for darwin/amd64/go1.17
Docs: https://miller.readthedocs.io
Type ':h' or ':help' for online help; ':q' or ':quit' to quit.

[mlr] :h repl-list
:l or :load
:o or :open
:reopen
:r or :read
:w or :write
:rw
:c or :context
:s or :skip
:p or :process
:w or :>
:w or :>>
:b or :begin
:m or :main
:e or :end
:astprint
:blocks
:rb or :resetblocks
:q or :quit
:h or :help

[mlr] :h :rb
:rb
:resetblocks with no arguments.
Clears out all begin, main, and end blocks that have been loaded.

[mlr] :blocks
#begin 0
#main  0
#end   0

[mlr] begin { print "Hello" }
[mlr] end { print "world!" }
[mlr] :b
Hello
[mlr] :e
world!
[mlr] :blocks
#begin 1
#main  0
#end   1

[mlr] :rb

[mlr] :b
[mlr] :e
[mlr] :blocks
#begin 0
#main  0
#end   0
[mlr]
```