### PR TITLE
Add on mouse over permalink anchor for titles

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,3 +110,7 @@ nav:
     - "Documents for previous releases": "release-docs.md"
     - "Glossary": "glossary.md"
   - "What's new in Miller 6": "new-in-miller-6.md"
+
+markdown_extensions:
+- toc:
+      permalink: true


### PR DESCRIPTION
This option adds an anchor link containing the paragraph symbol ¶ or another custom symbol at the end of each headline, exactly like on the page you're currently viewing. (the [doc](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=toc_depth#table-of-contents)).

I find it very convenient for sharing URLs, especially in very long pages.

![](https://i.imgur.com/T4nTTrD.png)