### PR TITLE
Include `null` in `any` typemask

### DIFF
--- a/pkg/mlrval/mlrval_type.go
+++ b/pkg/mlrval/mlrval_type.go
@@ -168,6 +168,7 @@ const MT_TYPE_MASK_VAR = (1 << MT_INT) |
 	(1 << MT_FLOAT) |
 	(1 << MT_BOOL) |
 	(1 << MT_VOID) |
+	(1 << MT_NULL) |
 	(1 << MT_STRING) |
 	(1 << MT_ARRAY) |
 	(1 << MT_MAP)


### PR DESCRIPTION
Before:

```
echo '[{"a":"b"},{"a":3},{"a":null}]' | /usr/local/bin/mlr --json put 'for (k,v in $*) {}'
mlr: couldn't assign variable any v from value null null
```

After:

```
echo '[{"a":"b"},{"a":3},{"a":null}]' | ./mlr --json put 'for (k,v in $*) {}'
[
{
  "a": "b"
},
{
  "a": 3
},
{
  "a": null
}
]
```

Fixes #1394