### PR TITLE
feat: system/exec() function call ( #1043)

### DIFF
--- a/internal/pkg/dsl/cst/builtin_function_manager.go
+++ b/internal/pkg/dsl/cst/builtin_function_manager.go
@@ -1924,6 +1924,24 @@ either case it should return a boolean.`,
 		},
 
 		{
+			name:      "exec",
+			class:     FUNC_CLASS_SYSTEM,
+			help:      `'$output = exec(
+	"command",
+	["arg1", "arg2"],
+	{"env": ["ENV_VAR=ENV_VALUE"],
+	"dir": "/tmp/run_command_here",
+	"stdin_string": "this is input fed to program",
+	"combined_output": true
+)'
+Run a command via executable, path, args and environment, yielding its stdout minus final carriage return.`,
+			examples: []string{
+				`exec("echo", ["Hello", "$YOUR_NAME"], {"env": "YOUR_NAME=World"}) outputs "Hello World"`,
+			},
+			variadicFunc: bifs.BIF_exec,
+		},
+
+		{
 			name:     "version",
 			class:    FUNC_CLASS_SYSTEM,
 			help:     `Returns the Miller version as a string.`,


### PR DESCRIPTION
Feature as detailed in #1043 

Changes from discussed

 * For `env`, I did not use a dictionary / map for environmental variables but instead an array with KEY=VALUE items, as this matches the golang API
 * Changed the option `string_input` to `stdin_string` as that seemed better
 * Added a `combined_output` option which includes both STDOUT and STDERR as it seemed like a good idea and was easy with the golang API.

NOTE: I've never wrote (, or practically even looked at) any golang code before. I'm not sure on how good this is, specifically my define a variable then use an `if`/`else` afterwards (combinedOutput) to change it seems naff.

Happy to have feedback.