### PR TITLE
New --lazy-quotes flag for helping with malformed CSV

### DIFF
--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -133,6 +133,8 @@ Here are the differences between CSV and CSV-lite:
 
 CSV, TSV, CSV-lite, and TSV-lite have in common the `--implicit-csv-header` flag for input and the `--headerless-csv-output` flag for output.
 
+See also the [`--lazy-quotes` flag](reference-main-flag-list.md#csv-only-flags) which can help with CSV files which are not fully compliant with RFC-4180.
+
 ## JSON
 
 [JSON](https://json.org) is a format which supports scalars (numbers, strings,

--- a/docs/src/file-formats.md.in
+++ b/docs/src/file-formats.md.in
@@ -45,6 +45,8 @@ Here are the differences between CSV and CSV-lite:
 
 CSV, TSV, CSV-lite, and TSV-lite have in common the `--implicit-csv-header` flag for input and the `--headerless-csv-output` flag for output.
 
+See also the [`--lazy-quotes` flag](reference-main-flag-list.md#csv-only-flags) which can help with CSV files which are not fully compliant with RFC-4180.
+
 ## JSON
 
 [JSON](https://json.org) is a format which supports scalars (numbers, strings,

--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -320,6 +320,8 @@ CSV-ONLY FLAGS
                                 Use 1,2,3,... as field labels, rather than from line
                                 1 of input files. Tip: combine with `label` to
                                 recreate missing headers.
+       --lazy-quotes            Accepts quotes appearing in unquoted fields, and
+                                non-doubled quotes appearing in quoted fields.
        --no-implicit-csv-header Opposite of `--implicit-csv-header`. This is the
                                 default anyway -- the main use is for the flags to
                                 `mlr join` if you have main file(s) which are

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -299,6 +299,8 @@ CSV-ONLY FLAGS
                                 Use 1,2,3,... as field labels, rather than from line
                                 1 of input files. Tip: combine with `label` to
                                 recreate missing headers.
+       --lazy-quotes            Accepts quotes appearing in unquoted fields, and
+                                non-doubled quotes appearing in quoted fields.
        --no-implicit-csv-header Opposite of `--implicit-csv-header`. This is the
                                 default anyway -- the main use is for the flags to
                                 `mlr join` if you have main file(s) which are

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -119,6 +119,7 @@ These are flags which are applicable to CSV format.
 * `--allow-ragged-csv-input or --ragged`: If a data line has fewer fields than the header line, fill remaining keys with empty string. If a data line has more fields than the header line, use integer field labels as in the implicit-header case.
 * `--headerless-csv-output or --ho`: Print only CSV data lines; do not print CSV header lines.
 * `--implicit-csv-header or --headerless-csv-input or --hi`: Use 1,2,3,... as field labels, rather than from line 1 of input files. Tip: combine with `label` to recreate missing headers.
+* `--lazy-quotes`: Accepts quotes appearing in unquoted fields, and non-doubled quotes appearing in quoted fields.
 * `--no-implicit-csv-header`: Opposite of `--implicit-csv-header`. This is the default anyway -- the main use is for the flags to `mlr join` if you have main file(s) which are headerless but you want to join in on a file which does have a CSV header. Then you could use `mlr --csv --implicit-csv-header join --no-implicit-csv-header -l your-join-in-with-header.csv ... your-headerless.csv`.
 * `-N`: Keystroke-saver for `--implicit-csv-header --headerless-csv-output`.
 

--- a/internal/pkg/cli/option_parse.go
+++ b/internal/pkg/cli/option_parse.go
@@ -1322,6 +1322,7 @@ var FormatConversionKeystrokeSaverFlagSection = FlagSection{
 				options.WriterOptions.OutputFileFormat = "nidx"
 				options.WriterOptions.OFS = " "
 				options.WriterOptions.ofsWasSpecified = true
+				options.ReaderOptions.CSVLazyQuotes = true
 				*pargi += 1
 			},
 		},
@@ -2129,6 +2130,15 @@ var CSVOnlyFlagSection = FlagSection{
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
 				options.ReaderOptions.UseImplicitCSVHeader = true
 				options.WriterOptions.HeaderlessCSVOutput = true
+				*pargi += 1
+			},
+		},
+
+		{
+			name: "--lazy-quotes",
+			help: "Accepts quotes appearing in unquoted fields, and non-doubled quotes appearing in quoted fields.",
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.ReaderOptions.CSVLazyQuotes = true
 				*pargi += 1
 			},
 		},

--- a/internal/pkg/cli/option_types.go
+++ b/internal/pkg/cli/option_types.go
@@ -55,6 +55,7 @@ type TReaderOptions struct {
 
 	UseImplicitCSVHeader bool
 	AllowRaggedCSVInput  bool
+	CSVLazyQuotes        bool
 
 	CommentHandling TCommentHandling
 	CommentString   string

--- a/internal/pkg/input/record_reader_csv.go
+++ b/internal/pkg/input/record_reader_csv.go
@@ -20,6 +20,7 @@ type RecordReaderCSV struct {
 	readerOptions   *cli.TReaderOptions
 	recordsPerBatch int64 // distinct from readerOptions.RecordsPerBatch for join/repl
 	ifs0            byte  // Go's CSV library only lets its 'Comma' be a single character
+	csvLazyQuotes   bool  // Maps directly to Go's CSV library's LazyQuotes
 
 	filename   string
 	rowNumber  int64
@@ -41,6 +42,7 @@ func NewRecordReaderCSV(
 		readerOptions:   readerOptions,
 		ifs0:            readerOptions.IFS[0],
 		recordsPerBatch: recordsPerBatch,
+		csvLazyQuotes:   readerOptions.CSVLazyQuotes,
 	}, nil
 }
 
@@ -101,6 +103,7 @@ func (reader *RecordReaderCSV) processHandle(
 
 	csvReader := csv.NewReader(NewBOMStrippingReader(handle))
 	csvReader.Comma = rune(reader.ifs0)
+	csvReader.LazyQuotes = reader.csvLazyQuotes
 	csvRecordsChannel := make(chan *list.List, recordsPerBatch)
 	go channelizedCSVRecordScanner(csvReader, csvRecordsChannel, downstreamDoneChannel, errorChannel,
 		recordsPerBatch)

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -299,6 +299,8 @@ CSV-ONLY FLAGS
                                 Use 1,2,3,... as field labels, rather than from line
                                 1 of input files. Tip: combine with `label` to
                                 recreate missing headers.
+       --lazy-quotes            Accepts quotes appearing in unquoted fields, and
+                                non-doubled quotes appearing in quoted fields.
        --no-implicit-csv-header Opposite of `--implicit-csv-header`. This is the
                                 default anyway -- the main use is for the flags to
                                 `mlr join` if you have main file(s) which are

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -370,6 +370,8 @@ These are flags which are applicable to CSV format.
                          Use 1,2,3,... as field labels, rather than from line
                          1 of input files. Tip: combine with `label` to
                          recreate missing headers.
+--lazy-quotes            Accepts quotes appearing in unquoted fields, and
+                         non-doubled quotes appearing in quoted fields.
 --no-implicit-csv-header Opposite of `--implicit-csv-header`. This is the
                          default anyway -- the main use is for the flags to
                          `mlr join` if you have main file(s) which are

--- a/test/cases/io-rfc-csv/0018/cmd
+++ b/test/cases/io-rfc-csv/0018/cmd
@@ -1,1 +1,1 @@
-mlr --icsv --lazy-quotes --ojson cat $CASEDIR/input
+mlr --icsv --lazy-quotes --ojson cat ${CASEDIR}/input

--- a/test/cases/io-rfc-csv/0018/cmd
+++ b/test/cases/io-rfc-csv/0018/cmd
@@ -1,0 +1,1 @@
+mlr --icsv --lazy-quotes --ojson cat $CASEDIR/input

--- a/test/cases/io-rfc-csv/0018/expout
+++ b/test/cases/io-rfc-csv/0018/expout
@@ -1,0 +1,7 @@
+[
+{
+  "a": "this",
+  "b": "is \"ok\" for us",
+  "c": "to do"
+}
+]

--- a/test/cases/io-rfc-csv/0018/input
+++ b/test/cases/io-rfc-csv/0018/input
@@ -1,0 +1,2 @@
+a,b,c
+this,is "ok" for us,to do

--- a/todo.txt
+++ b/todo.txt
@@ -2,7 +2,6 @@
 RELEASES
 
 * plan 6.1.0
-  ! IANA-TSV w/ \{X}
   ? w/ natural sort order
   ? strptime
   ? datediff et al.
@@ -10,6 +9,8 @@ RELEASES
   ? rank
   o fmt/unfmt/regex doc
   o FAQ/examples reorg
+  k IANA-TSV w/ \{X}
+  k still need csv --lazy-quotes
   k default colors; bold/underline/reverse
   k array concat
   k format/unformat
@@ -35,7 +36,6 @@ TSV etc
 ? try out nidx single-line w/ \001, \002 FS/PS & \n or \n\n RS
   o make/publicize a shorthand for this -- ?
   o --words && --lines & --paragraphs -- ?
-* still need csv --lazy-quotes
 
 ----------------------------------------------------------------
 * natural sort order


### PR DESCRIPTION
Example: the following file isn't compliant with [RFC-4180](https://github.com/johnkerl/miller/pull/925):

```
$ cat input.csv
a,b,c
this,is "ok" for us,to do
```

```
$ mlr --c2j cat input.csv
mlr :  mlr: CSV header/data length mismatch 3 != 1 at filename input.csv row 2.

$ mlr --c2j --lazy-quotes cat input.csv
[
{
  "a": "this",
  "b": "is \"ok\" for us",
  "c": "to do"
}
]
```