### PR TITLE
Reduce number of os.Exit callsites, part 1 of n

### DIFF
--- a/internal/pkg/auxents/regtest/invoker.go
+++ b/internal/pkg/auxents/regtest/invoker.go
@@ -91,14 +91,7 @@ func RunDiffCommandOnStrings(
 	// output is simply something (in addition to printing the actual &
 	// expected outputs) to help people debug, and hey, we tried.
 
-	// err := cmd.Run()
 	_ = cmd.Run()
-	//if err != nil {
-	//	fmt.Printf("Error executing %s:\n", strings.Join(diffRunArray, " "))
-	//	fmt.Println(err)
-	//	fmt.Println(stderrBuffer.String())
-	//	os.Exit(1)
-	//}
 
 	return stdoutBuffer.String()
 }
@@ -128,14 +121,7 @@ func RunDiffCommandOnFilenames(
 	// output is simply something (in addition to printing the actual &
 	// expected outputs) to help people debug, and hey, we tried.
 
-	// err := cmd.Run()
 	_ = cmd.Run()
-	//if err != nil {
-	//	fmt.Printf("Error executing %s:\n", strings.Join(diffRunArray, " "))
-	//	fmt.Println(err)
-	//	fmt.Println(stderrBuffer.String())
-	//	os.Exit(1)
-	//}
 
 	return stdoutBuffer.String()
 }

