### PR TITLE
Avoid panic when the command line ends in 'then'

### DIFF
--- a/internal/pkg/climain/mlrcli_parse.go
+++ b/internal/pkg/climain/mlrcli_parse.go
@@ -170,6 +170,10 @@ func parseCommandLinePassOne(
 				oargi++
 				argi++
 			}
+			if argi >= argc {
+				fmt.Fprintln(os.Stderr, "mlr: 'then' must have a verb after it.")
+				os.Exit(1)
+			}
 			verb := args[argi]
 			onFirst = false
 


### PR DESCRIPTION
Before:

```
$ mlr --csv --from x head -n 10 then
panic: runtime error: index out of range [8] with length 8
```

After:

```
$ mlr --csv --from x head -n 10 then
mlr: 'then' must have a verb after it
```