### PR TITLE
Account for varying mlr locations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,11 @@ jobs:
     - name: Test
       run: make check
 
+    - name: Regression tests
+      # We run these with a convoluted path to ensure the tests don't
+      # rely on a specific invocation
+      run: test/../mlr regtest -S
+
     - name: PrepareArtifactNonWindows
       if: matrix.os != 'windows-latest'
       run: mkdir -p bin/${{matrix.os}} && cp mlr bin/${{matrix.os}}

--- a/test/cases/dsl-local-date-time-functions/not-a-valid-timezone/experr
+++ b/test/cases/dsl-local-date-time-functions/not-a-valid-timezone/experr
@@ -1,1 +1,1 @@
-mlr :  unknown time zone this-is-not-a-valid-timezone-name
+${MLR} :  unknown time zone this-is-not-a-valid-timezone-name


### PR DESCRIPTION
The expected error output for the "not-a-valid-timezone" test assumes
that mlr is invoked as mlr. Use "${MLR}" instead to cope with any
invocation path.

This also adds a regression test to catch future instances before they
get merged.

Signed-off-by: Stephen Kitt <steve@sk2.org>