### PR TITLE
Remove `replacements` from `.goreleaser.yaml`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ builds:
     goos:
       - linux
       - windows
-      - darwin
+      - macos
       - freebsd
       - aix
     goarch:
@@ -38,11 +38,11 @@ builds:
     ignore:
       - goos: linux
         goarch: ppc64
-      - goos: darwin
+      - goos: macos
         goarch: arm
-      - goos: darwin
+      - goos: macos
         goarch: ppc64le
-      - goos: darwin
+      - goos: macos
         goarch: s390x
       - goos: windows
         goarch: arm64
@@ -70,8 +70,6 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: macos
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - LICENSE.txt

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/johnkerl/lumin v1.0.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/klauspost/compress v1.16.7
 	github.com/lestrrat-go/strftime v1.0.6
 	github.com/mattn/go-isatty v0.0.19
 	github.com/nine-lives-later/go-windows-terminal-sequences v1.0.4
@@ -34,7 +35,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
-	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
I saw in
https://github.com/johnkerl/miller/actions/runs/6037943131/job/16383293749#step:5:65
that this has been deprecated.

See also
https://github.com/goreleaser/goreleaser/releases/tag/v1.20.0
which came out 3 weeks ago.