### PR TITLE
Fix `mlr grep` docs re OFS/OPS

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -1210,13 +1210,13 @@ MILLER(1)                                                            MILLER(1)
        Note that "mlr filter" is more powerful, but requires you to know field names.
        By contrast, "mlr grep" allows you to regex-match the entire record. It does this
        by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-       command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-       regex specified here. In particular, the regex is not applied to the input
-       stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-       regex will be matched, not against either of these lines, but against the DKVP
-       line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-       supported, and this command is intended to be merely a keystroke-saver. To get
-       all the features of system grep, you can do
+       OFS "," and OPS "=", and matching the resulting line against the regex specified
+       here. In particular, the regex is not applied to the input stream: if you have
+       CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+       matched, not against either of these lines, but against the DKVP line
+       "x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+       and this command is intended to be merely a keystroke-saver. To get all the
+       features of system grep, you can do
          "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 
    1mgroup-by0m
@@ -3354,5 +3354,5 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-06-04                         MILLER(1)
+                                  2023-06-06                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -1189,13 +1189,13 @@ MILLER(1)                                                            MILLER(1)
        Note that "mlr filter" is more powerful, but requires you to know field names.
        By contrast, "mlr grep" allows you to regex-match the entire record. It does this
        by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-       command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-       regex specified here. In particular, the regex is not applied to the input
-       stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-       regex will be matched, not against either of these lines, but against the DKVP
-       line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-       supported, and this command is intended to be merely a keystroke-saver. To get
-       all the features of system grep, you can do
+       OFS "," and OPS "=", and matching the resulting line against the regex specified
+       here. In particular, the regex is not applied to the input stream: if you have
+       CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+       matched, not against either of these lines, but against the DKVP line
+       "x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+       and this command is intended to be merely a keystroke-saver. To get all the
+       features of system grep, you can do
          "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 
    1mgroup-by0m
@@ -3333,4 +3333,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-06-04                         MILLER(1)
+                                  2023-06-06                         MILLER(1)

--- a/docs/src/reference-verbs.md
+++ b/docs/src/reference-verbs.md
@@ -1355,13 +1355,13 @@ Options:
 Note that "mlr filter" is more powerful, but requires you to know field names.
 By contrast, "mlr grep" allows you to regex-match the entire record. It does this
 by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-regex specified here. In particular, the regex is not applied to the input
-stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-regex will be matched, not against either of these lines, but against the DKVP
-line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-supported, and this command is intended to be merely a keystroke-saver. To get
-all the features of system grep, you can do
+OFS "," and OPS "=", and matching the resulting line against the regex specified
+here. In particular, the regex is not applied to the input stream: if you have
+CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+matched, not against either of these lines, but against the DKVP line
+"x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+and this command is intended to be merely a keystroke-saver. To get all the
+features of system grep, you can do
   "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 </pre>
 

--- a/internal/pkg/transformers/grep.go
+++ b/internal/pkg/transformers/grep.go
@@ -36,13 +36,13 @@ func transformerGrepUsage(
 	fmt.Fprintf(o, `Note that "%s filter" is more powerful, but requires you to know field names.
 By contrast, "%s grep" allows you to regex-match the entire record. It does this
 by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-regex specified here. In particular, the regex is not applied to the input
-stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-regex will be matched, not against either of these lines, but against the DKVP
-line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-supported, and this command is intended to be merely a keystroke-saver. To get
-all the features of system grep, you can do
+OFS "," and OPS "=", and matching the resulting line against the regex specified
+here. In particular, the regex is not applied to the input stream: if you have
+CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+matched, not against either of these lines, but against the DKVP line
+"x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+and this command is intended to be merely a keystroke-saver. To get all the
+features of system grep, you can do
   "%s --odkvp ... | grep ... | %s --idkvp ..."
 `, "mlr", "mlr", "mlr", "mlr")
 }

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -1189,13 +1189,13 @@ MILLER(1)                                                            MILLER(1)
        Note that "mlr filter" is more powerful, but requires you to know field names.
        By contrast, "mlr grep" allows you to regex-match the entire record. It does this
        by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-       command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-       regex specified here. In particular, the regex is not applied to the input
-       stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-       regex will be matched, not against either of these lines, but against the DKVP
-       line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-       supported, and this command is intended to be merely a keystroke-saver. To get
-       all the features of system grep, you can do
+       OFS "," and OPS "=", and matching the resulting line against the regex specified
+       here. In particular, the regex is not applied to the input stream: if you have
+       CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+       matched, not against either of these lines, but against the DKVP line
+       "x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+       and this command is intended to be merely a keystroke-saver. To get all the
+       features of system grep, you can do
          "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 
    1mgroup-by0m
@@ -3333,4 +3333,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-06-04                         MILLER(1)
+                                  2023-06-06                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-06-04
+.\"      Date: 2023-06-06
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-06-04" "\ \&" "\ \&"
+.TH "MILLER" "1" "2023-06-06" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1480,13 +1480,13 @@ Options:
 Note that "mlr filter" is more powerful, but requires you to know field names.
 By contrast, "mlr grep" allows you to regex-match the entire record. It does this
 by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-regex specified here. In particular, the regex is not applied to the input
-stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-regex will be matched, not against either of these lines, but against the DKVP
-line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-supported, and this command is intended to be merely a keystroke-saver. To get
-all the features of system grep, you can do
+OFS "," and OPS "=", and matching the resulting line against the regex specified
+here. In particular, the regex is not applied to the input stream: if you have
+CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+matched, not against either of these lines, but against the DKVP line
+"x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+and this command is intended to be merely a keystroke-saver. To get all the
+features of system grep, you can do
   "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 .fi
 .if n \{\

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -353,13 +353,13 @@ Options:
 Note that "mlr filter" is more powerful, but requires you to know field names.
 By contrast, "mlr grep" allows you to regex-match the entire record. It does this
 by formatting each record in memory as DKVP (or NIDX, if -a is supplied), using
-command-line-specified ORS/OFS/OPS, and matching the resulting line against the
-regex specified here. In particular, the regex is not applied to the input
-stream: if you have CSV with header line "x,y,z" and data line "1,2,3" then the
-regex will be matched, not against either of these lines, but against the DKVP
-line "x=1,y=2,z=3".  Furthermore, not all the options to system grep are
-supported, and this command is intended to be merely a keystroke-saver. To get
-all the features of system grep, you can do
+OFS "," and OPS "=", and matching the resulting line against the regex specified
+here. In particular, the regex is not applied to the input stream: if you have
+CSV with header line "x,y,z" and data line "1,2,3" then the regex will be
+matched, not against either of these lines, but against the DKVP line
+"x=1,y=2,z=3".  Furthermore, not all the options to system grep are supported,
+and this command is intended to be merely a keystroke-saver. To get all the
+features of system grep, you can do
   "mlr --odkvp ... | grep ... | mlr --idkvp ..."
 
 ================================================================


### PR DESCRIPTION
`mlr grep -h` said it uses command-line-specified OFS and OPS. It doesn't. The docs now match the latter behavior.