### PR TITLE
filename options for `split` (iss. #1365)

### DIFF
--- a/docs/src/10min.md
+++ b/docs/src/10min.md
@@ -909,3 +909,40 @@ yellow,triangle,true,1,11,43.6498,9.8870
 purple,triangle,false,5,51,81.2290,8.5910
 purple,triangle,false,7,65,80.1405,5.8240
 </pre>
+
+Alternatively, the `split` verb can do the same thing:
+
+<pre class="pre-highlight-non-pair">
+<b>mlr --csv --from example.csv split -g shape</b>
+</pre>
+
+<pre class="pre-highlight-in-pair">
+<b>cat split_circle.csv</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+color,shape,flag,k,index,quantity,rate
+red,circle,true,3,16,13.8103,2.9010
+yellow,circle,true,8,73,63.9785,4.2370
+yellow,circle,true,9,87,63.5058,8.3350
+</pre>
+
+<pre class="pre-highlight-in-pair">
+<b>cat split_square.csv</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+color,shape,flag,k,index,quantity,rate
+red,square,true,2,15,79.2778,0.0130
+red,square,false,4,48,77.5542,7.4670
+red,square,false,6,64,77.1991,9.5310
+purple,square,false,10,91,72.3735,8.2430
+</pre>
+
+<pre class="pre-highlight-in-pair">
+<b>cat split_triangle.csv</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+color,shape,flag,k,index,quantity,rate
+yellow,triangle,true,1,11,43.6498,9.8870
+purple,triangle,false,5,51,81.2290,8.5910
+purple,triangle,false,7,65,80.1405,5.8240
+</pre>

--- a/docs/src/10min.md.in
+++ b/docs/src/10min.md.in
@@ -434,3 +434,21 @@ GENMD-EOF
 GENMD-RUN-COMMAND
 cat triangle.csv
 GENMD-EOF
+
+Alternatively, the `split` verb can do the same thing:
+
+GENMD-RUN-COMMAND
+mlr --csv --from example.csv split -g shape
+GENMD-EOF
+
+GENMD-RUN-COMMAND
+cat split_circle.csv
+GENMD-EOF
+
+GENMD-RUN-COMMAND
+cat split_square.csv
+GENMD-EOF
+
+GENMD-RUN-COMMAND
+cat split_triangle.csv
+GENMD-EOF

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -1813,6 +1813,8 @@ MILLER(1)                                                            MILLER(1)
        --suffix {s} Specify filename suffix; default is from mlr output format, e.g. "csv".
        -a           Append to existing file(s), if any, rather than overwriting.
        -v           Send records along to downstream verbs as well as splitting to files.
+       -e           Do NOT URL-escape names of output files.
+       -j {j}       Use string J to join filename parts; default "_".
        -h|--help    Show this message.
        Any of the output-format command-line flags (see mlr -h). For example, using
          mlr --icsv --from myfile.csv split --ojson -n 1000

--- a/internal/pkg/transformers/split.go
+++ b/internal/pkg/transformers/split.go
@@ -422,10 +422,6 @@ func (tr *TransformerSplit) makeGroupedOutputFileName(
 ) string {
 	var fileNameParts []string
 
-	if tr.outputFileNamePrefix != "" {
-		fileNameParts = append(fileNameParts, tr.outputFileNamePrefix)
-	}
-
 	for _, groupByFieldValue := range groupByFieldValues {
 		fileNameParts = append(fileNameParts, groupByFieldValue.String())
 	}
@@ -433,8 +429,12 @@ func (tr *TransformerSplit) makeGroupedOutputFileName(
 	fileName := strings.Join(fileNameParts, tr.fileNamePartJoiner)
 
 	if tr.escapeFileNameCharacters {
-		fileName = url.QueryEscape(fileName)
+		fileName = url.QueryEscape(fileName) + "." + tr.outputFileNameSuffix
 	}
 
-	return fileName + "." + tr.outputFileNameSuffix
+	if tr.outputFileNamePrefix != "" {
+		fileName = tr.outputFileNamePrefix + tr.fileNamePartJoiner + fileName
+	}
+
+	return fileName
 }

--- a/internal/pkg/transformers/split.go
+++ b/internal/pkg/transformers/split.go
@@ -429,12 +429,12 @@ func (tr *TransformerSplit) makeGroupedOutputFileName(
 	fileName := strings.Join(fileNameParts, tr.fileNamePartJoiner)
 
 	if tr.escapeFileNameCharacters {
-		fileName = url.QueryEscape(fileName) + "." + tr.outputFileNameSuffix
+		fileName = url.QueryEscape(fileName)
 	}
 
 	if tr.outputFileNamePrefix != "" {
 		fileName = tr.outputFileNamePrefix + tr.fileNamePartJoiner + fileName
 	}
 
-	return fileName
+	return fileName + "." + tr.outputFileNameSuffix
 }

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-08-20
+.\"      Date: 2023-08-22
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-08-20" "\ \&" "\ \&"
+.TH "MILLER" "1" "2023-08-22" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2296,6 +2296,8 @@ Exactly one  of -m, -n, or -g must be supplied.
 --suffix {s} Specify filename suffix; default is from mlr output format, e.g. "csv".
 -a           Append to existing file(s), if any, rather than overwriting.
 -v           Send records along to downstream verbs as well as splitting to files.
+-e           Do NOT URL-escape names of output files.
+-j {j}       Use string J to join filename parts; default "_".
 -h|--help    Show this message.
 Any of the output-format command-line flags (see mlr -h). For example, using
   mlr --icsv --from myfile.csv split --ojson -n 1000

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -997,6 +997,8 @@ Exactly one  of -m, -n, or -g must be supplied.
 --suffix {s} Specify filename suffix; default is from mlr output format, e.g. "csv".
 -a           Append to existing file(s), if any, rather than overwriting.
 -v           Send records along to downstream verbs as well as splitting to files.
+-e           Do NOT URL-escape names of output files.
+-j {j}       Use string J to join filename parts; default "_".
 -h|--help    Show this message.
 Any of the output-format command-line flags (see mlr -h). For example, using
   mlr --icsv --from myfile.csv split --ojson -n 1000


### PR DESCRIPTION
* Don't use joiner string when prefix is empty.
* Add `-j` option to specify joiner string.
* Add `-e` option to not URL-escape file names.

Resolves #1365.