### PR TITLE
Remove redundant nil check

### DIFF
--- a/internal/pkg/cli/flag_types.go
+++ b/internal/pkg/cli/flag_types.go
@@ -398,11 +398,9 @@ func (flag *Flag) Owns(input string) bool {
 	if flag.name == input {
 		return true
 	}
-	if flag.altNames != nil {
-		for _, name := range flag.altNames {
-			if name == input {
-				return true
-			}
+	for _, name := range flag.altNames {
+		if name == input {
+			return true
 		}
 	}
 	return false
@@ -414,11 +412,9 @@ func (flag *Flag) Matches(input string) bool {
 	if strings.Contains(flag.name, input) {
 		return true
 	}
-	if flag.altNames != nil {
-		for _, name := range flag.altNames {
-			if strings.Contains(name, input) {
-				return true
-			}
+	for _, name := range flag.altNames {
+		if strings.Contains(name, input) {
+			return true
 		}
 	}
 	return false

--- a/internal/pkg/dsl/ast_print.go
+++ b/internal/pkg/dsl/ast_print.go
@@ -75,10 +75,8 @@ func (node *ASTNode) printAux(depth int) {
 	fmt.Println()
 
 	// Children, indented one level further
-	if node.Children != nil {
-		for _, child := range node.Children {
-			child.printAux(depth + 1)
-		}
+	for _, child := range node.Children {
+		child.printAux(depth + 1)
 	}
 }
 

--- a/internal/pkg/dsl/cst/for.go
+++ b/internal/pkg/dsl/cst/for.go
@@ -887,12 +887,10 @@ func (node *TripleForLoopNode) Execute(state *runtime.State) (*BlockExitPayload,
 	}
 
 	for {
-		if node.precontinuationAssignments != nil {
-			for _, precontinuationAssignment := range node.precontinuationAssignments {
-				_, err := precontinuationAssignment.Execute(state)
-				if err != nil {
-					return nil, err
-				}
+		for _, precontinuationAssignment := range node.precontinuationAssignments {
+			_, err := precontinuationAssignment.Execute(state)
+			if err != nil {
+				return nil, err
 			}
 		}
 		if node.continuationExpressionNode != nil { // empty is true

--- a/internal/pkg/dsl/cst/validate.go
+++ b/internal/pkg/dsl/cst/validate.go
@@ -35,23 +35,21 @@ func ValidateAST(
 		}
 	}
 
-	if ast.RootNode.Children != nil {
-		for _, astChild := range ast.RootNode.Children {
-			err := validateASTAux(
-				astChild,
-				dslInstanceType,
-				atTopLevel,
-				inLoop,
-				inBeginOrEnd,
-				inUDF,
-				inUDS,
-				isMainBlockLastStatement,
-				isAssignmentLHS,
-				isUnset,
-			)
-			if err != nil {
-				return err
-			}
+	for _, astChild := range ast.RootNode.Children {
+		err := validateASTAux(
+			astChild,
+			dslInstanceType,
+			atTopLevel,
+			inLoop,
+			inBeginOrEnd,
+			inUDF,
+			inUDS,
+			isMainBlockLastStatement,
+			isAssignmentLHS,
+			isUnset,
+		)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -219,25 +217,23 @@ func validateASTAux(
 	//  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Treewalk
 
-	if astNode.Children != nil {
-		for i, astChild := range astNode.Children {
-			nextLevelIsAssignmentLHS = astNode.Type == dsl.NodeTypeAssignment && i == 0
-			nextLevelIsUnset = astNode.Type == dsl.NodeTypeUnset
-			err := validateASTAux(
-				astChild,
-				dslInstanceType,
-				nextLevelAtTopLevel,
-				nextLevelInLoop,
-				nextLevelInBeginOrEnd,
-				nextLevelInUDF,
-				nextLevelInUDS,
-				isMainBlockLastStatement,
-				nextLevelIsAssignmentLHS,
-				nextLevelIsUnset,
-			)
-			if err != nil {
-				return err
-			}
+	for i, astChild := range astNode.Children {
+		nextLevelIsAssignmentLHS = astNode.Type == dsl.NodeTypeAssignment && i == 0
+		nextLevelIsUnset = astNode.Type == dsl.NodeTypeUnset
+		err := validateASTAux(
+			astChild,
+			dslInstanceType,
+			nextLevelAtTopLevel,
+			nextLevelInLoop,
+			nextLevelInBeginOrEnd,
+			nextLevelInUDF,
+			nextLevelInUDS,
+			isMainBlockLastStatement,
+			nextLevelIsAssignmentLHS,
+			nextLevelIsUnset,
+		)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
From the Go docs [^1]:

>  "1. For a nil slice, the number of iterations is 0."
>  "3. If the map is nil, the number of iterations is 0."

Therefore, an additional nil check for before the loop is unnecessary. Example; https://go.dev/play/p/hchBhEu7ZS5

<details><summary>Output of <code>make check</code></summary>
<p>

```
go build github.com/johnkerl/miller/cmd/mlr
Build complete. The Miller executable is ./mlr (or .\mlr.exe on Windows).
You can use 'make check' to run tests.
go test github.com/johnkerl/miller/internal/pkg/...
?   	github.com/johnkerl/miller/internal/pkg/auxents	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/cli	[no test files]
ok  	github.com/johnkerl/miller/internal/pkg/bifs	0.003s
?   	github.com/johnkerl/miller/internal/pkg/climain	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/colorizer	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/dsl	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/dsl/cst	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/entrypoint	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/go-csv	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/output	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing/lexer	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing/errors	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing/parser	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing/token	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/parsing/util	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/platform	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/runtime	[no test files]
ok  	github.com/johnkerl/miller/internal/pkg/input	0.005s
ok  	github.com/johnkerl/miller/internal/pkg/lib	0.004s
ok  	github.com/johnkerl/miller/internal/pkg/mlrval	0.007s
ok  	github.com/johnkerl/miller/internal/pkg/pbnjay-strptime	0.007s
?   	github.com/johnkerl/miller/internal/pkg/stream	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/terminals	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/terminals/help	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/terminals/regtest	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/terminals/repl	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/transformers	[no test files]
ok  	github.com/johnkerl/miller/internal/pkg/scan	0.004s
?   	github.com/johnkerl/miller/internal/pkg/types	[no test files]
?   	github.com/johnkerl/miller/internal/pkg/version	[no test files]
ok  	github.com/johnkerl/miller/internal/pkg/transformers/utils	0.005s
go test -v regression_test.go
=== RUN   TestRegression
REGRESSION TEST:
  ./test/cases
Using executable: mlr

PASS ./test/cases/auxents
PASS ./test/cases/chaining
PASS ./test/cases/cli-csv-rs-environment-defaults
PASS ./test/cases/cli-getoptish
PASS ./test/cases/cli-help
PASS ./test/cases/cli-mfrom
PASS ./test/cases/cli-ofmt
PASS ./test/cases/dsl-absent-empty/dsl-absent-empty
PASS ./test/cases/dsl-absent-empty
PASS ./test/cases/dsl-argpass-typedecl
PASS ./test/cases/dsl-array-map-indexing
PASS ./test/cases/dsl-arrayify
PASS ./test/cases/dsl-asserting
PASS ./test/cases/dsl-basic
PASS ./test/cases/dsl-begin-end
PASS ./test/cases/dsl-block-exit
PASS ./test/cases/dsl-break-continue
PASS ./test/cases/dsl-clean-whitespace
PASS ./test/cases/dsl-collection-equality
PASS ./test/cases/dsl-comments
PASS ./test/cases/dsl-concat
PASS ./test/cases/dsl-context-specific-validation
PASS ./test/cases/dsl-context-validation
PASS ./test/cases/dsl-depth
PASS ./test/cases/dsl-do-while
PASS ./test/cases/dsl-do-while-loops
PASS ./test/cases/dsl-dump-print
PASS ./test/cases/dsl-emit
PASS ./test/cases/dsl-emit-basic-indexing
PASS ./test/cases/dsl-emit-het
PASS ./test/cases/dsl-emit1
PASS ./test/cases/dsl-empty
PASS ./test/cases/dsl-empty-statements
PASS ./test/cases/dsl-env
PASS ./test/cases/dsl-extended-typeof
PASS ./test/cases/dsl-filter
PASS ./test/cases/dsl-filter-pattern-action
PASS ./test/cases/dsl-first-class-functions
PASS ./test/cases/dsl-flatten-unflatten
PASS ./test/cases/dsl-for-bind-loops-for-valgrind
PASS ./test/cases/dsl-for-map-depth
PASS ./test/cases/dsl-for-multi
PASS ./test/cases/dsl-for-one
PASS ./test/cases/dsl-for-oosvar-loops
PASS ./test/cases/dsl-for-srec-loops
PASS ./test/cases/dsl-for-two
PASS ./test/cases/dsl-for-variants
PASS ./test/cases/dsl-forbind-typedecl
PASS ./test/cases/dsl-format
PASS ./test/cases/dsl-from-file
PASS ./test/cases/dsl-func-decl-hoist
PASS ./test/cases/dsl-functional-tests
PASS ./test/cases/dsl-gmt-date-time-functions/0019n
PASS ./test/cases/dsl-gmt-date-time-functions
PASS ./test/cases/dsl-hashing
PASS ./test/cases/dsl-haskey
PASS ./test/cases/dsl-if-chain
PASS ./test/cases/dsl-if-chaining
PASS ./test/cases/dsl-index
PASS ./test/cases/dsl-indexing
PASS ./test/cases/dsl-indirect-oosvar-assignments
PASS ./test/cases/dsl-indirect-srec-assignments
PASS ./test/cases/dsl-int-function
PASS ./test/cases/dsl-is-predicates
PASS ./test/cases/dsl-json-collection-output
PASS ./test/cases/dsl-json-parse-json-stringify
PASS ./test/cases/dsl-lashed-emitp-singles
PASS ./test/cases/dsl-latin1
PASS ./test/cases/dsl-leafcount
PASS ./test/cases/dsl-leftpad-rightpad
PASS ./test/cases/dsl-length
PASS ./test/cases/dsl-length-depth-leafcount
PASS ./test/cases/dsl-lhs-indexing
PASS ./test/cases/dsl-line-number-column-number
PASS ./test/cases/dsl-load
PASS ./test/cases/dsl-local-date-time-functions
PASS ./test/cases/dsl-local-map-variable-typedecl
PASS ./test/cases/dsl-local-map-variable-write-read
PASS ./test/cases/dsl-localvar-scope-and-extent
PASS ./test/cases/dsl-localvar-typedecl
PASS ./test/cases/dsl-localvar-unsets
PASS ./test/cases/dsl-map-dot
PASS ./test/cases/dsl-map-funcs
PASS ./test/cases/dsl-map-variant-dumps
PASS ./test/cases/dsl-mapsum-mapdiff-mapexcept
PASS ./test/cases/dsl-mapvar-assignments
PASS ./test/cases/dsl-mapvar-emit
PASS ./test/cases/dsl-mapvar-for-loops
PASS ./test/cases/dsl-mapvars-in-scalar-function-call-contexts
PASS ./test/cases/dsl-mapvars-udfs-subroutines
PASS ./test/cases/dsl-mathy
PASS ./test/cases/dsl-max-variadic
PASS ./test/cases/dsl-min-max-types
PASS ./test/cases/dsl-modular-arithmetic
PASS ./test/cases/dsl-more-type-predicates
PASS ./test/cases/dsl-multi-index
PASS ./test/cases/dsl-multipart-scripts
PASS ./test/cases/dsl-nested-double-quotes
PASS ./test/cases/dsl-no-filter-in-filter
PASS ./test/cases/dsl-null-empty-handling
PASS ./test/cases/dsl-number-formatting
PASS ./test/cases/dsl-oosvar-assignments
PASS ./test/cases/dsl-oosvars
PASS ./test/cases/dsl-operator-associativity
PASS ./test/cases/dsl-operator-precedence
PASS ./test/cases/dsl-operator-rewrites
PASS ./test/cases/dsl-output-redirects
PASS ./test/cases/dsl-parameterized-emit
PASS ./test/cases/dsl-parse
PASS ./test/cases/dsl-prefixed-unprefixed-emit
PASS ./test/cases/dsl-print
PASS ./test/cases/dsl-programming-examples
PASS ./test/cases/dsl-put-dash-s
PASS ./test/cases/dsl-put-multiple-dash-e
PASS ./test/cases/dsl-pythonic-division
PASS ./test/cases/dsl-redirects
PASS ./test/cases/dsl-regex
PASS ./test/cases/dsl-regex-captures
PASS ./test/cases/dsl-regex-matching
PASS ./test/cases/dsl-scientific-notation
PASS ./test/cases/dsl-scope
PASS ./test/cases/dsl-sec2gmt
PASS ./test/cases/dsl-semicolons
PASS ./test/cases/dsl-short-circuit
PASS ./test/cases/dsl-slice
PASS ./test/cases/dsl-sorts
PASS ./test/cases/dsl-split-join
PASS ./test/cases/dsl-split-join-more
PASS ./test/cases/dsl-stack-allocation
PASS ./test/cases/dsl-string-array-indexing-slicing
PASS ./test/cases/dsl-strlen
PASS ./test/cases/dsl-subr
PASS ./test/cases/dsl-subs
PASS ./test/cases/dsl-substr
PASS ./test/cases/dsl-toupper-tolower
PASS ./test/cases/dsl-trailing-commas
PASS ./test/cases/dsl-triple-for-loops
PASS ./test/cases/dsl-truncate
PASS ./test/cases/dsl-type-inference
PASS ./test/cases/dsl-type-predicates
PASS ./test/cases/dsl-type-reflect
PASS ./test/cases/dsl-typed-overlay
PASS ./test/cases/dsl-typedecl
PASS ./test/cases/dsl-unformat
PASS ./test/cases/dsl-unset
PASS ./test/cases/dsl-user-defined-functions
PASS ./test/cases/dsl-user-defined-functions-and-subroutines
PASS ./test/cases/dsl-utf8-field-names
PASS ./test/cases/dsl-utf8-strlen
PASS ./test/cases/dsl-utf8-uppercase-lowercase
PASS ./test/cases/dsl-warnings
PASS ./test/cases/dsl-whitespace
PASS ./test/cases/globbing
PASS ./test/cases/help
PASS ./test/cases/int64-io
PASS ./test/cases/io-barred-pprint
PASS ./test/cases/io-compressed-input
PASS ./test/cases/io-dedupe-field-names
PASS ./test/cases/io-format-conversion-keystroke-savers
PASS ./test/cases/io-gen
PASS ./test/cases/io-het-csv-input
PASS ./test/cases/io-het-pprint-input
PASS ./test/cases/io-implicit-header-csv-input
PASS ./test/cases/io-in-place-processing
PASS ./test/cases/io-infer-flags
PASS ./test/cases/io-ixs-regex
PASS ./test/cases/io-json-io
PASS ./test/cases/io-jsonl-io
PASS ./test/cases/io-lf-crlf-and-autodetect
PASS ./test/cases/io-markdown-output
PASS ./test/cases/io-missing-final-lf
PASS ./test/cases/io-multi
PASS ./test/cases/io-multi-character-ixs
PASS ./test/cases/io-nr-progress-mod
PASS ./test/cases/io-pprint
PASS ./test/cases/io-ragged-non-rfc-csv
PASS ./test/cases/io-rfc-csv
PASS ./test/cases/io-separator-aliases
PASS ./test/cases/io-skip-pass-comments
PASS ./test/cases/io-space-padding
PASS ./test/cases/io-spec-tsv
PASS ./test/cases/io-uri-schemes
PASS ./test/cases/io-utf8-alignment
PASS ./test/cases/io-utf8-bom
PASS ./test/cases/mix-null-field-input/0001
PASS ./test/cases/mix-null-field-input/0002
PASS ./test/cases/mix-null-field-input/0003
PASS ./test/cases/mix-null-field-input/0007
PASS ./test/cases/mix-null-field-input/0011
PASS ./test/cases/mix-null-field-input
PASS ./test/cases/mix-number-formatting
PASS ./test/cases/non-windows/dsl-redirects
PASS ./test/cases/non-windows/verb-having-fields
PASS ./test/cases/non-windows/verb-rename-regex
PASS ./test/cases/output-colorization
PASS ./test/cases/repl
PASS ./test/cases/repl-help
PASS ./test/cases/verb-altkv
PASS ./test/cases/verb-bar
PASS ./test/cases/verb-bootstrap
PASS ./test/cases/verb-case
PASS ./test/cases/verb-cat
PASS ./test/cases/verb-check
PASS ./test/cases/verb-count
PASS ./test/cases/verb-count-distinct
PASS ./test/cases/verb-count-similar
PASS ./test/cases/verb-cut
PASS ./test/cases/verb-cut-regexed
PASS ./test/cases/verb-decimate
PASS ./test/cases/verb-fill-down
PASS ./test/cases/verb-fill-empty
PASS ./test/cases/verb-flatten-unflatten
PASS ./test/cases/verb-format-values/0003
PASS ./test/cases/verb-format-values
PASS ./test/cases/verb-fraction
PASS ./test/cases/verb-gap
PASS ./test/cases/verb-grep
PASS ./test/cases/verb-group-by
PASS ./test/cases/verb-group-like
PASS ./test/cases/verb-having-fields
PASS ./test/cases/verb-head
PASS ./test/cases/verb-head-early-out
PASS ./test/cases/verb-histogram
PASS ./test/cases/verb-int-float-stats1-step1
PASS ./test/cases/verb-join
PASS ./test/cases/verb-join-mixed-format
PASS ./test/cases/verb-json-parse-json-stringify
PASS ./test/cases/verb-label
PASS ./test/cases/verb-latin1-to-utf8
PASS ./test/cases/verb-merge-fields
PASS ./test/cases/verb-most-least-frequent
PASS ./test/cases/verb-nest
PASS ./test/cases/verb-nothing
PASS ./test/cases/verb-regularize
PASS ./test/cases/verb-remove-empty-columns
PASS ./test/cases/verb-rename
PASS ./test/cases/verb-rename-no-regex
PASS ./test/cases/verb-rename-regex
PASS ./test/cases/verb-reorder
PASS ./test/cases/verb-repeat
PASS ./test/cases/verb-reshape
PASS ./test/cases/verb-sample
PASS ./test/cases/verb-sec2gmt
PASS ./test/cases/verb-seqgen
PASS ./test/cases/verb-shuffle
PASS ./test/cases/verb-skip-trivial-records
PASS ./test/cases/verb-sort
PASS ./test/cases/verb-sort-within-records
PASS ./test/cases/verb-split
PASS ./test/cases/verb-stats1
PASS ./test/cases/verb-stats1-percentile-interpolation
PASS ./test/cases/verb-stats1-regexed-field-names
PASS ./test/cases/verb-stats2
PASS ./test/cases/verb-step
PASS ./test/cases/verb-sub-gsub-ssub
PASS ./test/cases/verb-summary
PASS ./test/cases/verb-tac
PASS ./test/cases/verb-tail
PASS ./test/cases/verb-template
PASS ./test/cases/verb-top
PASS ./test/cases/verb-truncate
PASS ./test/cases/verb-uniq
PASS ./test/cases/verb-unspace
PASS ./test/cases/verb-unsparsify
PASS ./test/cases/verb-utf8-to-latin1
PASS ./test/cases

NUMBER OF CASES            PASSED 4498
NUMBER OF CASES            FAILED 0
NUMBER OF CASE-DIRECTORIES PASSED 266
NUMBER OF CASE-DIRECTORIES FAILED 0

PASS overall
--- PASS: TestRegression (40.05s)
PASS
ok  	command-line-arguments	40.058s
Tests complete. You can use 'make install' if you like, optionally preceded
by './configure --prefix=/your/install/path' if you wish to install to
somewhere other than /usr/local/bin -- the default prefix is /usr/local.
```

</p>
</details> 

[^1]: https://go.dev/ref/spec#For_range