### PR TITLE
Complete #1181

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -1525,7 +1525,7 @@ MILLER(1)                                                            MILLER(1)
          Regex-replacement:
            '$name = sub($name, "http.*com"i, "")'
          Regex-capture:
-           'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+            'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
          Built-in variables:
            '$filename = FILENAME'
          Aggregations (use mlr put -q):
@@ -3297,5 +3297,5 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-01-01                         MILLER(1)
+                                  2023-01-28                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -1504,7 +1504,7 @@ MILLER(1)                                                            MILLER(1)
          Regex-replacement:
            '$name = sub($name, "http.*com"i, "")'
          Regex-capture:
-           'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+            'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
          Built-in variables:
            '$filename = FILENAME'
          Aggregations (use mlr put -q):
@@ -3276,4 +3276,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-01-01                         MILLER(1)
+                                  2023-01-28                         MILLER(1)

--- a/docs/src/reference-verbs.md
+++ b/docs/src/reference-verbs.md
@@ -2265,7 +2265,7 @@ More example put expressions:
   Regex-replacement:
     '$name = sub($name, "http.*com"i, "")'
   Regex-capture:
-    'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+	'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
   Built-in variables:
     '$filename = FILENAME'
   Aggregations (use mlr put -q):

--- a/internal/pkg/transformers/put_or_filter.go
+++ b/internal/pkg/transformers/put_or_filter.go
@@ -119,7 +119,7 @@ More example put expressions:
   Regex-replacement:
     '$name = sub($name, "http.*com"i, "")'
   Regex-capture:
-    'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+	'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
   Built-in variables:
     '$filename = FILENAME'
   Aggregations (use mlr put -q):

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -1504,7 +1504,7 @@ MILLER(1)                                                            MILLER(1)
          Regex-replacement:
            '$name = sub($name, "http.*com"i, "")'
          Regex-capture:
-           'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+            'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
          Built-in variables:
            '$filename = FILENAME'
          Aggregations (use mlr put -q):
@@ -3276,4 +3276,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-01-01                         MILLER(1)
+                                  2023-01-28                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-01-01
+.\"      Date: 2023-01-28
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-01-01" "\ \&" "\ \&"
+.TH "MILLER" "1" "2023-01-28" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1885,7 +1885,7 @@ More example put expressions:
   Regex-replacement:
     '$name = sub($name, "http.*com"i, "")'
   Regex-capture:
-    'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\e1"; $c = "right_\e2" }'
+	'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\e1"; $c = "right_\e2" }'
   Built-in variables:
     '$filename = FILENAME'
   Aggregations (use mlr put -q):

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -689,7 +689,7 @@ More example put expressions:
   Regex-replacement:
     '$name = sub($name, "http.*com"i, "")'
   Regex-capture:
-    'if ($a =~ "([a-z]+)_([0-9]+)) { $b = "left_\1"; $c = "right_\2" }'
+	'if ($a =~ "([a-z]+)_([0-9]+)") { $b = "left_\1"; $c = "right_\2" }'
   Built-in variables:
     '$filename = FILENAME'
   Aggregations (use mlr put -q):


### PR DESCRIPTION
#1181 fixes `references-verbs.md`; this fixes the original source of the typo. Followed by artifacts from `make dev`.