### PR TITLE
transformers/grep: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/pkg/transformers/grep.go
+++ b/pkg/transformers/grep.go
@@ -168,7 +168,7 @@ func (tr *TransformerGrep) Transform(
 		} else {
 			inrecAsString = inrec.ToDKVPString()
 		}
-		matches := tr.regexp.Match([]byte(inrecAsString))
+		matches := tr.regexp.MatchString(inrecAsString)
 		if tr.invert {
 			if !matches {
 				outputRecordsAndContexts.PushBack(inrecAndContext)


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. We have been using `MatchString` in other places, e.g. the `cut` transformer:

https://github.com/johnkerl/miller/blob/6aab161cb00ee4b3175700f7ef69d3f04d28ea70/pkg/transformers/cut.go#L273

Example benchmark:

```go
var grepRegex = regexp.MustCompile("foo.*")

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := grepRegex.Match([]byte("foo bar baz")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := grepRegex.MatchString("foo bar baz"); !match {
			b.Fail()
		}
	}
}
```

```
goos: linux
goarch: amd64
pkg: github.com/johnkerl/miller/pkg/transformers
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 5700908	       210.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkMatchString-16    	 8006731	       156.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/johnkerl/miller/pkg/transformers	2.857s
```