--- a/internal/pkg/auxents/repl/dsl.go
+++ b/internal/pkg/auxents/repl/dsl.go
@@ -47,12 +47,13 @@ func (repl *Repl) handleDSLStringAux(
 
 	repl.cstRootNode.ResetForREPL()
 
-	err := repl.cstRootNode.Build(
+	// Disregard the first hadWarnings return value since it's only used for fatal-on-warnings,
+	// which the REPL doesn't use.
+	_, err := repl.cstRootNode.Build(
 		[]string{dslString},
 		cst.DSLInstanceTypeREPL,
 		isReplImmediate,
 		doWarnings,
-		false, // warningsAreFatal
 		func(dslString string, astNode *dsl.AST) {
 			if repl.astPrintMode == ASTPrintParex {
 				astNode.PrintParex()

--- a/internal/pkg/auxents/repl/entry.go
+++ b/internal/pkg/auxents/repl/entry.go
@@ -182,9 +182,17 @@ func ReplMain(args []string) int {
 		repl.openFiles(filenames)
 	}
 
-	repl.handleSession(os.Stdin)
+	err = repl.handleSession(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s %s: %v", repl.exeName, repl.replName, err)
+		os.Exit(1)
+	}
 
 	repl.bufferedRecordOutputStream.Flush()
-	repl.closeBufferedOutputStream()
+	err = repl.closeBufferedOutputStream()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s %s: %v", repl.exeName, repl.replName, err)
+		os.Exit(1)
+	}
 	return 0
 }

--- a/internal/pkg/auxents/repl/verbs.go
+++ b/internal/pkg/auxents/repl/verbs.go
@@ -476,12 +476,13 @@ func handleSkipOrProcessN(repl *Repl, n int64, processingNotSkipping bool) {
 
 func handleSkipOrProcessUntil(repl *Repl, dslString string, processingNotSkipping bool) {
 
-	err := repl.cstRootNode.Build(
+	// Disregard the first hadWarnings return value since it's only used for fatal-on-warnings,
+	// which the REPL doesn't use.
+	_, err := repl.cstRootNode.Build(
 		[]string{dslString},
 		cst.DSLInstanceTypeREPL,
 		true, // isReplImmediate
 		repl.doWarnings,
-		false, // warningsAreFatal
 		func(dslString string, astNode *dsl.AST) {
 			if repl.astPrintMode == ASTPrintParex {
 				astNode.PrintParex()

--- a/internal/pkg/climain/mlrcli_parse.go
+++ b/internal/pkg/climain/mlrcli_parse.go
@@ -93,7 +93,10 @@ func ParseCommandLine(
 ) {
 	// mlr -s scriptfile {data-file names ...} means take the contents of
 	// scriptfile as if it were command-line items.
-	args = maybeInterpolateDashS(args)
+	args, err = maybeInterpolateDashS(args)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Pass one as described at the top of this file.
 	flagSequences, verbSequences, dataFileNames := parseCommandLinePassOne(args)

--- a/internal/pkg/climain/mlrcli_parse.go
+++ b/internal/pkg/climain/mlrcli_parse.go
@@ -281,7 +281,10 @@ func parseCommandLinePassTwo(
 	}
 
 	// Check now to avoid confusing timezone-library behavior later on
-	lib.SetTZFromEnv()
+	err = lib.SetTZFromEnv()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	cli.FinalizeReaderOptions(&options.ReaderOptions)
 	cli.FinalizeWriterOptions(&options.WriterOptions)

--- a/internal/pkg/dsl/cst/lvalues.go
+++ b/internal/pkg/dsl/cst/lvalues.go
@@ -1096,7 +1096,10 @@ func (node *EnvironmentVariableLvalueNode) Assign(
 	svalue := rvalue.String()
 	os.Setenv(sname, svalue)
 	if sname == "TZ" {
-		lib.SetTZFromEnv() // affects the time library; notify it
+		err := lib.SetTZFromEnv() // affects the time library; notify it
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/pkg/entrypoint/entrypoint.go
+++ b/internal/pkg/entrypoint/entrypoint.go
@@ -58,9 +58,13 @@ func Main() MainReturn {
 	}
 
 	if !options.DoInPlace {
-		processToStdout(options, recordTransformers)
+		err = processToStdout(options, recordTransformers)
 	} else {
-		processInPlace(options)
+		err = processInPlace(options)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mlr: %v.\n", err)
+		os.Exit(1)
 	}
 
 	return MainReturn{
@@ -74,12 +78,8 @@ func Main() MainReturn {
 func processToStdout(
 	options *cli.TOptions,
 	recordTransformers []transformers.IRecordTransformer,
-) {
-	err := stream.Stream(options.FileNames, options, recordTransformers, os.Stdout, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v.\n", err)
-		os.Exit(1)
-	}
+) error {
+	return stream.Stream(options.FileNames, options, recordTransformers, os.Stdout, true)
 }
 
 // ----------------------------------------------------------------
@@ -97,7 +97,7 @@ func processToStdout(
 
 func processInPlace(
 	originalOptions *cli.TOptions,
-) {
+) error {
 	// This should have been already checked by the CLI parser when validating
 	// the -I flag.
 	lib.InternalCodingErrorIf(originalOptions.FileNames == nil)
@@ -112,8 +112,7 @@ func processInPlace(
 	for _, fileName := range fileNames {
 
 		if _, err := os.Stat(fileName); os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", "mlr", err)
-			os.Exit(1)
+			return err
 		}
 
 		// Reconstruct the transformers for each file name, and allocate
@@ -122,8 +121,7 @@ func processInPlace(
 		// each output file, and so on.
 		options, recordTransformers, err := climain.ParseCommandLine(os.Args)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, os.Args[0], ": ", err)
-			os.Exit(1)
+			return err
 		}
 
 		// We can't in-place update http://, https://, etc. Also, anything with
@@ -131,8 +129,7 @@ func processInPlace(
 		// command to produce re-compressed output.
 		err = lib.IsUpdateableInPlace(fileName, options.ReaderOptions.Prepipe)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		containingDirectory := path.Dir(fileName)
@@ -140,8 +137,7 @@ func processInPlace(
 		// as revealed by printing handle.Name().
 		handle, err := ioutil.TempFile(containingDirectory, "mlr-in-place-")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		tempFileName := handle.Name()
 
@@ -154,16 +150,14 @@ func processInPlace(
 		wrappedHandle, isNew, err := lib.WrapOutputHandle(handle, inputFileEncoding)
 		if err != nil {
 			os.Remove(tempFileName)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		// Run the Miller processing stream from the input file to the temp-output file.
 		err = stream.Stream([]string{fileName}, options, recordTransformers, wrappedHandle, false)
 		if err != nil {
 			os.Remove(tempFileName)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		// Close the recompressor handle, if any recompression is being applied.
@@ -171,8 +165,7 @@ func processInPlace(
 			err = wrappedHandle.Close()
 			if err != nil {
 				os.Remove(tempFileName)
-				fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 		}
 
@@ -181,16 +174,15 @@ func processInPlace(
 		err = handle.Close()
 		if err != nil {
 			os.Remove(tempFileName)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		// Rename the temp-output file on top of the input file.
 		err = os.Rename(tempFileName, fileName)
 		if err != nil {
 			os.Remove(tempFileName)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
 }

--- a/internal/pkg/lib/time.go
+++ b/internal/pkg/lib/time.go
@@ -15,13 +15,13 @@ import (
 // simply *ignored* -- we want to surface that error to the user.  (3) On any
 // platform this is necessary for *changing* TZ mid-process: e.g.  if a DSL
 // statement does 'ENV["TZ"] = Asia/Istanbul'.
-func SetTZFromEnv() {
+func SetTZFromEnv() error {
 	location, err := time.LoadLocation(os.Getenv("TZ"))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return err
 	}
 	time.Local = location
+	return nil
 }
 
 func Sec2GMT(epochSeconds float64, numDecimalPlaces int) string {

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -3,9 +3,7 @@ package stream
 import (
 	"bufio"
 	"container/list"
-	"fmt"
 	"io"
-	"os"
 
 	"github.com/johnkerl/miller/internal/pkg/cli"
 	"github.com/johnkerl/miller/internal/pkg/input"
@@ -93,8 +91,7 @@ func Stream(
 	for !done {
 		select {
 		case err := <-errorChannel:
-			fmt.Fprintln(os.Stderr, "mlr", ": ", err)
-			os.Exit(1)
+			return err
 		case _ = <-doneWritingChannel:
 			done = true
 			break

--- a/internal/pkg/transformers/aaa_record_transformer.go
+++ b/internal/pkg/transformers/aaa_record_transformer.go
@@ -29,8 +29,6 @@ type RecordTransformerFunc func(
 
 type TransformerUsageFunc func(
 	ostream *os.File,
-	doExit bool,
-	exitCode int,
 )
 
 type TransformerParseCLIFunc func(

--- a/internal/pkg/transformers/aaa_transformer_table.go
+++ b/internal/pkg/transformers/aaa_transformer_table.go
@@ -136,5 +136,4 @@ func UsageVerbs() {
 		transformerSetup.UsageFunc(os.Stdout, false, 0)
 	}
 	fmt.Printf("%s\n", separator)
-	os.Exit(0)
 }

--- a/internal/pkg/transformers/aaa_transformer_table.go
+++ b/internal/pkg/transformers/aaa_transformer_table.go
@@ -79,7 +79,7 @@ func ShowHelpForTransformer(verb string) bool {
 	transformerSetup := LookUp(verb)
 	if transformerSetup != nil {
 		fmt.Println(colorizer.MaybeColorizeHelp(transformerSetup.Verb, true))
-		transformerSetup.UsageFunc(os.Stdout, false, 0)
+		transformerSetup.UsageFunc(os.Stdout)
 		return true
 	}
 	return false
@@ -90,7 +90,7 @@ func ShowHelpForTransformerApproximate(searchString string) bool {
 	for _, transformerSetup := range TRANSFORMER_LOOKUP_TABLE {
 		if strings.Contains(transformerSetup.Verb, searchString) {
 			fmt.Println(colorizer.MaybeColorizeHelp(transformerSetup.Verb, true))
-			transformerSetup.UsageFunc(os.Stdout, false, 0)
+			transformerSetup.UsageFunc(os.Stdout)
 			found = true
 		}
 	}
@@ -133,7 +133,7 @@ func UsageVerbs() {
 		fmt.Printf("%s\n", separator)
 		lib.InternalCodingErrorIf(transformerSetup.UsageFunc == nil)
 		fmt.Println(colorizer.MaybeColorizeHelp(transformerSetup.Verb, true))
-		transformerSetup.UsageFunc(os.Stdout, false, 0)
+		transformerSetup.UsageFunc(os.Stdout)
 	}
 	fmt.Printf("%s\n", separator)
 }

--- a/internal/pkg/transformers/altkv.go
+++ b/internal/pkg/transformers/altkv.go
@@ -24,16 +24,11 @@ var AltkvSetup = TransformerSetup{
 
 func transformerAltkvUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameAltkv)
 	fmt.Fprintf(o, "Given fields with values of the form a,b,c,d,e,f emits a=b,c=d,e=f pairs.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerAltkvParseCLI(
@@ -59,10 +54,12 @@ func transformerAltkvParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerAltkvUsage(os.Stdout, true, 0)
+			transformerAltkvUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerAltkvUsage(os.Stderr, true, 1)
+			transformerAltkvUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/bar.go
+++ b/internal/pkg/transformers/bar.go
@@ -31,8 +31,6 @@ var BarSetup = TransformerSetup{
 
 func transformerBarUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameBar)
 	fmt.Fprintf(o, "Replaces a numeric field with a number of asterisks, allowing for cheesy\n")
@@ -50,10 +48,6 @@ func transformerBarUsage(
 	fmt.Fprintf(o, "Nominally the fill, out-of-bounds, and blank characters will be strings of length 1.\n")
 	fmt.Fprintf(o, "However you can make them all longer if you so desire.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerBarParseCLI(
@@ -90,7 +84,8 @@ func transformerBarParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerBarUsage(os.Stdout, true, 0)
+			transformerBarUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -113,12 +108,14 @@ func transformerBarParseCLI(
 			doAuto = true
 
 		} else {
-			transformerBarUsage(os.Stderr, true, 1)
+			transformerBarUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerBarUsage(os.Stderr, true, 1)
+		transformerBarUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/bootstrap.go
+++ b/internal/pkg/transformers/bootstrap.go
@@ -23,8 +23,6 @@ var BootstrapSetup = TransformerSetup{
 
 func transformerBootstrapUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameBootstrap)
 	fmt.Fprintf(o,
@@ -37,10 +35,6 @@ See also %s sample and %s shuffle.
     Must be non-negative.
 `)
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerBootstrapParseCLI(
@@ -69,13 +63,15 @@ func transformerBootstrapParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerBootstrapUsage(os.Stdout, true, 0)
+			transformerBootstrapUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			nout = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerBootstrapUsage(os.Stderr, true, 1)
+			transformerBootstrapUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/cat.go
+++ b/internal/pkg/transformers/cat.go
@@ -23,8 +23,6 @@ var CatSetup = TransformerSetup{
 
 func transformerCatUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCat)
 	fmt.Fprintf(o, "Passes input records directly to output. Most useful for format conversion.\n")
@@ -33,10 +31,6 @@ func transformerCatUsage(
 	fmt.Fprintf(o, "-N {name}  Prepend field {name} to each record with record-counter starting at 1.\n")
 	fmt.Fprintf(o, "-g {a,b,c} Optional group-by-field names for counters, e.g. a,b,c\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCatParseCLI(
@@ -68,7 +62,8 @@ func transformerCatParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCatUsage(os.Stdout, true, 0)
+			transformerCatUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			counterFieldName = "n"
@@ -80,7 +75,8 @@ func transformerCatParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerCatUsage(os.Stderr, true, 1)
+			transformerCatUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/check.go
+++ b/internal/pkg/transformers/check.go
@@ -22,18 +22,12 @@ var CheckSetup = TransformerSetup{
 
 func transformerCheckUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCheck)
 	fmt.Fprintf(o, "Consumes records without printing any output.\n")
 	fmt.Fprintf(o, "Useful for doing a well-formatted check on input data.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCheckParseCLI(
@@ -59,10 +53,12 @@ func transformerCheckParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCheckUsage(os.Stdout, true, 0)
+			transformerCheckUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerCheckUsage(os.Stderr, true, 1)
+			transformerCheckUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/clean_whitespace.go
+++ b/internal/pkg/transformers/clean_whitespace.go
@@ -24,8 +24,6 @@ var CleanWhitespaceSetup = TransformerSetup{
 
 func transformerCleanWhitespaceUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCleanWhitespace)
 	fmt.Fprintf(o, "For each record, for each field in the record, whitespace-cleans the keys and/or\n")
@@ -40,10 +38,6 @@ func transformerCleanWhitespaceUsage(
 	fmt.Fprintf(o, "It is an error to specify -k as well as -v -- to clean keys and values,\n")
 	fmt.Fprintf(o, "leave off -k as well as -v.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCleanWhitespaceParseCLI(
@@ -72,7 +66,8 @@ func transformerCleanWhitespaceParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCleanWhitespaceUsage(os.Stdout, true, 0)
+			transformerCleanWhitespaceUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-k" || opt == "--keys-only" {
 			doKeys = true
@@ -82,12 +77,14 @@ func transformerCleanWhitespaceParseCLI(
 			doValues = true
 
 		} else {
-			transformerCleanWhitespaceUsage(os.Stderr, true, 1)
+			transformerCleanWhitespaceUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if !doKeys && !doValues {
-		transformerCleanWhitespaceUsage(os.Stderr, true, 1)
+		transformerCleanWhitespaceUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/count.go
+++ b/internal/pkg/transformers/count.go
@@ -24,8 +24,6 @@ var CountSetup = TransformerSetup{
 
 func transformerCountUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCount)
 	fmt.Fprint(o,
@@ -36,10 +34,6 @@ func transformerCountUsage(
 	fmt.Fprintf(o, "-n {n} Show only the number of distinct values. Not interesting without -g.\n")
 	fmt.Fprintf(o, "-o {name} Field name for output-count. Default \"count\".\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCountParseCLI(
@@ -70,7 +64,8 @@ func transformerCountParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCountUsage(os.Stdout, true, 0)
+			transformerCountUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-g" {
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -82,7 +77,8 @@ func transformerCountParseCLI(
 			outputFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerCountUsage(os.Stderr, true, 1)
+			transformerCountUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/count_similar.go
+++ b/internal/pkg/transformers/count_similar.go
@@ -24,8 +24,6 @@ var CountSimilarSetup = TransformerSetup{
 
 func transformerCountSimilarUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCountSimilar)
 	fmt.Fprintf(o, "Ingests all records, then emits each record augmented by a count of\n")
@@ -34,10 +32,6 @@ func transformerCountSimilarUsage(
 	fmt.Fprintf(o, "-g {a,b,c} Group-by-field names for counts, e.g. a,b,c\n")
 	fmt.Fprintf(o, "-o {name} Field name for output-counts. Defaults to \"count\".\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCountSimilarParseCLI(
@@ -67,7 +61,8 @@ func transformerCountSimilarParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCountSimilarUsage(os.Stdout, true, 0)
+			transformerCountSimilarUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-g" {
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -76,12 +71,14 @@ func transformerCountSimilarParseCLI(
 			counterFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerCountSimilarUsage(os.Stderr, true, 1)
+			transformerCountSimilarUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if groupByFieldNames == nil {
-		transformerCountSimilarUsage(os.Stderr, true, 1)
+		transformerCountSimilarUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/cut.go
+++ b/internal/pkg/transformers/cut.go
@@ -25,8 +25,6 @@ var CutSetup = TransformerSetup{
 
 func transformerCutUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameCut)
 	fmt.Fprintf(o, "Passes through input records with specified fields included/excluded.\n")
@@ -46,10 +44,6 @@ func transformerCutUsage(
 	fmt.Fprintf(o, "  %s %s -r -f '^status$,sda[0-9]'\n", "mlr", verbNameCut)
 	fmt.Fprintf(o, "  %s %s -r -f '^status$,\"sda[0-9]\"'\n", "mlr", verbNameCut)
 	fmt.Fprintf(o, "  %s %s -r -f '^status$,\"sda[0-9]\"i' (this is case-insensitive)\n", "mlr", verbNameCut)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCutParseCLI(
@@ -81,7 +75,8 @@ func transformerCutParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCutUsage(os.Stdout, true, 0)
+			transformerCutUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -99,12 +94,14 @@ func transformerCutParseCLI(
 			doRegexes = true
 
 		} else {
-			transformerCutUsage(os.Stderr, true, 1)
+			transformerCutUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerCutUsage(os.Stderr, true, 1)
+		transformerCutUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/decimate.go
+++ b/internal/pkg/transformers/decimate.go
@@ -22,8 +22,6 @@ var DecimateSetup = TransformerSetup{
 
 func transformerDecimateUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameDecimate)
 	fmt.Fprintf(o, "Passes through one of every n records, optionally by category.\n")
@@ -33,10 +31,6 @@ func transformerDecimateUsage(
 	fmt.Fprintf(o, " -g {a,b,c} Optional group-by-field names for decimate counts, e.g. a,b,c.\n")
 	fmt.Fprintf(o, " -n {n} Decimation factor (default 10).\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerDecimateParseCLI(
@@ -68,12 +62,14 @@ func transformerDecimateParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerDecimateUsage(os.Stdout, true, 0)
+			transformerDecimateUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			decimateCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
 			if decimateCount <= 0 {
-				transformerDecimateUsage(os.Stderr, true, 1)
+				transformerDecimateUsage(os.Stderr)
+				os.Exit(1)
 			}
 
 		} else if opt == "-b" {
@@ -86,7 +82,8 @@ func transformerDecimateParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerDecimateUsage(os.Stderr, true, 1)
+			transformerDecimateUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/fill_down.go
+++ b/internal/pkg/transformers/fill_down.go
@@ -23,8 +23,6 @@ var FillDownSetup = TransformerSetup{
 
 func transformerFillDownUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameFillDown)
 	fmt.Fprintln(o, "If a given record has a missing value for a given field, fill that from")
@@ -40,10 +38,6 @@ func transformerFillDownUsage(
 	fmt.Fprintln(o, "     With -a, a field is 'missing' only if it is absent.")
 	fmt.Fprintln(o, " -f  Field names for fill-down.")
 	fmt.Fprintln(o, " -h|--help Show this message.")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerFillDownParseCLI(
@@ -74,7 +68,8 @@ func transformerFillDownParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerFillDownUsage(os.Stdout, true, 0)
+			transformerFillDownUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fillDownFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -89,12 +84,14 @@ func transformerFillDownParseCLI(
 			onlyIfAbsent = true
 
 		} else {
-			transformerFillDownUsage(os.Stderr, true, 1)
+			transformerFillDownUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fillDownFieldNames == nil && !doAll {
-		transformerFillDownUsage(os.Stderr, true, 1)
+		transformerFillDownUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/fill_empty.go
+++ b/internal/pkg/transformers/fill_empty.go
@@ -24,18 +24,12 @@ var FillEmptySetup = TransformerSetup{
 
 func transformerFillEmptyUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameFillEmpty)
 	fmt.Fprintf(o, "Fills empty-string fields with specified fill-value.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-v {string} Fill-value: defaults to \"%s\"\n", defaultFillEmptyString)
 	fmt.Fprintf(o, "-S          Don't infer type -- so '-v 0' would fill string 0 not int 0.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerFillEmptyParseCLI(
@@ -65,7 +59,8 @@ func transformerFillEmptyParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerFillEmptyUsage(os.Stdout, true, 0)
+			transformerFillEmptyUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-v" {
 			fillString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -74,7 +69,8 @@ func transformerFillEmptyParseCLI(
 			inferType = false
 
 		} else {
-			transformerFillEmptyUsage(os.Stderr, true, 1)
+			transformerFillEmptyUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/flatten.go
+++ b/internal/pkg/transformers/flatten.go
@@ -23,8 +23,6 @@ var FlattenSetup = TransformerSetup{
 
 func transformerFlattenUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameFlatten)
 	fmt.Fprint(o,
@@ -35,10 +33,6 @@ and value '{"b": { "c": 4 }}' becomes name 'a.b.c' and value 4.
 	fmt.Fprint(o, "-f Comma-separated list of field names to flatten (default all).\n")
 	fmt.Fprintf(o, "-s Separator, defaulting to %s --flatsep value.\n", "mlr")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerFlattenParseCLI(
@@ -68,7 +62,8 @@ func transformerFlattenParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerFlattenUsage(os.Stdout, true, 0)
+			transformerFlattenUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-s" {
 			oFlatSep = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -77,7 +72,8 @@ func transformerFlattenParseCLI(
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerFlattenUsage(os.Stderr, true, 1)
+			transformerFlattenUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/format_values.go
+++ b/internal/pkg/transformers/format_values.go
@@ -28,8 +28,6 @@ var FormatValuesSetup = TransformerSetup{
 // ----------------------------------------------------------------
 func transformerFormatValuesUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameFormatValues)
 	fmt.Fprintf(o, "Applies format strings to all field values, depending on autodetected type.\n")
@@ -60,10 +58,6 @@ func transformerFormatValuesUsage(
 	fmt.Fprintf(o, "                    with s in them. Undefined behavior results otherwise.\n")
 	fmt.Fprintf(o, "-n                  Coerce field values autodetected as int to float, and then\n")
 	fmt.Fprintf(o, "                    apply the float format.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerFormatValuesParseCLI(
@@ -95,7 +89,8 @@ func transformerFormatValuesParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerFormatValuesUsage(os.Stdout, true, 0)
+			transformerFormatValuesUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-s" {
 			stringFormat = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -107,7 +102,8 @@ func transformerFormatValuesParseCLI(
 			coerceIntToFloat = true
 
 		} else {
-			transformerFormatValuesUsage(os.Stderr, true, 1)
+			transformerFormatValuesUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/fraction.go
+++ b/internal/pkg/transformers/fraction.go
@@ -25,8 +25,6 @@ var FractionSetup = TransformerSetup{
 
 func transformerFractionUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameFraction
@@ -50,10 +48,6 @@ func transformerFractionUsage(
 	fmt.Fprintf(o, "              E.g. with input records  x=1  x=2  x=3  and  x=4, emits output records\n")
 	fmt.Fprintf(o, "              x=1,x_cumulative_fraction=0.1  x=2,x_cumulative_fraction=0.3\n")
 	fmt.Fprintf(o, "              x=3,x_cumulative_fraction=0.6  and  x=4,x_cumulative_fraction=1.0\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerFractionParseCLI(
@@ -86,7 +80,8 @@ func transformerFractionParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerFractionUsage(os.Stdout, true, 0)
+			transformerFractionUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fractionFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -101,12 +96,14 @@ func transformerFractionParseCLI(
 			doCumu = true
 
 		} else {
-			transformerFractionUsage(os.Stderr, true, 1)
+			transformerFractionUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fractionFieldNames == nil {
-		transformerFractionUsage(os.Stderr, true, 1)
+		transformerFractionUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/gap.go
+++ b/internal/pkg/transformers/gap.go
@@ -23,8 +23,6 @@ var GapSetup = TransformerSetup{
 
 func transformerGapUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameGap)
 	fmt.Fprint(o, "Emits an empty record every n records, or when certain values change.\n")
@@ -36,10 +34,6 @@ func transformerGapUsage(
 	fmt.Fprintf(o, "One of -f or -g is required.\n")
 	fmt.Fprintf(o, "-n is ignored if -g is present.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerGapParseCLI(
@@ -69,7 +63,8 @@ func transformerGapParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerGapUsage(os.Stdout, true, 0)
+			transformerGapUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			gapCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -78,12 +73,14 @@ func transformerGapParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerGapUsage(os.Stderr, true, 1)
+			transformerGapUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if gapCount == -1 && groupByFieldNames == nil {
-		transformerGapUsage(os.Stderr, true, 1)
+		transformerGapUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/grep.go
+++ b/internal/pkg/transformers/grep.go
@@ -23,8 +23,6 @@ var GrepSetup = TransformerSetup{
 
 func transformerGrepUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {regular expression}\n", "mlr", verbNameGrep)
 	fmt.Fprintf(o, "Passes through records which match the regular expression.\n")
@@ -46,10 +44,6 @@ and this command is intended to be merely a keystroke-saver. To get all the
 features of system grep, you can do
   "%s --odkvp ... | grep ... | %s --idkvp ..."
 `, "mlr", "mlr", "mlr", "mlr")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerGrepParseCLI(
@@ -79,7 +73,8 @@ func transformerGrepParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerGrepUsage(os.Stdout, true, 0)
+			transformerGrepUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-i" {
 			ignoreCase = true
@@ -88,13 +83,15 @@ func transformerGrepParseCLI(
 			invert = true
 
 		} else {
-			transformerGrepUsage(os.Stderr, true, 1)
+			transformerGrepUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	// Get the regex from the command line
 	if argi >= argc {
-		transformerGrepUsage(os.Stderr, true, 1)
+		transformerGrepUsage(os.Stderr)
+		os.Exit(1)
 	}
 	pattern := args[argi]
 	argi++

--- a/internal/pkg/transformers/group_by.go
+++ b/internal/pkg/transformers/group_by.go
@@ -23,17 +23,11 @@ var GroupBySetup = TransformerSetup{
 
 func transformerGroupByUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {comma-separated field names}\n", "mlr", verbNameGroupBy)
 	fmt.Fprint(o, "Outputs records in batches having identical values at specified field names.")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerGroupByParseCLI(
@@ -59,16 +53,19 @@ func transformerGroupByParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerGroupByUsage(os.Stdout, true, 0)
+			transformerGroupByUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerGroupByUsage(os.Stderr, true, 1)
+			transformerGroupByUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	// Get the group-by field names from the command line
 	if argi >= argc {
-		transformerGroupByUsage(os.Stderr, true, 1)
+		transformerGroupByUsage(os.Stderr)
+		os.Exit(1)
 	}
 	groupByFieldNames := lib.SplitString(args[argi], ",")
 	argi++

--- a/internal/pkg/transformers/group_like.go
+++ b/internal/pkg/transformers/group_like.go
@@ -23,17 +23,11 @@ var GroupLikeSetup = TransformerSetup{
 
 func transformerGroupLikeUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameGroupLike)
 	fmt.Fprintln(o, "Outputs records in batches having identical field names.")
 	fmt.Fprintln(o, "Options:")
 	fmt.Fprintln(o, "-h|--help Show this message.")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerGroupLikeParseCLI(
@@ -59,10 +53,12 @@ func transformerGroupLikeParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerGroupLikeUsage(os.Stdout, true, 0)
+			transformerGroupLikeUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerGroupLikeUsage(os.Stderr, true, 1)
+			transformerGroupLikeUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/having_fields.go
+++ b/internal/pkg/transformers/having_fields.go
@@ -37,8 +37,6 @@ var HavingFieldsSetup = TransformerSetup{
 
 func transformerHavingFieldsUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	exeName := "mlr"
 	verb := verbNameHavingFields
@@ -57,10 +55,6 @@ func transformerHavingFieldsUsage(
 	fmt.Fprintf(o, "  %s %s --any-matching 'sda[0-9]'\n", exeName, verb)
 	fmt.Fprintf(o, "  %s %s --any-matching '\"sda[0-9]\"'\n", exeName, verb)
 	fmt.Fprintf(o, "  %s %s --any-matching '\"sda[0-9]\"i' (this is case-insensitive)\n", exeName, verb)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerHavingFieldsParseCLI(
@@ -91,7 +85,8 @@ func transformerHavingFieldsParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerHavingFieldsUsage(os.Stdout, true, 0)
+			transformerHavingFieldsUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "--at-least" {
 			havingFieldsCriterion = havingFieldsAtLeast
@@ -124,15 +119,18 @@ func transformerHavingFieldsParseCLI(
 			fieldNames = nil
 
 		} else {
-			transformerHavingFieldsUsage(os.Stderr, true, 1)
+			transformerHavingFieldsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if havingFieldsCriterion == havingFieldsCriterionUnspecified {
-		transformerHavingFieldsUsage(os.Stderr, true, 1)
+		transformerHavingFieldsUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if fieldNames == nil && regexString == "" {
-		transformerHavingFieldsUsage(os.Stderr, true, 1)
+		transformerHavingFieldsUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/head.go
+++ b/internal/pkg/transformers/head.go
@@ -22,8 +22,6 @@ var HeadSetup = TransformerSetup{
 
 func transformerHeadUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameHead)
 	fmt.Fprintf(o, "Passes through the first n records, optionally by category.\n")
@@ -33,10 +31,6 @@ func transformerHeadUsage(
 	fmt.Fprintf(o, "-g {a,b,c} Optional group-by-field names for head counts, e.g. a,b,c.\n")
 	fmt.Fprintf(o, "-n {n} Head-count to print. Default 10.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerHeadParseCLI(
@@ -66,7 +60,8 @@ func transformerHeadParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerHeadUsage(os.Stdout, true, 0)
+			transformerHeadUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			headCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -85,7 +80,8 @@ func transformerHeadParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerHeadUsage(os.Stderr, true, 1)
+			transformerHeadUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/histogram.go
+++ b/internal/pkg/transformers/histogram.go
@@ -25,8 +25,6 @@ var HistogramSetup = TransformerSetup{
 
 func transformerHistogramUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameHistogram
@@ -40,10 +38,6 @@ func transformerHistogramUsage(
 	fmt.Fprintf(o, "              Holds all values in memory before producing any output.\n")
 	fmt.Fprintf(o, "-o {prefix}   Prefix for output field name. Default: no prefix.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerHistogramParseCLI(
@@ -78,7 +72,8 @@ func transformerHistogramParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerHistogramUsage(os.Stdout, true, 0)
+			transformerHistogramUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			valueFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -99,20 +94,24 @@ func transformerHistogramParseCLI(
 			outputPrefix = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerHistogramUsage(os.Stderr, true, 1)
+			transformerHistogramUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if valueFieldNames == nil {
-		transformerHistogramUsage(os.Stderr, true, 1)
+		transformerHistogramUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	if nbins <= 0 {
-		transformerHistogramUsage(os.Stderr, true, 1)
+		transformerHistogramUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	if lo == hi && !doAuto {
-		transformerHistogramUsage(os.Stderr, true, 1)
+		transformerHistogramUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/join.go
+++ b/internal/pkg/transformers/join.go
@@ -76,8 +76,6 @@ func newJoinOptions() *tJoinOptions {
 // ----------------------------------------------------------------
 func transformerJoinUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameJoin)
 	fmt.Fprintf(o, "Joins records from specified left file name with records from all file names\n")
@@ -132,10 +130,6 @@ func transformerJoinUsage(
 		"mlr")
 	fmt.Fprintf(o, "Please see https://miller.readthedocs.io/en/latest/reference-verbs.html#join for more information\n")
 	fmt.Fprintf(o, "including examples.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 // ----------------------------------------------------------------
@@ -171,7 +165,8 @@ func transformerJoinParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerJoinUsage(os.Stdout, true, 0)
+			transformerJoinUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "--prepipe" {
 			opts.prepipe = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -227,7 +222,8 @@ func transformerJoinParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerJoinUsage(os.Stderr, true, 1)
+				transformerJoinUsage(os.Stderr)
+				os.Exit(1)
 			}
 		}
 	}
@@ -236,20 +232,23 @@ func transformerJoinParseCLI(
 
 	if opts.leftFileName == "" {
 		fmt.Fprintf(os.Stderr, "%s %s: need left file name\n", "mlr", verb)
-		transformerJoinUsage(os.Stderr, true, 1)
+		transformerJoinUsage(os.Stderr)
+		os.Exit(1)
 		return nil
 	}
 
 	if !opts.emitPairables && !opts.emitLeftUnpairables && !opts.emitRightUnpairables {
 		fmt.Fprintf(os.Stderr, "%s %s: all emit flags are unset; no output is possible.\n",
 			"mlr", verb)
-		transformerJoinUsage(os.Stderr, true, 1)
+		transformerJoinUsage(os.Stderr)
+		os.Exit(1)
 		return nil
 	}
 
 	if opts.outputJoinFieldNames == nil {
 		fmt.Fprintf(os.Stderr, "%s %s: need output field names\n", "mlr", verb)
-		transformerJoinUsage(os.Stderr, true, 1)
+		transformerJoinUsage(os.Stderr)
+		os.Exit(1)
 		return nil
 	}
 

--- a/internal/pkg/transformers/json_parse.go
+++ b/internal/pkg/transformers/json_parse.go
@@ -23,8 +23,6 @@ var JSONParseSetup = TransformerSetup{
 
 func transformerJSONParseUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameJSONParse)
 	fmt.Fprintln(
@@ -34,10 +32,6 @@ func transformerJSONParseUsage(
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-f {...} Comma-separated list of field names to json-parse (default all).\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerJSONParseParseCLI(
@@ -66,13 +60,15 @@ func transformerJSONParseParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerJSONParseUsage(os.Stdout, true, 0)
+			transformerJSONParseUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerJSONParseUsage(os.Stderr, true, 1)
+			transformerJSONParseUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/json_stringify.go
+++ b/internal/pkg/transformers/json_stringify.go
@@ -24,8 +24,6 @@ var JSONStringifySetup = TransformerSetup{
 
 func transformerJSONStringifyUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameJSONStringify)
 	fmt.Fprint(o,
@@ -36,10 +34,6 @@ func transformerJSONStringifyUsage(
 	fmt.Fprintf(o, "--jvstack Produce multi-line JSON output.\n")
 	fmt.Fprintf(o, "--no-jvstack Produce single-line JSON output per record (default).\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerJSONStringifyParseCLI(
@@ -69,7 +63,8 @@ func transformerJSONStringifyParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerJSONStringifyUsage(os.Stdout, true, 0)
+			transformerJSONStringifyUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -81,7 +76,8 @@ func transformerJSONStringifyParseCLI(
 			jvStack = false
 
 		} else {
-			transformerJSONStringifyUsage(os.Stderr, true, 1)
+			transformerJSONStringifyUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/label.go
+++ b/internal/pkg/transformers/label.go
@@ -23,8 +23,6 @@ var LabelSetup = TransformerSetup{
 
 func transformerLabelUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {new1,new2,new3,...}\n", "mlr", verbNameLabel)
 	fmt.Fprintf(o, "Given n comma-separated names, renames the first n fields of each record to\n")
@@ -34,10 +32,6 @@ func transformerLabelUsage(
 	fmt.Fprintf(o, "\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerLabelParseCLI(
@@ -63,16 +57,19 @@ func transformerLabelParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerLabelUsage(os.Stdout, true, 0)
+			transformerLabelUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerLabelUsage(os.Stderr, true, 1)
+			transformerLabelUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	// Get the label field names from the command line
 	if argi >= argc {
-		transformerLabelUsage(os.Stderr, true, 1)
+		transformerLabelUsage(os.Stderr)
+		os.Exit(1)
 	}
 	newNames := lib.SplitString(args[argi], ",")
 	argi++

--- a/internal/pkg/transformers/latin1_to_utf8.go
+++ b/internal/pkg/transformers/latin1_to_utf8.go
@@ -24,17 +24,12 @@ var Latin1ToUTF8Setup = TransformerSetup{
 
 func transformerLatin1ToUTF8Usage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s, with no options.\n", "mlr", verbNameLatin1ToUTF8)
 	fmt.Fprintf(o, "Recursively converts record strings from Latin-1 to UTF-8.\n")
 	fmt.Fprintf(o, "For field-level control, please see the latin1_to_utf8 DSL function.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerLatin1ToUTF8ParseCLI(
@@ -60,10 +55,12 @@ func transformerLatin1ToUTF8ParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerLatin1ToUTF8Usage(os.Stdout, true, 0)
+			transformerLatin1ToUTF8Usage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerLatin1ToUTF8Usage(os.Stderr, true, 1)
+			transformerLatin1ToUTF8Usage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/merge_fields.go
+++ b/internal/pkg/transformers/merge_fields.go
@@ -34,8 +34,6 @@ const (
 
 func transformerMergeFieldsUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameMergeFields
@@ -71,10 +69,6 @@ func transformerMergeFieldsUsage(
 	fmt.Fprintf(o, "  produces \"a_x_sum=3,a_x_count=2,b_y_sum=4,b_y_count=1,b_x_sum=8,b_x_count=1\"\n")
 	fmt.Fprintf(o, "  since \"a_in_x\" and \"a_out_x\" both collapse to \"a_x\", \"b_in_y\" collapses to\n")
 	fmt.Fprintf(o, "  \"b_y\", and \"b_out_x\" collapses to \"b_x\".\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerMergeFieldsParseCLI(
@@ -108,7 +102,8 @@ func transformerMergeFieldsParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerMergeFieldsUsage(os.Stdout, true, 0)
+			transformerMergeFieldsUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-a" {
 			accumulatorNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -141,7 +136,8 @@ func transformerMergeFieldsParseCLI(
 			// No-op pass-through for backward compatibility with Miller 5
 
 		} else {
-			transformerMergeFieldsUsage(os.Stderr, true, 1)
+			transformerMergeFieldsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
@@ -158,7 +154,8 @@ func transformerMergeFieldsParseCLI(
 	}
 	if outputFieldBasename == "" {
 		if doWhich == e_MERGE_BY_NAME_LIST || doWhich == e_MERGE_BY_NAME_REGEX {
-			transformerMergeFieldsUsage(os.Stderr, true, 1)
+			transformerMergeFieldsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/most_or_least_frequent.go
+++ b/internal/pkg/transformers/most_or_least_frequent.go
@@ -36,8 +36,6 @@ var LeastFrequentSetup = TransformerSetup{
 
 func transformerMostFrequentUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameMostFrequent
@@ -50,15 +48,10 @@ func transformerMostFrequentUsage(
 	fmt.Fprintf(o, "-b          Suppress counts; show only field values.\n")
 	fmt.Fprintf(o, "-o {name}   Field name for output count. Default \"%s\".\n", mostLeastFrequentDefaultOutputFieldName)
 	fmt.Fprintf(o, "See also \"%s %s\".\n", argv0, "least-frequent")
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerLeastFrequentUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameLeastFrequent
@@ -71,9 +64,6 @@ func transformerLeastFrequentUsage(
 	fmt.Fprintf(o, "-b          Suppress counts; show only field values.\n")
 	fmt.Fprintf(o, "-o {name}   Field name for output count. Default \"%s\".\n", mostLeastFrequentDefaultOutputFieldName)
 	fmt.Fprintf(o, "See also \"%s %s\".\n", argv0, "most-frequent")
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerMostFrequentParseCLI(
@@ -127,7 +117,8 @@ func transformerMostOrLeastFrequentParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			usageFunc(os.Stdout, true, 0)
+			usageFunc(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -142,12 +133,14 @@ func transformerMostOrLeastFrequentParseCLI(
 			outputFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			usageFunc(os.Stderr, true, 1)
+			usageFunc(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if groupByFieldNames == nil {
-		usageFunc(os.Stderr, true, 1)
+		usageFunc(os.Stderr)
+		os.Exit(1)
 		return nil
 	}
 

--- a/internal/pkg/transformers/nest.go
+++ b/internal/pkg/transformers/nest.go
@@ -27,8 +27,6 @@ var NestSetup = TransformerSetup{
 
 func transformerNestUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameNest
@@ -87,10 +85,6 @@ func transformerNestUsage(
 	fmt.Fprintf(o, "* It's up to you to ensure that the nested-fs is distinct from your data's IFS:\n")
 	fmt.Fprintf(o, "  e.g. by default the former is semicolon and the latter is comma.\n")
 	fmt.Fprintf(o, "See also %s reshape.\n", argv0)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerNestParseCLI(
@@ -130,7 +124,8 @@ func transformerNestParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerNestUsage(os.Stdout, true, 0)
+			transformerNestUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -180,7 +175,8 @@ func transformerNestParseCLI(
 			doAcrossFieldsSpecified = true
 
 		} else {
-			transformerNestUsage(os.Stderr, true, 1)
+			transformerNestUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
@@ -198,19 +194,24 @@ func transformerNestParseCLI(
 	}
 
 	if fieldName == "" {
-		transformerNestUsage(os.Stderr, true, 1)
+		transformerNestUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if !doExplodeSpecified {
-		transformerNestUsage(os.Stderr, true, 1)
+		transformerNestUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if !doPairsSpecified {
-		transformerNestUsage(os.Stderr, true, 1)
+		transformerNestUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if !doAcrossFieldsSpecified {
-		transformerNestUsage(os.Stderr, true, 1)
+		transformerNestUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if doPairs && !doExplode {
-		transformerNestUsage(os.Stderr, true, 1)
+		transformerNestUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/nothing.go
+++ b/internal/pkg/transformers/nothing.go
@@ -22,18 +22,12 @@ var NothingSetup = TransformerSetup{
 
 func transformerNothingUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameNothing)
 	fmt.Fprintf(o, "Drops all input records. Useful for testing, or after tee/print/etc. have\n")
 	fmt.Fprintf(o, "produced other output.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerNothingParseCLI(
@@ -59,10 +53,12 @@ func transformerNothingParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerNothingUsage(os.Stdout, true, 0)
+			transformerNothingUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerNothingUsage(os.Stderr, true, 1)
+			transformerNothingUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/put_or_filter.go
+++ b/internal/pkg/transformers/put_or_filter.go
@@ -37,24 +37,18 @@ var FilterSetup = TransformerSetup{
 // ----------------------------------------------------------------
 func transformerPutUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
-	transformerPutOrFilterUsage(o, doExit, exitCode, "put")
+	transformerPutOrFilterUsage(o, "put")
 }
 
 func transformerFilterUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
-	transformerPutOrFilterUsage(o, doExit, exitCode, "filter")
+	transformerPutOrFilterUsage(o, "filter")
 }
 
 func transformerPutOrFilterUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 	verb string,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {DSL expression}\n", "mlr", verb)
@@ -177,10 +171,6 @@ More example filter expressions:
 
 	fmt.Fprintln(o)
 	fmt.Fprintf(o, "See also %s/reference-dsl for more context.\n", lib.DOC_URL)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 // ----------------------------------------------------------------
@@ -243,7 +233,8 @@ func transformerPutOrFilterParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerPutOrFilterUsage(os.Stdout, true, 0, verb)
+			transformerPutOrFilterUsage(os.Stdout, verb)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			// Get a DSL string from the user-specified filename
@@ -319,7 +310,8 @@ func transformerPutOrFilterParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerPutOrFilterUsage(os.Stderr, true, 1, verb)
+				transformerPutOrFilterUsage(os.Stderr, verb)
+				os.Exit(1)
 			}
 		}
 	}

--- a/internal/pkg/transformers/put_or_filter.go
+++ b/internal/pkg/transformers/put_or_filter.go
@@ -395,12 +395,11 @@ func NewTransformerPut(
 
 	cstRootNode := cst.NewEmptyRoot(&options.WriterOptions, dslInstanceType).WithStrictMode(strictMode)
 
-	err := cstRootNode.Build(
+	hadWarnings, err := cstRootNode.Build(
 		dslStrings,
 		dslInstanceType,
 		false, // isReplImmediate
 		doWarnings,
-		warningsAreFatal,
 
 		func(dslString string, astNode *dsl.AST) {
 
@@ -425,6 +424,14 @@ func NewTransformerPut(
 
 		},
 	)
+
+	if warningsAreFatal && hadWarnings {
+		fmt.Printf(
+			"%s: Exiting due to warnings treated as fatal.\n",
+			"mlr",
+		)
+		os.Exit(1)
+	}
 
 	if exitAfterParse {
 		os.Exit(0)

--- a/internal/pkg/transformers/regularize.go
+++ b/internal/pkg/transformers/regularize.go
@@ -24,17 +24,11 @@ var RegularizeSetup = TransformerSetup{
 
 func transformerRegularizeUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameRegularize)
 	fmt.Fprintf(o, "Outputs records sorted lexically ascending by keys.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerRegularizeParseCLI(
@@ -60,10 +54,12 @@ func transformerRegularizeParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerRegularizeUsage(os.Stdout, true, 0)
+			transformerRegularizeUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerRegularizeUsage(os.Stderr, true, 1)
+			transformerRegularizeUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/remove_empty_columns.go
+++ b/internal/pkg/transformers/remove_empty_columns.go
@@ -23,17 +23,11 @@ var RemoveEmptyColumnsSetup = TransformerSetup{
 
 func transformerRemoveEmptyColumnsUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameRemoveEmptyColumns)
 	fmt.Fprintf(o, "Omits fields which are empty on every input row. Non-streaming.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerRemoveEmptyColumnsParseCLI(
@@ -59,10 +53,12 @@ func transformerRemoveEmptyColumnsParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerRemoveEmptyColumnsUsage(os.Stdout, true, 0)
+			transformerRemoveEmptyColumnsUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerRemoveEmptyColumnsUsage(os.Stderr, true, 1)
+			transformerRemoveEmptyColumnsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/rename.go
+++ b/internal/pkg/transformers/rename.go
@@ -24,8 +24,6 @@ var RenameSetup = TransformerSetup{
 
 func transformerRenameUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	exeName := "mlr"
 	verb := verbNameRename
@@ -51,10 +49,6 @@ func transformerRenameUsage(
 	fmt.Fprintf(o, "%s %s -r '\"Date_[0-9]+\",Date' Same\n", exeName, verb)
 	fmt.Fprintf(o, "%s %s -r 'Date_([0-9]+).*,\\1' Rename all such fields to be of the form 20151015\n", exeName, verb)
 	fmt.Fprintf(o, "%s %s -r '\"name\"i,Name'       Rename \"name\", \"Name\", \"NAME\", etc. to \"Name\"\n", exeName, verb)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerRenameParseCLI(
@@ -83,7 +77,8 @@ func transformerRenameParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerRenameUsage(os.Stdout, true, 0)
+			transformerRenameUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-r" {
 			doRegexes = true
@@ -92,7 +87,8 @@ func transformerRenameParseCLI(
 			doGsub = true
 
 		} else {
-			transformerRenameUsage(os.Stderr, true, 1)
+			transformerRenameUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
@@ -102,11 +98,13 @@ func transformerRenameParseCLI(
 
 	// Get the rename field names from the command line
 	if argi >= argc {
-		transformerRenameUsage(os.Stderr, true, 1)
+		transformerRenameUsage(os.Stderr)
+		os.Exit(1)
 	}
 	names := lib.SplitString(args[argi], ",")
 	if len(names)%2 != 0 {
-		transformerRenameUsage(os.Stderr, true, 1)
+		transformerRenameUsage(os.Stderr)
+		os.Exit(1)
 	}
 	argi++
 

--- a/internal/pkg/transformers/reorder.go
+++ b/internal/pkg/transformers/reorder.go
@@ -24,8 +24,6 @@ var ReorderSetup = TransformerSetup{
 
 func transformerReorderUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameReorder
@@ -47,10 +45,6 @@ func transformerReorderUsage(
 	fmt.Fprintf(o, "Examples:\n")
 	fmt.Fprintf(o, "%s %s    -f a,b sends input record \"d=4,b=2,a=1,c=3\" to \"a=1,b=2,d=4,c=3\".\n", argv0, verb)
 	fmt.Fprintf(o, "%s %s -e -f a,b sends input record \"d=4,b=2,a=1,c=3\" to \"d=4,c=3,a=1,b=2\".\n", argv0, verb)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerReorderParseCLI(
@@ -82,7 +76,8 @@ func transformerReorderParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerReorderUsage(os.Stdout, true, 0)
+			transformerReorderUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -103,12 +98,14 @@ func transformerReorderParseCLI(
 			afterFieldName = ""
 
 		} else {
-			transformerReorderUsage(os.Stderr, true, 1)
+			transformerReorderUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerReorderUsage(os.Stderr, true, 1)
+		transformerReorderUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/repeat.go
+++ b/internal/pkg/transformers/repeat.go
@@ -31,8 +31,6 @@ var RepeatSetup = TransformerSetup{
 
 func transformerRepeatUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameRepeat)
 	fmt.Fprintf(o, "Copies input records to output records multiple times.\n")
@@ -59,10 +57,6 @@ func transformerRepeatUsage(
 	fmt.Fprintf(o, "  a=1,b=2,c=3\n")
 	fmt.Fprintf(o, "  a=1,b=2,c=3\n")
 	fmt.Fprintf(o, "  a=1,b=2,c=3\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerRepeatParseCLI(
@@ -93,7 +87,8 @@ func transformerRepeatParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerRepeatUsage(os.Stdout, true, 0)
+			transformerRepeatUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			repeatCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -104,12 +99,14 @@ func transformerRepeatParseCLI(
 			repeatCountSource = repeatCountFromFieldName
 
 		} else {
-			transformerRepeatUsage(os.Stderr, true, 1)
+			transformerRepeatUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if repeatCountSource == repeatCountSourceUnspecified {
-		transformerRepeatUsage(os.Stderr, true, 1)
+		transformerRepeatUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/reshape.go
+++ b/internal/pkg/transformers/reshape.go
@@ -52,8 +52,6 @@ var ReshapeSetup = TransformerSetup{
 
 func transformerReshapeUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameReshape
@@ -114,10 +112,6 @@ func transformerReshapeUsage(
 	fmt.Fprintf(o, "    2009-01-02 -0.89248112 0.2154713\n")
 	fmt.Fprintf(o, "    2009-01-03 0.98012375  1.3179287\n")
 	fmt.Fprintf(o, "See also %s nest.\n", argv0)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerReshapeParseCLI(
@@ -150,7 +144,8 @@ func transformerReshapeParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerReshapeUsage(os.Stdout, true, 0)
+			transformerReshapeUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-i" {
 			inputFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -162,7 +157,8 @@ func transformerReshapeParseCLI(
 			splitOutFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerReshapeUsage(os.Stderr, true, 1)
+			transformerReshapeUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
@@ -174,21 +170,25 @@ func transformerReshapeParseCLI(
 	if splitOutFieldNames == nil {
 		// wide to long
 		if inputFieldNames == nil && inputFieldRegexStrings == nil {
-			transformerReshapeUsage(os.Stderr, true, 1)
+			transformerReshapeUsage(os.Stderr)
+			os.Exit(1)
 		}
 
 		if outputFieldNames == nil {
-			transformerReshapeUsage(os.Stderr, true, 1)
+			transformerReshapeUsage(os.Stderr)
+			os.Exit(1)
 		}
 		if len(outputFieldNames) != 2 {
-			transformerReshapeUsage(os.Stderr, true, 1)
+			transformerReshapeUsage(os.Stderr)
+			os.Exit(1)
 		}
 		outputKeyFieldName = outputFieldNames[0]
 		outputValueFieldName = outputFieldNames[1]
 	} else {
 		// long to wide
 		if len(splitOutFieldNames) != 2 {
-			transformerReshapeUsage(os.Stderr, true, 1)
+			transformerReshapeUsage(os.Stderr)
+			os.Exit(1)
 		}
 		splitOutKeyFieldName = splitOutFieldNames[0]
 		splitOutValueFieldName = splitOutFieldNames[1]

--- a/internal/pkg/transformers/sample.go
+++ b/internal/pkg/transformers/sample.go
@@ -23,8 +23,6 @@ var SampleSetup = TransformerSetup{
 
 func transformerSampleUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameSample)
 	fmt.Fprintf(o,
@@ -35,10 +33,6 @@ See also %s bootstrap and %s shuffle.
 	fmt.Fprintf(o, "-g {a,b,c} Optional: group-by-field names for samples, e.g. a,b,c.\n")
 	fmt.Fprintf(o, "-k {k} Required: number of records to output in total, or by group if using -g.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSampleParseCLI(
@@ -68,7 +62,8 @@ func transformerSampleParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSampleUsage(os.Stdout, true, 0)
+			transformerSampleUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-k" {
 			sampleCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -77,12 +72,14 @@ func transformerSampleParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerSampleUsage(os.Stderr, true, 1)
+			transformerSampleUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if sampleCount < 0 {
-		transformerSampleUsage(os.Stderr, true, 1)
+		transformerSampleUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/sec2gmt.go
+++ b/internal/pkg/transformers/sec2gmt.go
@@ -23,8 +23,6 @@ var Sec2GMTSetup = TransformerSetup{
 
 func transformerSec2GMTUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {comma-separated list of field names}\n", "mlr", verbNameSec2GMT)
 	fmt.Fprintf(o, "Replaces a numeric field representing seconds since the epoch with the\n")
@@ -39,10 +37,6 @@ func transformerSec2GMTUsage(
 	fmt.Fprintf(o, "--micros Input numbers are treated as microseconds since the epoch.\n")
 	fmt.Fprintf(o, "--nanos  Input numbers are treated as nanoseconds since the epoch.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSec2GMTParseCLI(
@@ -71,7 +65,8 @@ func transformerSec2GMTParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSec2GMTUsage(os.Stdout, true, 0)
+			transformerSec2GMTUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-1" {
 			numDecimalPlaces = 1
@@ -100,12 +95,14 @@ func transformerSec2GMTParseCLI(
 			preDivide = 1.0e9
 
 		} else {
-			transformerSec2GMTUsage(os.Stderr, true, 1)
+			transformerSec2GMTUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if argi >= argc {
-		transformerSec2GMTUsage(os.Stderr, true, 1)
+		transformerSec2GMTUsage(os.Stderr)
+		os.Exit(1)
 	}
 	fieldNames := args[argi]
 	argi++

--- a/internal/pkg/transformers/sec2gmtdate.go
+++ b/internal/pkg/transformers/sec2gmtdate.go
@@ -23,8 +23,6 @@ var Sec2GMTDateSetup = TransformerSetup{
 
 func transformerSec2GMTDateUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: ../c/mlr sec2gmtdate {comma-separated list of field names}\n")
 	fmt.Fprintf(o, "Replaces a numeric field representing seconds since the epoch with the\n")
@@ -33,10 +31,6 @@ func transformerSec2GMTDateUsage(
 	fmt.Fprintf(o, "  ../c/mlr sec2gmtdate time1,time2\n")
 	fmt.Fprintf(o, "is the same as\n")
 	fmt.Fprintf(o, "  ../c/mlr put '$time1=sec2gmtdate($time1);$time2=sec2gmtdate($time2)'\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSec2GMTDateParseCLI(
@@ -62,15 +56,18 @@ func transformerSec2GMTDateParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSec2GMTDateUsage(os.Stdout, true, 0)
+			transformerSec2GMTDateUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerSec2GMTDateUsage(os.Stderr, true, 1)
+			transformerSec2GMTDateUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if argi >= argc {
-		transformerSec2GMTDateUsage(os.Stderr, true, 1)
+		transformerSec2GMTDateUsage(os.Stderr)
+		os.Exit(1)
 	}
 	fieldNames := args[argi]
 	argi++

--- a/internal/pkg/transformers/seqgen.go
+++ b/internal/pkg/transformers/seqgen.go
@@ -24,8 +24,6 @@ var SeqgenSetup = TransformerSetup{
 
 func transformerSeqgenUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameSeqgen)
 	fmt.Fprintf(o, "Passes input records directly to output. Most useful for format conversion.\n")
@@ -42,10 +40,6 @@ func transformerSeqgenUsage(
 	fmt.Fprintf(o, "Start, stop, and/or step may be floating-point. Output is integer if start,\n")
 	fmt.Fprintf(o, "stop, and step are all integers. Step may be negative. It may not be zero\n")
 	fmt.Fprintf(o, "unless start == stop.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSeqgenParseCLI(
@@ -77,7 +71,8 @@ func transformerSeqgenParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSeqgenUsage(os.Stdout, true, 0)
+			transformerSeqgenUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -92,7 +87,8 @@ func transformerSeqgenParseCLI(
 			stepString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerSeqgenUsage(os.Stderr, true, 1)
+			transformerSeqgenUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/shuffle.go
+++ b/internal/pkg/transformers/shuffle.go
@@ -23,8 +23,6 @@ var ShuffleSetup = TransformerSetup{
 
 func transformerShuffleUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameShuffle)
 	fmt.Fprintf(o, "Outputs records randomly permuted. No output records are produced until\n")
@@ -33,10 +31,6 @@ func transformerShuffleUsage(
 	)
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerShuffleParseCLI(
@@ -62,10 +56,12 @@ func transformerShuffleParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerShuffleUsage(os.Stdout, true, 0)
+			transformerShuffleUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerShuffleUsage(os.Stderr, true, 1)
+			transformerShuffleUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/skip_trivial_records.go
+++ b/internal/pkg/transformers/skip_trivial_records.go
@@ -22,18 +22,12 @@ var SkipTrivialRecordsSetup = TransformerSetup{
 
 func transformerSkipTrivialRecordsUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameSkipTrivialRecords)
 	fmt.Fprintf(o, "Passes through all records except those with zero fields,\n")
 	fmt.Fprintf(o, "or those for which all fields have empty value.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSkipTrivialRecordsParseCLI(
@@ -59,10 +53,12 @@ func transformerSkipTrivialRecordsParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSkipTrivialRecordsUsage(os.Stdout, true, 0)
+			transformerSkipTrivialRecordsUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerSkipTrivialRecordsUsage(os.Stderr, true, 1)
+			transformerSkipTrivialRecordsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/sort.go
+++ b/internal/pkg/transformers/sort.go
@@ -66,8 +66,6 @@ var SortSetup = TransformerSetup{
 
 func transformerSortUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s {flags}\n", "mlr", verbNameSort)
 	fmt.Fprintf(o, "Sorts records primarily by the first specified field, secondarily by the second\n")
@@ -92,10 +90,6 @@ func transformerSortUsage(
 	fmt.Fprintf(o, "  %s %s -f a,b -nr x,y,z\n", "mlr", verbNameSort)
 	fmt.Fprintf(o, "which is the same as:\n")
 	fmt.Fprintf(o, "  %s %s -f a -f b -nr x -nr y -nr z\n", "mlr", verbNameSort)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSortParseCLI(
@@ -125,7 +119,8 @@ func transformerSortParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSortUsage(os.Stdout, true, 0)
+			transformerSortUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			subList := cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -249,12 +244,14 @@ func transformerSortParseCLI(
 			}
 
 		} else {
-			transformerSortUsage(os.Stderr, true, 1)
+			transformerSortUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if len(groupByFieldNames) == 0 {
-		transformerSortUsage(os.Stderr, true, 1)
+		transformerSortUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/sort_within_records.go
+++ b/internal/pkg/transformers/sort_within_records.go
@@ -22,18 +22,12 @@ var SortWithinRecordsSetup = TransformerSetup{
 
 func transformerSortWithinRecordsUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameSortWithinRecords)
 	fmt.Fprintln(o, "Outputs records sorted lexically ascending by keys.")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-r        Recursively sort subobjects/submaps, e.g. for JSON input.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSortWithinRecordsParseCLI(
@@ -60,13 +54,15 @@ func transformerSortWithinRecordsParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSortWithinRecordsUsage(os.Stdout, true, 0)
+			transformerSortWithinRecordsUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-r" {
 			doRecurse = true
 
 		} else {
-			transformerSortWithinRecordsUsage(os.Stderr, true, 1)
+			transformerSortWithinRecordsUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/split.go
+++ b/internal/pkg/transformers/split.go
@@ -27,8 +27,6 @@ var SplitSetup = TransformerSetup{
 
 func transformerSplitUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {filename}\n", "mlr", verbNameSplit)
 	fmt.Fprintf(o,
@@ -70,9 +68,6 @@ then there will be split_yellow_triangle.csv, split_yellow_square.csv, etc.
 
 See also the "tee" DSL function which lets you do more ad-hoc customization.
 `)
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerSplitParseCLI(
@@ -116,7 +111,8 @@ func transformerSplitParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerSplitUsage(os.Stdout, true, 0)
+			transformerSplitUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			n = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -152,7 +148,8 @@ func transformerSplitParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerSplitUsage(os.Stderr, true, 1)
+				transformerSplitUsage(os.Stderr)
+				os.Exit(1)
 			}
 		}
 	}

--- a/internal/pkg/transformers/stats1.go
+++ b/internal/pkg/transformers/stats1.go
@@ -27,8 +27,6 @@ var Stats1Setup = TransformerSetup{
 
 func transformerStats1Usage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameStats1)
 	fmt.Fprint(o,
@@ -87,10 +85,6 @@ Options:
   In particular, 1 and 1.0 are distinct text for count and mode.
 * When there are mode ties, the first-encountered datum wins.
 `)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerStats1ParseCLI(
@@ -129,7 +123,8 @@ func transformerStats1ParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerStats1Usage(os.Stdout, true, 0)
+			transformerStats1Usage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-a" {
 			accumulatorNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -176,7 +171,8 @@ func transformerStats1ParseCLI(
 			// No-op pass-through for backward compatibility with Miller 5
 
 		} else {
-			transformerStats1Usage(os.Stderr, true, 1)
+			transformerStats1Usage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/stats2.go
+++ b/internal/pkg/transformers/stats2.go
@@ -29,8 +29,6 @@ var Stats2Setup = TransformerSetup{
 
 func transformerStats2Usage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameStats2
@@ -57,10 +55,6 @@ func transformerStats2Usage(
 	fmt.Fprintf(o, "Example: %s %s -a linreg-pca -f x,y\n", argv0, verb)
 	fmt.Fprintf(o, "Example: %s %s -a linreg-ols,r2 -f x,y -g size,shape\n", argv0, verb)
 	fmt.Fprintf(o, "Example: %s %s -a corr -f x,y\n", argv0, verb)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 // ----------------------------------------------------------------
@@ -97,7 +91,8 @@ func transformerStats2ParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerStats2Usage(os.Stdout, true, 0)
+			transformerStats2Usage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-a" {
 			accumulatorNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -127,12 +122,14 @@ func transformerStats2ParseCLI(
 			// for all applicable stats2 accumulators (i.e. none of them).
 
 		} else {
-			transformerStats2Usage(os.Stderr, true, 1)
+			transformerStats2Usage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if doIterativeStats && doHoldAndFit {
-		transformerStats2Usage(os.Stderr, true, 1)
+		transformerStats2Usage(os.Stderr)
+		os.Exit(1)
 	}
 	if accumulatorNameList == nil {
 		fmt.Fprintf(os.Stderr, "%s %s: -a option is required.\n", argv0, verb)

--- a/internal/pkg/transformers/step.go
+++ b/internal/pkg/transformers/step.go
@@ -96,8 +96,6 @@ var StepSetup = TransformerSetup{
 
 func transformerStepUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: mlr %s [options]\n", verbNameStep)
 	fmt.Fprintf(o, "Computes values dependent on earlier/later records, optionally grouped by category.\n")
@@ -141,10 +139,6 @@ func transformerStepUsage(
 	fmt.Fprintf(o, "Please see https://miller.readthedocs.io/en/latest/reference-verbs.html#filter or\n")
 	fmt.Fprintf(o, "https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average\n")
 	fmt.Fprintf(o, "for more information on EWMA.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerStepParseCLI(
@@ -177,7 +171,8 @@ func transformerStepParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerStepUsage(os.Stdout, true, 0)
+			transformerStepUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-a" {
 			// Let them do '-a delta -a rsum' or '-a delta,rsum'
@@ -214,7 +209,8 @@ func transformerStepParseCLI(
 			// as a no-op for backward compatibility with Miller 5 and below.
 
 		} else {
-			transformerStepUsage(os.Stderr, true, 1)
+			transformerStepUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/tac.go
+++ b/internal/pkg/transformers/tac.go
@@ -22,17 +22,11 @@ var TacSetup = TransformerSetup{
 
 func transformerTacUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameTac)
 	fmt.Fprintf(o, "Prints records in reverse order from the order in which they were encountered.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerTacParseCLI(
@@ -58,10 +52,12 @@ func transformerTacParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerTacUsage(os.Stdout, true, 0)
+			transformerTacUsage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerTacUsage(os.Stderr, true, 1)
+			transformerTacUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/tail.go
+++ b/internal/pkg/transformers/tail.go
@@ -23,8 +23,6 @@ var TailSetup = TransformerSetup{
 
 func transformerTailUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameTail)
 	fmt.Fprintln(o, "Passes through the last n records, optionally by category.")
@@ -33,10 +31,6 @@ func transformerTailUsage(
 	fmt.Fprintf(o, "-g {a,b,c} Optional group-by-field names for head counts, e.g. a,b,c.\n")
 	fmt.Fprintf(o, "-n {n} Head-count to print. Default 10.\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerTailParseCLI(
@@ -66,7 +60,8 @@ func transformerTailParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerTailUsage(os.Stdout, true, 0)
+			transformerTailUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			tailCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -85,7 +80,8 @@ func transformerTailParseCLI(
 			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerTailUsage(os.Stderr, true, 1)
+			transformerTailUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/tee.go
+++ b/internal/pkg/transformers/tee.go
@@ -23,8 +23,6 @@ var TeeSetup = TransformerSetup{
 
 func transformerTeeUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {filename}\n", "mlr", verbNameTee)
 	fmt.Fprintf(o, "Options:\n")
@@ -38,9 +36,6 @@ is written in JSON format.
 
 -h|--help Show this message.
 `)
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerTeeParseCLI(
@@ -78,7 +73,8 @@ func transformerTeeParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerTeeUsage(os.Stdout, true, 0)
+			transformerTeeUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-a" {
 			appending = true
@@ -98,7 +94,8 @@ func transformerTeeParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerTeeUsage(os.Stderr, true, 1)
+				transformerTeeUsage(os.Stderr)
+				os.Exit(1)
 			}
 		}
 	}
@@ -107,7 +104,8 @@ func transformerTeeParseCLI(
 
 	// Get the filename/command from the command line, after the flags
 	if argi >= argc {
-		transformerTeeUsage(os.Stderr, true, 1)
+		transformerTeeUsage(os.Stderr)
+		os.Exit(1)
 	}
 	filenameOrCommand = args[argi]
 	argi++

--- a/internal/pkg/transformers/template.go
+++ b/internal/pkg/transformers/template.go
@@ -24,8 +24,6 @@ var TemplateSetup = TransformerSetup{
 
 func transformerTemplateUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameTemplate)
 	fmt.Fprintf(o, "Places input-record fields in the order specified by list of column names.\n")
@@ -40,10 +38,6 @@ func transformerTemplateUsage(
 	fmt.Fprintf(o, "* Specified fields are a,b,c.\n")
 	fmt.Fprintf(o, "* Input record is c=3,a=1,f=6.\n")
 	fmt.Fprintf(o, "* Output record is a=1,b=,c=3.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerTemplateParseCLI(
@@ -73,7 +67,8 @@ func transformerTemplateParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerTemplateUsage(os.Stdout, true, 0)
+			transformerTemplateUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -91,12 +86,14 @@ func transformerTemplateParseCLI(
 			fillWith = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerTemplateUsage(os.Stderr, true, 1)
+			transformerTemplateUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerTemplateUsage(os.Stderr, true, 1)
+		transformerTemplateUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/top.go
+++ b/internal/pkg/transformers/top.go
@@ -26,8 +26,6 @@ var TopSetup = TransformerSetup{
 
 func transformerTopUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameTop
@@ -48,10 +46,6 @@ func transformerTopUsage(
 	fmt.Fprintf(o, "with the same fields as they appeared in the input. Without -a, only fields\n")
 	fmt.Fprintf(o, "from -f, fields from -g, and the top-index field are emitted. For more information\n")
 	fmt.Fprintf(o, "please see https://miller.readthedocs.io/en/latest/reference-verbs#top\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerTopParseCLI(
@@ -86,7 +80,8 @@ func transformerTopParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerTopUsage(os.Stdout, true, 0)
+			transformerTopUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-n" {
 			topCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
@@ -106,15 +101,18 @@ func transformerTopParseCLI(
 			outputFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerTopUsage(os.Stderr, true, 1)
+			transformerTopUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if valueFieldNames == nil {
-		transformerTopUsage(os.Stderr, true, 1)
+		transformerTopUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if len(valueFieldNames) > 1 && showFullRecords {
-		transformerTopUsage(os.Stderr, true, 1)
+		transformerTopUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	*pargi = argi

--- a/internal/pkg/transformers/unflatten.go
+++ b/internal/pkg/transformers/unflatten.go
@@ -23,8 +23,6 @@ var UnflattenSetup = TransformerSetup{
 
 func transformerUnflattenUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameUnflatten)
 	fmt.Fprint(o,
@@ -35,10 +33,6 @@ becomes name 'a' and value '{"b": { "c": 4 }}'.
 	fmt.Fprintf(o, "-f {a,b,c} Comma-separated list of field names to unflatten (default all).\n")
 	fmt.Fprintf(o, "-s {string} Separator, defaulting to %s --flatsep value.\n", "mlr")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerUnflattenParseCLI(
@@ -68,7 +62,8 @@ func transformerUnflattenParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerUnflattenUsage(os.Stdout, true, 0)
+			transformerUnflattenUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-s" {
 			oFlatSep = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -77,7 +72,8 @@ func transformerUnflattenParseCLI(
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerUnflattenUsage(os.Stderr, true, 1)
+			transformerUnflattenUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/uniq.go
+++ b/internal/pkg/transformers/uniq.go
@@ -34,8 +34,6 @@ var UniqSetup = TransformerSetup{
 // ----------------------------------------------------------------
 func transformerCountDistinctUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameCountDistinct
@@ -53,10 +51,6 @@ func transformerCountDistinctUsage(
 	fmt.Fprintf(o, "              and b field values. With -f a,b and with -u, computes counts\n")
 	fmt.Fprintf(o, "              for distinct a field values and counts for distinct b field\n")
 	fmt.Fprintf(o, "              values separately.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerCountDistinctParseCLI(
@@ -89,7 +83,8 @@ func transformerCountDistinctParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerCountDistinctUsage(os.Stdout, true, 0)
+			transformerCountDistinctUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-g" || opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -104,15 +99,18 @@ func transformerCountDistinctParseCLI(
 			doLashed = false
 
 		} else {
-			transformerCountDistinctUsage(os.Stderr, true, 1)
+			transformerCountDistinctUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerCountDistinctUsage(os.Stderr, true, 1)
+		transformerCountDistinctUsage(os.Stderr)
+		os.Exit(1)
 	}
 	if !doLashed && showNumDistinctOnly {
-		transformerCountDistinctUsage(os.Stderr, true, 1)
+		transformerCountDistinctUsage(os.Stderr)
+		os.Exit(1)
 	}
 
 	showCounts := true
@@ -142,8 +140,6 @@ func transformerCountDistinctParseCLI(
 // ----------------------------------------------------------------
 func transformerUniqUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	argv0 := "mlr"
 	verb := verbNameUniq
@@ -160,10 +156,6 @@ func transformerUniqUsage(
 	fmt.Fprintf(o, "              With -c, produces unique records, with repeat counts for each.\n")
 	fmt.Fprintf(o, "              With -n, produces only one record which is the unique-record count.\n")
 	fmt.Fprintf(o, "              With neither -c nor -n, produces unique records.\n")
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerUniqParseCLI(
@@ -197,7 +189,8 @@ func transformerUniqParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerUniqUsage(os.Stdout, true, 0)
+			transformerUniqUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "-g" || opt == "-f" {
 			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
@@ -215,20 +208,24 @@ func transformerUniqParseCLI(
 			uniqifyEntireRecords = true
 
 		} else {
-			transformerUniqUsage(os.Stderr, true, 1)
+			transformerUniqUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 
 	if uniqifyEntireRecords {
 		if fieldNames != nil {
-			transformerUniqUsage(os.Stderr, true, 1)
+			transformerUniqUsage(os.Stderr)
+			os.Exit(1)
 		}
 		if showCounts && showNumDistinctOnly {
-			transformerUniqUsage(os.Stderr, true, 1)
+			transformerUniqUsage(os.Stderr)
+			os.Exit(1)
 		}
 	} else {
 		if fieldNames == nil {
-			transformerUniqUsage(os.Stderr, true, 1)
+			transformerUniqUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/unsparsify.go
+++ b/internal/pkg/transformers/unsparsify.go
@@ -24,8 +24,6 @@ var UnsparsifySetup = TransformerSetup{
 
 func transformerUnsparsifyUsage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", "mlr", verbNameUnsparsify)
 	fmt.Fprint(o,
@@ -46,10 +44,6 @@ a value. This verb retains all input before producing any output.
 being 'b=3,c=4', then the output is the two records 'a=1,b=2,c=' and
 'a=,b=3,c=4'.
 `)
-
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerUnsparsifyParseCLI(
@@ -79,7 +73,8 @@ func transformerUnsparsifyParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerUnsparsifyUsage(os.Stdout, true, 0)
+			transformerUnsparsifyUsage(os.Stdout)
+			os.Exit(0)
 
 		} else if opt == "--fill-with" {
 			fillerString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
@@ -88,7 +83,8 @@ func transformerUnsparsifyParseCLI(
 			specifiedFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
 
 		} else {
-			transformerUnsparsifyUsage(os.Stderr, true, 1)
+			transformerUnsparsifyUsage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/pkg/transformers/utf8_to_latin1.go
+++ b/internal/pkg/transformers/utf8_to_latin1.go
@@ -24,17 +24,12 @@ var UTF8ToLatin1Setup = TransformerSetup{
 
 func transformerUTF8ToLatin1Usage(
 	o *os.File,
-	doExit bool,
-	exitCode int,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s, with no options.\n", "mlr", verbNameUTF8ToLatin1)
 	fmt.Fprintf(o, "Recursively converts record strings from Latin-1 to UTF-8.\n")
 	fmt.Fprintf(o, "For field-level control, please see the utf8_to_latin1 DSL function.\n")
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
-	if doExit {
-		os.Exit(exitCode)
-	}
 }
 
 func transformerUTF8ToLatin1ParseCLI(
@@ -60,10 +55,12 @@ func transformerUTF8ToLatin1ParseCLI(
 		argi++
 
 		if opt == "-h" || opt == "--help" {
-			transformerUTF8ToLatin1Usage(os.Stdout, true, 0)
+			transformerUTF8ToLatin1Usage(os.Stdout)
+			os.Exit(0)
 
 		} else {
-			transformerUTF8ToLatin1Usage(os.Stderr, true, 1)
+			transformerUTF8ToLatin1Usage(os.Stderr)
+			os.Exit(1)
 		}
 	}
 

--- a/test/cases/dsl-local-date-time-functions/not-a-valid-timezone/experr
+++ b/test/cases/dsl-local-date-time-functions/not-a-valid-timezone/experr
@@ -1,1 +1,1 @@
-mlr: unknown time zone this-is-not-a-valid-timezone-name
+mlr :  unknown time zone this-is-not-a-valid-timezone-name


### PR DESCRIPTION
The current behavior is fine for main `mlr` processing; not so great for the REPL where we want an error message printed out without killing the session.