### PR TITLE
Add a regression test with path check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,11 @@ jobs:
     - name: Test
       run: make check
 
+    - name: Regression tests
+      # We run these with a convoluted path to ensure the tests don't
+      # rely on a specific invocation
+      run: test/../mlr regtest -S
+
     - name: PrepareArtifactNonWindows
       if: matrix.os != 'windows-latest'
       run: mkdir -p bin/${{matrix.os}} && cp mlr bin/${{matrix.os}}


### PR DESCRIPTION
The idea here is both to run the regression tests, using mlr regtest
rather than make check, and also to check that the tests don't assume
a specific invocation path.

Signed-off-by: Stephen Kitt <steve@sk2.org>