### PR TITLE
[Docs] moving --xvright out of the FLATTEN-UNFLATTEN FLAGS section

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -394,6 +394,7 @@ FILE-FORMAT FLAGS
        --tsvlite                Use TSV-lite format for input and output data.
        --usv or --usvlite       Use USV format for input and output data.
        --xtab                   Use XTAB format for input and output data.
+       --xvright                Right-justify values for XTAB format.
        -i {format name}         Use format name for input data. For example: `-i csv`
                                 is the same as `--icsv`.
        -o {format name}         Use format name for output data. For example: `-o
@@ -419,7 +420,6 @@ FLATTEN-UNFLATTEN FLAGS
                                 `$y=[7,8,9]`. flattens to `y.1=7,y.2=8,y.3=9. With
                                 `--no-auto-flatten`, instead we get
                                 `${y.1}=7,${y.2}=8,${y.3}=9`.
-       --xvright                Right-justify values for XTAB format.
 
 FORMAT-CONVERSION KEYSTROKE-SAVER FLAGS
        As keystroke-savers for format-conversion you may use the following.

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -373,6 +373,7 @@ FILE-FORMAT FLAGS
        --tsvlite                Use TSV-lite format for input and output data.
        --usv or --usvlite       Use USV format for input and output data.
        --xtab                   Use XTAB format for input and output data.
+       --xvright                Right-justify values for XTAB format.
        -i {format name}         Use format name for input data. For example: `-i csv`
                                 is the same as `--icsv`.
        -o {format name}         Use format name for output data. For example: `-o
@@ -398,7 +399,6 @@ FLATTEN-UNFLATTEN FLAGS
                                 `$y=[7,8,9]`. flattens to `y.1=7,y.2=8,y.3=9. With
                                 `--no-auto-flatten`, instead we get
                                 `${y.1}=7,${y.2}=8,${y.3}=9`.
-       --xvright                Right-justify values for XTAB format.
 
 FORMAT-CONVERSION KEYSTROKE-SAVER FLAGS
        As keystroke-savers for format-conversion you may use the following.

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -181,6 +181,7 @@ are overridden in all cases by setting output format to `format2`.
 * `--tsvlite`: Use TSV-lite format for input and output data.
 * `--usv or --usvlite`: Use USV format for input and output data.
 * `--xtab`: Use XTAB format for input and output data.
+* `--xvright`: Right-justify values for XTAB format.
 * `-i {format name}`: Use format name for input data. For example: `-i csv` is the same as `--icsv`.
 * `-o {format name}`: Use format name for output data.  For example: `-o csv` is the same as `--ocsv`.
 
@@ -196,7 +197,6 @@ See the Flatten/unflatten doc page for more information.
 * `--flatsep or --jflatsep {string}`: Separator for flattening multi-level JSON keys, e.g. `{"a":{"b":3}}` becomes `a:b => 3` for non-JSON formats. Defaults to `.`.
 * `--no-auto-flatten`: When output is non-JSON, suppress the default auto-flatten behavior. Default: if `$y = [7,8,9]` then this flattens to `y.1=7,y.2=8,y.3=9, and similarly for maps. With `--no-auto-flatten`, instead we get `$y=[1, 2, 3]`.
 * `--no-auto-unflatten`: When input non-JSON and output is JSON, suppress the default auto-unflatten behavior. Default: if the input has `y.1=7,y.2=8,y.3=9` then this unflattens to `$y=[7,8,9]`.  flattens to `y.1=7,y.2=8,y.3=9. With `--no-auto-flatten`, instead we get `${y.1}=7,${y.2}=8,${y.3}=9`.
-* `--xvright`: Right-justify values for XTAB format.
 
 ## Format-conversion keystroke-saver flags
 

--- a/internal/pkg/cli/option_parse.go
+++ b/internal/pkg/cli/option_parse.go
@@ -1095,6 +1095,15 @@ var FileFormatFlagSection = FlagSection{
 		},
 
 		{
+			name: "--xvright",
+			help: "Right-justify values for XTAB format.",
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.WriterOptions.RightAlignedXTABOutput = true
+				*pargi += 1
+			},
+		},
+
+		{
 			name: "--pprint",
 			help: "Use PPRINT format for input and output data.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
@@ -2569,15 +2578,6 @@ var FlattenUnflattenFlagSection = FlagSection{
 				CheckArgCount(args, *pargi, argc, 2)
 				options.WriterOptions.FLATSEP = SeparatorFromArg(args[*pargi+1])
 				*pargi += 2
-			},
-		},
-
-		{
-			name: "--xvright",
-			help: "Right-justify values for XTAB format.",
-			parser: func(args []string, argc int, pargi *int, options *TOptions) {
-				options.WriterOptions.RightAlignedXTABOutput = true
-				*pargi += 1
 			},
 		},
 

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -373,6 +373,7 @@ FILE-FORMAT FLAGS
        --tsvlite                Use TSV-lite format for input and output data.
        --usv or --usvlite       Use USV format for input and output data.
        --xtab                   Use XTAB format for input and output data.
+       --xvright                Right-justify values for XTAB format.
        -i {format name}         Use format name for input data. For example: `-i csv`
                                 is the same as `--icsv`.
        -o {format name}         Use format name for output data. For example: `-o
@@ -398,7 +399,6 @@ FLATTEN-UNFLATTEN FLAGS
                                 `$y=[7,8,9]`. flattens to `y.1=7,y.2=8,y.3=9. With
                                 `--no-auto-flatten`, instead we get
                                 `${y.1}=7,${y.2}=8,${y.3}=9`.
-       --xvright                Right-justify values for XTAB format.
 
 FORMAT-CONVERSION KEYSTROKE-SAVER FLAGS
        As keystroke-savers for format-conversion you may use the following.

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -452,6 +452,7 @@ are overridden in all cases by setting output format to `format2`.
 --tsvlite                Use TSV-lite format for input and output data.
 --usv or --usvlite       Use USV format for input and output data.
 --xtab                   Use XTAB format for input and output data.
+--xvright                Right-justify values for XTAB format.
 -i {format name}         Use format name for input data. For example: `-i csv`
                          is the same as `--icsv`.
 -o {format name}         Use format name for output data. For example: `-o
@@ -485,7 +486,6 @@ See the Flatten/unflatten doc page for more information.
                          `$y=[7,8,9]`. flattens to `y.1=7,y.2=8,y.3=9. With
                          `--no-auto-flatten`, instead we get
                          `${y.1}=7,${y.2}=8,${y.3}=9`.
---xvright                Right-justify values for XTAB format.
 .fi
 .if n \{\
 .RE


### PR DESCRIPTION
Hello.
I've noticed that `--xvright` in the docs was located in the FLATTEN-UNFLATTEN FLAGS section. It felt like an oversight so I've fixed it in this PR.
Let me know if I made some mistake @johnkerl 