### PR TITLE
Enable ANSI escape-sequence processing on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lestrrat-go/strftime v1.0.6
 	github.com/mattn/go-isatty v0.0.14
+	github.com/nine-lives-later/go-windows-terminal-sequences v1.0.4 // indirect
 	github.com/pkg/profile v1.6.0
 	github.com/stretchr/testify v1.7.5
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/lestrrat-go/strftime v1.0.6 h1:CFGsDEt1pOpFNU+TJB0nhz9jl+K0hZSLE205Ah
 github.com/lestrrat-go/strftime v1.0.6/go.mod h1:f7jQKgV5nnJpYgdEasS+/y7EsTb8ykN2z68n3TtcTaw=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/nine-lives-later/go-windows-terminal-sequences v1.0.4 h1:NC4H8hewgaktBqMI5yzy6L/Vln5/H7BEziyxaE2fX3Y=
+github.com/nine-lives-later/go-windows-terminal-sequences v1.0.4/go.mod h1:eUQxpEiJy001RoaLXrNa5+QQLYiEgmEafwWuA3ppJSo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=

--- a/internal/pkg/entrypoint/entrypoint.go
+++ b/internal/pkg/entrypoint/entrypoint.go
@@ -33,6 +33,10 @@ func Main() MainReturn {
 	// as-is.)
 	os.Args = platform.GetArgs()
 
+	// Enable ANSI escape sequence processing on the Windows pseudo terminal,
+	// otherwise, we only raw ANSI escape sequences like ←[0;30m  0←[0m ←[0;31m  1
+	platform.EnableAnsiEscapeSequences()
+
 	// Expand "-xyz" into "-x -y -z" while leaving "--xyz" intact. This is a
 	// keystroke-saver for the user.
 	//

--- a/internal/pkg/platform/terminal_notwindows.go
+++ b/internal/pkg/platform/terminal_notwindows.go
@@ -1,0 +1,8 @@
+
+//go:build !windows
+// +build !windows
+
+package platform
+
+func EnableAnsiEscapeSequences() {
+}

--- a/internal/pkg/platform/terminal_windows.go
+++ b/internal/pkg/platform/terminal_windows.go
@@ -1,0 +1,16 @@
+
+//go:build windows
+// +build windows
+
+package platform
+
+import (
+	"syscall"
+
+	sequences "github.com/nine-lives-later/go-windows-terminal-sequences"
+)
+
+func EnableAnsiEscapeSequences() {
+	sequences.EnableVirtualTerminalProcessing(syscall.Stdout, true)
+	sequences.EnableVirtualTerminalProcessing(syscall.Stderr, true)
+}


### PR DESCRIPTION
As discussed, this adds support for ANSI escape sequence processing on Windows, and fixes #1029.

The Golang ecosystem is new to me, so had to get familiar with some of the way things are being done in golang, such as the build tags, and module system. I'm not sure if it all makes sense, or the way you normally do these things in golang. These were the things I wasn't sure about, and they mostly revolved around the following questions:

 * What is the best place to initiate this?
   * I think it makes sense to do this at the `entrypoint.go`, as that's the place that the platform package is being used, for example, to patch up `os.args`
   * However, this is not the very first thing that runs, `cmd/mlr/main.go` is the very first thing that runs, if I'm not mistaken, so any early printing that uses escape sequences wouldn't be color coded, but I think it's quite slim that you'd have that this early, so I don't really consider this a problem
 * Does it make sense to import such little code, or it it better to duplicate this effort?
   * I'm not so sure it makes sense to use a separate package for this, as I did right now
   * Looking at [the usage of this package](https://grep.app/search?q=go-windows-terminal-sequences&filter[lang][0]=Go&filter[path][0]=vendor/), I do see that it's being used, but not nearly [as much](https://grep.app/search?q=ENABLE_VIRTUAL_TERMINAL_PROCESSING&filter[lang][0]=Go) as this code is written in the golang ecosystem

BTW If you're pressed for time, and just want to merge the PR, or take it as inspiration, and sort out the details on your own, I'm totally fine with that. Let me know how you want to proceed with it.