### PR TITLE
Let `mlr repl` print empty strings

### DIFF
--- a/internal/pkg/auxents/repl/dsl.go
+++ b/internal/pkg/auxents/repl/dsl.go
@@ -84,16 +84,16 @@ func (repl *Repl) handleDSLStringAux(
 		// statement like 'true' or '$x > 0.5' etc. For the REPL, we re-use this for
 		// interactive expressions to be printed to the terminal. For the main DSL,
 		// the default is mlrval.FromTrue(); for the REPL, the default is
-		// mlrval.VOID.
+		// mlrval.NULL.
 		filterExpression := repl.runtimeState.FilterExpression
-		if filterExpression.IsVoid() {
+		if filterExpression.IsNull() {
 			// nothing to print
-		} else if filterExpression.IsString() {
+		} else if filterExpression.IsStringOrVoid() {
 			fmt.Printf("\"%s\"\n", filterExpression.String())
 		} else {
 			fmt.Println(filterExpression.String())
 		}
-		repl.runtimeState.FilterExpression = mlrval.VOID
+		repl.runtimeState.FilterExpression = mlrval.NULL
 	}
 
 	return nil

--- a/internal/pkg/auxents/repl/session.go
+++ b/internal/pkg/auxents/repl/session.go
@@ -69,8 +69,8 @@ func NewRepl(
 	// statement like 'true' or '$x > 0.5' etc. For the REPL, we re-use this for
 	// interactive expressions to be printed to the terminal. For the main DSL,
 	// the default is mlrval.FromTrue(); for the REPL, the default is
-	// mlrval.VOID.
-	runtimeState.FilterExpression = mlrval.VOID
+	// mlrval.NULL.
+	runtimeState.FilterExpression = mlrval.NULL
 
 	// For control-C handling
 	sysToSignalHandlerChannel := make(chan os.Signal, 1) // Our signal handler reads system notification here


### PR DESCRIPTION
Before:

```
$ mlr repl
Miller 6.0.0-dev REPL for darwin/amd64/go1.16.5
Docs: https://miller.readthedocs.io
Type ':h' or ':help' for online help; ':q' or ':quit' to quit.
[mlr] "abc"
"abc"
[mlr] ""
[mlr]
```

After:

```
$ mlr repl
Miller 6.0.0-dev REPL for darwin/amd64/go1.16.5
Docs: https://miller.readthedocs.io
Type ':h' or ':help' for online help; ':q' or ':quit' to quit.
[mlr] "abc"
"abc"
[mlr] ""
""
[mlr]
```