### PR TITLE
Include tools in the release tarball

### DIFF
--- a/create-release-tarball
+++ b/create-release-tarball
@@ -92,6 +92,7 @@ $tar \
   ./internal \
   ./regression_test.go \
   ./man \
-  ./test
+  ./test \
+  ./tools
 
 echo "Wrote   $TGZ_NAME"


### PR DESCRIPTION
This allows third-parties to run the tools from the tarball for a given release, instead of having to use the repository.