### PR TITLE
Implement `--csv-trim-leading-space` flag

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -316,6 +316,9 @@ MILLER(1)                                                            MILLER(1)
                                 fill remaining keys with empty string. If a data line
                                 has more fields than the header line, use integer
                                 field labels as in the implicit-header case.
+       --csv-trim-leading-space Trims leading spaces in CSV data. Use this for data
+                                like '"foo", "bar' which is non-RFC-4180 compliant,
+                                but common.
        --headerless-csv-output or --ho or --headerless-tsv-output
                                 Print only CSV/TSV data lines; do not print CSV/TSV
                                 header lines.
@@ -3354,5 +3357,5 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-04-16                         MILLER(1)
+                                  2023-04-20                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -295,6 +295,9 @@ MILLER(1)                                                            MILLER(1)
                                 fill remaining keys with empty string. If a data line
                                 has more fields than the header line, use integer
                                 field labels as in the implicit-header case.
+       --csv-trim-leading-space Trims leading spaces in CSV data. Use this for data
+                                like '"foo", "bar' which is non-RFC-4180 compliant,
+                                but common.
        --headerless-csv-output or --ho or --headerless-tsv-output
                                 Print only CSV/TSV data lines; do not print CSV/TSV
                                 header lines.
@@ -3333,4 +3336,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-04-16                         MILLER(1)
+                                  2023-04-20                         MILLER(1)

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -117,6 +117,7 @@ These are flags which are applicable to CSV format.
 **Flags:**
 
 * `--allow-ragged-csv-input or --ragged or --allow-ragged-tsv-input`: If a data line has fewer fields than the header line, fill remaining keys with empty string. If a data line has more fields than the header line, use integer field labels as in the implicit-header case.
+* `--csv-trim-leading-space`: Trims leading spaces in CSV data. Use this for data like '"foo", "bar' which is non-RFC-4180 compliant, but common.
 * `--headerless-csv-output or --ho or --headerless-tsv-output`: Print only CSV/TSV data lines; do not print CSV/TSV header lines.
 * `--implicit-csv-header or --headerless-csv-input or --hi or --implicit-tsv-header`: Use 1,2,3,... as field labels, rather than from line 1 of input files. Tip: combine with `label` to recreate missing headers.
 * `--lazy-quotes`: Accepts quotes appearing in unquoted fields, and non-doubled quotes appearing in quoted fields.

--- a/internal/pkg/cli/option_parse.go
+++ b/internal/pkg/cli/option_parse.go
@@ -2174,6 +2174,15 @@ var CSVTSVOnlyFlagSection = FlagSection{
 		},
 
 		{
+			name: "--csv-trim-leading-space",
+			help: `Trims leading spaces in CSV data. Use this for data like '"foo", "bar' which is non-RFC-4180 compliant, but common.`,
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.ReaderOptions.CSVTrimLeadingSpace = true
+				*pargi += 1
+			},
+		},
+
+		{
 			name: "--quote-all",
 			help: "Force double-quoting of CSV fields.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {

--- a/internal/pkg/cli/option_types.go
+++ b/internal/pkg/cli/option_types.go
@@ -56,6 +56,7 @@ type TReaderOptions struct {
 	UseImplicitCSVHeader bool
 	AllowRaggedCSVInput  bool
 	CSVLazyQuotes        bool
+	CSVTrimLeadingSpace  bool
 
 	CommentHandling TCommentHandling
 	CommentString   string

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -295,6 +295,9 @@ MILLER(1)                                                            MILLER(1)
                                 fill remaining keys with empty string. If a data line
                                 has more fields than the header line, use integer
                                 field labels as in the implicit-header case.
+       --csv-trim-leading-space Trims leading spaces in CSV data. Use this for data
+                                like '"foo", "bar' which is non-RFC-4180 compliant,
+                                but common.
        --headerless-csv-output or --ho or --headerless-tsv-output
                                 Print only CSV/TSV data lines; do not print CSV/TSV
                                 header lines.
@@ -3333,4 +3336,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-04-16                         MILLER(1)
+                                  2023-04-20                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-04-16
+.\"      Date: 2023-04-20
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-04-16" "\ \&" "\ \&"
+.TH "MILLER" "1" "2023-04-20" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -366,6 +366,9 @@ These are flags which are applicable to CSV format.
                          fill remaining keys with empty string. If a data line
                          has more fields than the header line, use integer
                          field labels as in the implicit-header case.
+--csv-trim-leading-space Trims leading spaces in CSV data. Use this for data
+                         like '"foo", "bar' which is non-RFC-4180 compliant,
+                         but common.
 --headerless-csv-output or --ho or --headerless-tsv-output
                          Print only CSV/TSV data lines; do not print CSV/TSV
                          header lines.

--- a/test/cases/help/0018/expout
+++ b/test/cases/help/0018/expout
@@ -1,3 +1,5 @@
+--csv-trim-leading-space
+Trims leading spaces in CSV data. Use this for data like '"foo", "bar' which is non-RFC-4180 compliant, but common.
 --csv
 Use CSV format for input and output data.
 --csvlite


### PR DESCRIPTION
Found while prepping for csv,conf,v7 (#1268). CSV files like this

```
"Year", "Quantity"
2015, 345
```

(note the [non-compliant](https://miller.readthedocs.io/en/latest/file-formats/#csvtsvasvusvetc) space after the comma) weren't being parsed successfully:

```
mlr: mlr: CSV header/data length mismatch 1 != 2 at filename x row 2.
```

With `mlr --csv --csv-trim-leading-space` these can now be parsed.

This is left non-default in accordance with Miller's general philosophy that it handles [RFC-4180-compliant CSV](https://miller.readthedocs.io/en/latest/file-formats/#csvtsvasvusvetc) by default.