### PR TITLE
Draft `match` function

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -220,18 +220,19 @@ MILLER(1)                                                            MILLER(1)
        is_numeric is_present is_string joink joinkv joinv json_parse json_stringify
        kurtosis latin1_to_utf8 leafcount leftpad length localtime2gmt localtime2nsec
        localtime2sec log log10 log1p logifit lstrip madd mapdiff mapexcept mapselect
-       mapsum max maxlen md5 mean meaneb median mexp min minlen mmul mode msub
-       nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os percentile
-       percentiles pow qnorm reduce regextract regextract_or_else rightpad round
-       roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate sec2localtime
-       select sgn sha1 sha256 sha512 sin sinh skewness sort sort_collection splita
-       splitax splitkv splitkvx splitnv splitnvx sqrt ssub stddev strfntime
-       strfntime_local strftime strftime_local string strip strlen strpntime
-       strpntime_local strptime strptime_local sub substr substr0 substr1 sum sum2
-       sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper truncate
-       typeof unflatten unformat unformatx upntime uptime urand urand32 urandelement
-       urandint urandrange utf8_to_latin1 variance version ! != !=~ % & && * ** + - .
-       .* .+ .- ./ / // &lt; &lt;&lt; &lt;= &lt;=&gt; == =~ &gt; &gt;= &gt;&gt; &gt;&gt;&gt; ?: ?? ??? ^ ^^ | || ~
+       mapsum match matchx max maxlen md5 mean meaneb median mexp min minlen mmul
+       mode msub nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os
+       percentile percentiles pow qnorm reduce regextract regextract_or_else rightpad
+       round roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate
+       sec2localtime select sgn sha1 sha256 sha512 sin sinh skewness sort
+       sort_collection splita splitax splitkv splitkvx splitnv splitnvx sqrt ssub
+       stddev strfntime strfntime_local strftime strftime_local string strip strlen
+       strpntime strpntime_local strptime strptime_local sub substr substr0 substr1
+       sum sum2 sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper
+       truncate typeof unflatten unformat unformatx upntime uptime urand urand32
+       urandelement urandint urandrange utf8_to_latin1 variance version ! != !=~ % &
+       && * ** + - . .* .+ .- ./ / // &lt; &lt;&lt; &lt;= &lt;=&gt; == =~ &gt; &gt;= &gt;&gt; &gt;&gt;&gt; ?: ?? ??? ^ ^^ |
+       || ~
 
 1mCOMMENTS-IN-DATA FLAGS0m
        Miller lets you put comments in your data, such as
@@ -2650,6 +2651,16 @@ MILLER(1)                                                            MILLER(1)
    1mmapsum0m
         (class=collections #args=variadic) With 0 args, returns empty map. With &gt;= 1 arg, returns a map with key-value pairs from all arguments. Rightmost collisions win, e.g. 'mapsum({1:2,3:4},{1:5})' is '{1:5,3:4}'.
 
+   1mmatch0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
+   1mmatchx0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
    1mmax0m
         (class=math #args=variadic) Max of n numbers; null loses. The min and max functions also recurse into arrays and maps, so they can be used to get min/max stats on array/map values.
 
@@ -3649,5 +3660,5 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-02                         MILLER(1)
+                                  2023-12-16                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -199,18 +199,19 @@ MILLER(1)                                                            MILLER(1)
        is_numeric is_present is_string joink joinkv joinv json_parse json_stringify
        kurtosis latin1_to_utf8 leafcount leftpad length localtime2gmt localtime2nsec
        localtime2sec log log10 log1p logifit lstrip madd mapdiff mapexcept mapselect
-       mapsum max maxlen md5 mean meaneb median mexp min minlen mmul mode msub
-       nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os percentile
-       percentiles pow qnorm reduce regextract regextract_or_else rightpad round
-       roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate sec2localtime
-       select sgn sha1 sha256 sha512 sin sinh skewness sort sort_collection splita
-       splitax splitkv splitkvx splitnv splitnvx sqrt ssub stddev strfntime
-       strfntime_local strftime strftime_local string strip strlen strpntime
-       strpntime_local strptime strptime_local sub substr substr0 substr1 sum sum2
-       sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper truncate
-       typeof unflatten unformat unformatx upntime uptime urand urand32 urandelement
-       urandint urandrange utf8_to_latin1 variance version ! != !=~ % & && * ** + - .
-       .* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ | || ~
+       mapsum match matchx max maxlen md5 mean meaneb median mexp min minlen mmul
+       mode msub nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os
+       percentile percentiles pow qnorm reduce regextract regextract_or_else rightpad
+       round roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate
+       sec2localtime select sgn sha1 sha256 sha512 sin sinh skewness sort
+       sort_collection splita splitax splitkv splitkvx splitnv splitnvx sqrt ssub
+       stddev strfntime strfntime_local strftime strftime_local string strip strlen
+       strpntime strpntime_local strptime strptime_local sub substr substr0 substr1
+       sum sum2 sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper
+       truncate typeof unflatten unformat unformatx upntime uptime urand urand32
+       urandelement urandint urandrange utf8_to_latin1 variance version ! != !=~ % &
+       && * ** + - . .* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ |
+       || ~
 
 1mCOMMENTS-IN-DATA FLAGS0m
        Miller lets you put comments in your data, such as
@@ -2629,6 +2630,16 @@ MILLER(1)                                                            MILLER(1)
    1mmapsum0m
         (class=collections #args=variadic) With 0 args, returns empty map. With >= 1 arg, returns a map with key-value pairs from all arguments. Rightmost collisions win, e.g. 'mapsum({1:2,3:4},{1:5})' is '{1:5,3:4}'.
 
+   1mmatch0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
+   1mmatchx0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
    1mmax0m
         (class=math #args=variadic) Max of n numbers; null loses. The min and max functions also recurse into arrays and maps, so they can be used to get min/max stats on array/map values.
 
@@ -3628,4 +3639,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-02                         MILLER(1)
+                                  2023-12-16                         MILLER(1)

--- a/docs/src/reference-dsl-builtin-functions.md
+++ b/docs/src/reference-dsl-builtin-functions.md
@@ -75,7 +75,7 @@ is 2. Unary operators such as `!` and `~` show argument-count of 1; the ternary
 * [**Higher-order-functions functions**](#higher-order-functions-functions):  [any](#any),  [apply](#apply),  [every](#every),  [fold](#fold),  [reduce](#reduce),  [select](#select),  [sort](#sort).
 * [**Math functions**](#math-functions):  [abs](#abs),  [acos](#acos),  [acosh](#acosh),  [asin](#asin),  [asinh](#asinh),  [atan](#atan),  [atan2](#atan2),  [atanh](#atanh),  [cbrt](#cbrt),  [ceil](#ceil),  [cos](#cos),  [cosh](#cosh),  [erf](#erf),  [erfc](#erfc),  [exp](#exp),  [expm1](#expm1),  [floor](#floor),  [invqnorm](#invqnorm),  [log](#log),  [log10](#log10),  [log1p](#log1p),  [logifit](#logifit),  [max](#max),  [min](#min),  [qnorm](#qnorm),  [round](#round),  [roundm](#roundm),  [sgn](#sgn),  [sin](#sin),  [sinh](#sinh),  [sqrt](#sqrt),  [tan](#tan),  [tanh](#tanh),  [urand](#urand),  [urand32](#urand32),  [urandelement](#urandelement),  [urandint](#urandint),  [urandrange](#urandrange).
 * [**Stats functions**](#stats-functions):  [antimode](#antimode),  [count](#count),  [distinct_count](#distinct_count),  [kurtosis](#kurtosis),  [maxlen](#maxlen),  [mean](#mean),  [meaneb](#meaneb),  [median](#median),  [minlen](#minlen),  [mode](#mode),  [null_count](#null_count),  [percentile](#percentile),  [percentiles](#percentiles),  [skewness](#skewness),  [sort_collection](#sort_collection),  [stddev](#stddev),  [sum](#sum),  [sum2](#sum2),  [sum3](#sum3),  [sum4](#sum4),  [variance](#variance).
-* [**String functions**](#string-functions):  [capitalize](#capitalize),  [clean_whitespace](#clean_whitespace),  [collapse_whitespace](#collapse_whitespace),  [contains](#contains),  [format](#format),  [gssub](#gssub),  [gsub](#gsub),  [index](#index),  [latin1_to_utf8](#latin1_to_utf8),  [leftpad](#leftpad),  [lstrip](#lstrip),  [regextract](#regextract),  [regextract_or_else](#regextract_or_else),  [rightpad](#rightpad),  [rstrip](#rstrip),  [ssub](#ssub),  [strip](#strip),  [strlen](#strlen),  [sub](#sub),  [substr](#substr),  [substr0](#substr0),  [substr1](#substr1),  [tolower](#tolower),  [toupper](#toupper),  [truncate](#truncate),  [unformat](#unformat),  [unformatx](#unformatx),  [utf8_to_latin1](#utf8_to_latin1),  [\.](#dot).
+* [**String functions**](#string-functions):  [capitalize](#capitalize),  [clean_whitespace](#clean_whitespace),  [collapse_whitespace](#collapse_whitespace),  [contains](#contains),  [format](#format),  [gssub](#gssub),  [gsub](#gsub),  [index](#index),  [latin1_to_utf8](#latin1_to_utf8),  [leftpad](#leftpad),  [lstrip](#lstrip),  [match](#match),  [matchx](#matchx),  [regextract](#regextract),  [regextract_or_else](#regextract_or_else),  [rightpad](#rightpad),  [rstrip](#rstrip),  [ssub](#ssub),  [strip](#strip),  [strlen](#strlen),  [sub](#sub),  [substr](#substr),  [substr0](#substr0),  [substr1](#substr1),  [tolower](#tolower),  [toupper](#toupper),  [truncate](#truncate),  [unformat](#unformat),  [unformatx](#unformatx),  [utf8_to_latin1](#utf8_to_latin1),  [\.](#dot).
 * [**System functions**](#system-functions):  [exec](#exec),  [hostname](#hostname),  [os](#os),  [system](#system),  [version](#version).
 * [**Time functions**](#time-functions):  [dhms2fsec](#dhms2fsec),  [dhms2sec](#dhms2sec),  [fsec2dhms](#fsec2dhms),  [fsec2hms](#fsec2hms),  [gmt2localtime](#gmt2localtime),  [gmt2nsec](#gmt2nsec),  [gmt2sec](#gmt2sec),  [hms2fsec](#hms2fsec),  [hms2sec](#hms2sec),  [localtime2gmt](#localtime2gmt),  [localtime2nsec](#localtime2nsec),  [localtime2sec](#localtime2sec),  [nsec2gmt](#nsec2gmt),  [nsec2gmtdate](#nsec2gmtdate),  [nsec2localdate](#nsec2localdate),  [nsec2localtime](#nsec2localtime),  [sec2dhms](#sec2dhms),  [sec2gmt](#sec2gmt),  [sec2gmtdate](#sec2gmtdate),  [sec2hms](#sec2hms),  [sec2localdate](#sec2localdate),  [sec2localtime](#sec2localtime),  [strfntime](#strfntime),  [strfntime_local](#strfntime_local),  [strftime](#strftime),  [strftime_local](#strftime_local),  [strpntime](#strpntime),  [strpntime_local](#strpntime_local),  [strptime](#strptime),  [strptime_local](#strptime_local),  [sysntime](#sysntime),  [systime](#systime),  [systimeint](#systimeint),  [upntime](#upntime),  [uptime](#uptime).
 * [**Typing functions**](#typing-functions):  [asserting_absent](#asserting_absent),  [asserting_array](#asserting_array),  [asserting_bool](#asserting_bool),  [asserting_boolean](#asserting_boolean),  [asserting_empty](#asserting_empty),  [asserting_empty_map](#asserting_empty_map),  [asserting_error](#asserting_error),  [asserting_float](#asserting_float),  [asserting_int](#asserting_int),  [asserting_map](#asserting_map),  [asserting_nonempty_map](#asserting_nonempty_map),  [asserting_not_array](#asserting_not_array),  [asserting_not_empty](#asserting_not_empty),  [asserting_not_map](#asserting_not_map),  [asserting_not_null](#asserting_not_null),  [asserting_null](#asserting_null),  [asserting_numeric](#asserting_numeric),  [asserting_present](#asserting_present),  [asserting_string](#asserting_string),  [is_absent](#is_absent),  [is_array](#is_array),  [is_bool](#is_bool),  [is_boolean](#is_boolean),  [is_empty](#is_empty),  [is_empty_map](#is_empty_map),  [is_error](#is_error),  [is_float](#is_float),  [is_int](#is_int),  [is_map](#is_map),  [is_nan](#is_nan),  [is_nonempty_map](#is_nonempty_map),  [is_not_array](#is_not_array),  [is_not_empty](#is_not_empty),  [is_not_map](#is_not_map),  [is_not_null](#is_not_null),  [is_null](#is_null),  [is_numeric](#is_numeric),  [is_present](#is_present),  [is_string](#is_string),  [typeof](#typeof).
@@ -1293,6 +1293,22 @@ leftpad("1234567", 10 , "0") gives "0001234567".
 ### lstrip
 <pre class="pre-non-highlight-non-pair">
 lstrip  (class=string #args=1) Strip leading whitespace from string.
+</pre>
+
+
+### match
+<pre class="pre-non-highlight-non-pair">
+match  (class=string #args=2) TODO: WRITE ME
+Example:
+TODO: WRITE ME
+</pre>
+
+
+### matchx
+<pre class="pre-non-highlight-non-pair">
+matchx  (class=string #args=2) TODO: WRITE ME
+Example:
+TODO: WRITE ME
 </pre>
 
 

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -199,18 +199,19 @@ MILLER(1)                                                            MILLER(1)
        is_numeric is_present is_string joink joinkv joinv json_parse json_stringify
        kurtosis latin1_to_utf8 leafcount leftpad length localtime2gmt localtime2nsec
        localtime2sec log log10 log1p logifit lstrip madd mapdiff mapexcept mapselect
-       mapsum max maxlen md5 mean meaneb median mexp min minlen mmul mode msub
-       nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os percentile
-       percentiles pow qnorm reduce regextract regextract_or_else rightpad round
-       roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate sec2localtime
-       select sgn sha1 sha256 sha512 sin sinh skewness sort sort_collection splita
-       splitax splitkv splitkvx splitnv splitnvx sqrt ssub stddev strfntime
-       strfntime_local strftime strftime_local string strip strlen strpntime
-       strpntime_local strptime strptime_local sub substr substr0 substr1 sum sum2
-       sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper truncate
-       typeof unflatten unformat unformatx upntime uptime urand urand32 urandelement
-       urandint urandrange utf8_to_latin1 variance version ! != !=~ % & && * ** + - .
-       .* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ | || ~
+       mapsum match matchx max maxlen md5 mean meaneb median mexp min minlen mmul
+       mode msub nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os
+       percentile percentiles pow qnorm reduce regextract regextract_or_else rightpad
+       round roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate
+       sec2localtime select sgn sha1 sha256 sha512 sin sinh skewness sort
+       sort_collection splita splitax splitkv splitkvx splitnv splitnvx sqrt ssub
+       stddev strfntime strfntime_local strftime strftime_local string strip strlen
+       strpntime strpntime_local strptime strptime_local sub substr substr0 substr1
+       sum sum2 sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper
+       truncate typeof unflatten unformat unformatx upntime uptime urand urand32
+       urandelement urandint urandrange utf8_to_latin1 variance version ! != !=~ % &
+       && * ** + - . .* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ |
+       || ~
 
 1mCOMMENTS-IN-DATA FLAGS0m
        Miller lets you put comments in your data, such as
@@ -2629,6 +2630,16 @@ MILLER(1)                                                            MILLER(1)
    1mmapsum0m
         (class=collections #args=variadic) With 0 args, returns empty map. With >= 1 arg, returns a map with key-value pairs from all arguments. Rightmost collisions win, e.g. 'mapsum({1:2,3:4},{1:5})' is '{1:5,3:4}'.
 
+   1mmatch0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
+   1mmatchx0m
+        (class=string #args=2) TODO: WRITE ME
+       Example:
+       TODO: WRITE ME
+
    1mmax0m
         (class=math #args=variadic) Max of n numbers; null loses. The min and max functions also recurse into arrays and maps, so they can be used to get min/max stats on array/map values.
 
@@ -3628,4 +3639,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-02                         MILLER(1)
+                                  2023-12-16                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-12-02
+.\"      Date: 2023-12-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-12-02" "\ \&" "\ \&"
+.TH "MILLER" "1" "2023-12-16" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -246,18 +246,19 @@ is_nonempty_map is_not_array is_not_empty is_not_map is_not_null is_null
 is_numeric is_present is_string joink joinkv joinv json_parse json_stringify
 kurtosis latin1_to_utf8 leafcount leftpad length localtime2gmt localtime2nsec
 localtime2sec log log10 log1p logifit lstrip madd mapdiff mapexcept mapselect
-mapsum max maxlen md5 mean meaneb median mexp min minlen mmul mode msub
-nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os percentile
-percentiles pow qnorm reduce regextract regextract_or_else rightpad round
-roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate sec2localtime
-select sgn sha1 sha256 sha512 sin sinh skewness sort sort_collection splita
-splitax splitkv splitkvx splitnv splitnvx sqrt ssub stddev strfntime
-strfntime_local strftime strftime_local string strip strlen strpntime
-strpntime_local strptime strptime_local sub substr substr0 substr1 sum sum2
-sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper truncate
-typeof unflatten unformat unformatx upntime uptime urand urand32 urandelement
-urandint urandrange utf8_to_latin1 variance version ! != !=~ % & && * ** + - .
-\&.* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ | || ~
+mapsum match matchx max maxlen md5 mean meaneb median mexp min minlen mmul
+mode msub nsec2gmt nsec2gmtdate nsec2localdate nsec2localtime null_count os
+percentile percentiles pow qnorm reduce regextract regextract_or_else rightpad
+round roundm rstrip sec2dhms sec2gmt sec2gmtdate sec2hms sec2localdate
+sec2localtime select sgn sha1 sha256 sha512 sin sinh skewness sort
+sort_collection splita splitax splitkv splitkvx splitnv splitnvx sqrt ssub
+stddev strfntime strfntime_local strftime strftime_local string strip strlen
+strpntime strpntime_local strptime strptime_local sub substr substr0 substr1
+sum sum2 sum3 sum4 sysntime system systime systimeint tan tanh tolower toupper
+truncate typeof unflatten unformat unformatx upntime uptime urand urand32
+urandelement urandint urandrange utf8_to_latin1 variance version ! != !=~ % &
+&& * ** + - . .* .+ .- ./ / // < << <= <=> == =~ > >= >> >>> ?: ?? ??? ^ ^^ |
+|| ~
 .fi
 .if n \{\
 .RE
@@ -3935,6 +3936,28 @@ localtime2sec("2001-02-03 04:05:06", "Asia/Istanbul") = 981165906"
 .\}
 .nf
  (class=collections #args=variadic) With 0 args, returns empty map. With >= 1 arg, returns a map with key-value pairs from all arguments. Rightmost collisions win, e.g. 'mapsum({1:2,3:4},{1:5})' is '{1:5,3:4}'.
+.fi
+.if n \{\
+.RE
+.SS "match"
+.if n \{\
+.RS 0
+.\}
+.nf
+ (class=string #args=2) TODO: WRITE ME
+Example:
+TODO: WRITE ME
+.fi
+.if n \{\
+.RE
+.SS "matchx"
+.if n \{\
+.RS 0
+.\}
+.nf
+ (class=string #args=2) TODO: WRITE ME
+Example:
+TODO: WRITE ME
 .fi
 .if n \{\
 .RE

--- a/pkg/bifs/regex.go
+++ b/pkg/bifs/regex.go
@@ -132,17 +132,16 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	return mlrval.FromBool(boolOutput)
 }
 
-// TODO: WRITE ME
 func BIF_matchx(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	if !input1.IsLegit() {
-		return mlrval.FromNotStringError("match", input1) // TODO: CHANGE FLAVOR
+		return mlrval.FromNotStringError("matchx", input1) // TODO: CHANGE FLAVOR
 	}
 	if !input2.IsLegit() {
-		return mlrval.FromNotStringError("match", input2) // TODO: CHANGE FLAVOR
+		return mlrval.FromNotStringError("matchx", input2) // TODO: CHANGE FLAVOR
 	}
 	input1string := input1.String()
 	if !input2.IsStringOrVoid() {
-		return mlrval.FromNotStringError("match", input2)
+		return mlrval.FromNotStringError("matchx", input2)
 	}
 
 	boolOutput, captures, starts, ends := lib.RegexStringMatchWithMapResults(input1string, input2.AcquireStringValue())
@@ -150,11 +149,7 @@ func BIF_matchx(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	results := mlrval.NewMlrmap()
 	results.PutReference("matched", mlrval.FromBool(boolOutput))
 
-	// XXX assert all lengths equal
-
 	captures_array := make([]*mlrval.Mlrval, len(captures))
-	starts_array := make([]*mlrval.Mlrval, len(captures))
-	ends_array := make([]*mlrval.Mlrval, len(captures))
 
 	if len(captures) > 0 {
 		for i, _ := range captures {
@@ -188,10 +183,6 @@ func BIF_matchx(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 			results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
 			results.PutReference("ends", mlrval.FromArray(ends_array[1:]))
 		}
-	} else {
-		results.PutReference("captures", mlrval.FromArray(captures_array))
-		results.PutReference("starts", mlrval.FromArray(starts_array))
-		results.PutReference("ends", mlrval.FromArray(ends_array))
 	}
 
 	return mlrval.FromMap(results)

--- a/pkg/bifs/regex.go
+++ b/pkg/bifs/regex.go
@@ -115,6 +115,68 @@ func BIF_gsub(input1, input2, input3 *mlrval.Mlrval) *mlrval.Mlrval {
 	return mlrval.FromString(stringOutput)
 }
 
+// TODO: WRITE ME
+func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
+	if !input1.IsLegit() {
+		return mlrval.FromNotStringError("match", input1) // TODO: CHANGE FLAVOR
+	}
+	if !input2.IsLegit() {
+		return mlrval.FromNotStringError("match", input2) // TODO: CHANGE FLAVOR
+	}
+	input1string := input1.String()
+	if !input2.IsStringOrVoid() {
+		return mlrval.FromNotStringError("match", input2)
+	}
+
+	boolOutput, captures, starts, lengths := lib.RegexMatchesTemp(input1string, input2.AcquireStringValue())
+
+	results := mlrval.NewMlrmap()
+	results.PutReference("matched", mlrval.FromBool(boolOutput))
+
+	// XXX assert all lengths equal
+
+	captures_array := make([]*mlrval.Mlrval, len(captures))
+	starts_array := make([]*mlrval.Mlrval, len(captures))
+	lengths_array := make([]*mlrval.Mlrval, len(captures))
+
+	if len(captures) > 0 {
+		for i, _ := range captures {
+			if i == 0 {
+				captures_array[i] = mlrval.FromString("")
+			} else {
+				captures_array[i] = mlrval.FromString(captures[i])
+			}
+		}
+		results.PutReference("captures", mlrval.FromArray(captures_array[1:]))
+
+		starts_array := make([]*mlrval.Mlrval, len(starts))
+		for i, _ := range starts {
+			if i == 0 {
+				starts_array[i] = mlrval.FromInt(0)
+			} else {
+				starts_array[i] = mlrval.FromInt(int64(starts[i]))
+			}
+		}
+		results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
+
+		lengths_array := make([]*mlrval.Mlrval, len(lengths))
+		for i, _ := range lengths {
+			if i == 0 {
+				lengths_array[i] = mlrval.FromInt(0)
+			} else {
+				lengths_array[i] = mlrval.FromInt(int64(lengths[i]))
+			}
+		}
+		results.PutReference("lengths", mlrval.FromArray(lengths_array[1:]))
+	} else {
+		results.PutReference("captures", mlrval.FromArray(captures_array))
+		results.PutReference("starts", mlrval.FromArray(starts_array))
+		results.PutReference("lengths", mlrval.FromArray(lengths_array))
+	}
+
+	return mlrval.FromMap(results)
+}
+
 // BIF_string_matches_regexp implements the =~ operator, with support for
 // setting regex-captures for later expressions to access using "\1" .. "\9".
 func BIF_string_matches_regexp(input1, input2 *mlrval.Mlrval) (retval *mlrval.Mlrval, captures []string) {

--- a/pkg/bifs/regex.go
+++ b/pkg/bifs/regex.go
@@ -115,7 +115,6 @@ func BIF_gsub(input1, input2, input3 *mlrval.Mlrval) *mlrval.Mlrval {
 	return mlrval.FromString(stringOutput)
 }
 
-// TODO: WRITE ME
 func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	if !input1.IsLegit() {
 		return mlrval.FromNotStringError("match", input1) // TODO: CHANGE FLAVOR
@@ -128,9 +127,7 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 		return mlrval.FromNotStringError("match", input2)
 	}
 
-	// TODO: make a simpler function which does less in the first place (don't just
-	// do more work and then throw it away -- do less)
-	boolOutput, _, _, _ := lib.RegexStringMatchWithMapResults(input1string, input2.AcquireStringValue())
+	boolOutput := lib.RegexStringMatchSimple(input1string, input2.AcquireStringValue())
 
 	return mlrval.FromBool(boolOutput)
 }

--- a/pkg/bifs/regex.go
+++ b/pkg/bifs/regex.go
@@ -81,7 +81,7 @@ func BIF_sub(input1, input2, input3 *mlrval.Mlrval) *mlrval.Mlrval {
 	sregex := input2.AcquireStringValue()
 	replacement := input3.AcquireStringValue()
 
-	stringOutput := lib.RegexSub(input, sregex, replacement)
+	stringOutput := lib.RegexStringSub(input, sregex, replacement)
 	return mlrval.FromString(stringOutput)
 }
 
@@ -111,7 +111,7 @@ func BIF_gsub(input1, input2, input3 *mlrval.Mlrval) *mlrval.Mlrval {
 	sregex := input2.AcquireStringValue()
 	replacement := input3.AcquireStringValue()
 
-	stringOutput := lib.RegexGsub(input, sregex, replacement)
+	stringOutput := lib.RegexStringGsub(input, sregex, replacement)
 	return mlrval.FromString(stringOutput)
 }
 
@@ -128,7 +128,27 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 		return mlrval.FromNotStringError("match", input2)
 	}
 
-	boolOutput, captures, starts, ends := lib.RegexMatchesTemp(input1string, input2.AcquireStringValue())
+	// TODO: make a simpler function which does less in the first place (don't just
+	// do more work and then throw it away -- do less)
+	boolOutput, _, _, _ := lib.RegexStringMatchWithMapResults(input1string, input2.AcquireStringValue())
+
+	return mlrval.FromBool(boolOutput)
+}
+
+// TODO: WRITE ME
+func BIF_matchx(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
+	if !input1.IsLegit() {
+		return mlrval.FromNotStringError("match", input1) // TODO: CHANGE FLAVOR
+	}
+	if !input2.IsLegit() {
+		return mlrval.FromNotStringError("match", input2) // TODO: CHANGE FLAVOR
+	}
+	input1string := input1.String()
+	if !input2.IsStringOrVoid() {
+		return mlrval.FromNotStringError("match", input2)
+	}
+
+	boolOutput, captures, starts, ends := lib.RegexStringMatchWithMapResults(input1string, input2.AcquireStringValue())
 
 	results := mlrval.NewMlrmap()
 	results.PutReference("matched", mlrval.FromBool(boolOutput))
@@ -167,9 +187,9 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 		}
 
 		if len(captures) > 1 {
-		results.PutReference("captures", mlrval.FromArray(captures_array[1:]))
-		results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
-		results.PutReference("ends", mlrval.FromArray(ends_array[1:]))
+			results.PutReference("captures", mlrval.FromArray(captures_array[1:]))
+			results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
+			results.PutReference("ends", mlrval.FromArray(ends_array[1:]))
 		}
 	} else {
 		results.PutReference("captures", mlrval.FromArray(captures_array))
@@ -194,7 +214,7 @@ func BIF_string_matches_regexp(input1, input2 *mlrval.Mlrval) (retval *mlrval.Ml
 		return mlrval.FromNotStringError("=~", input2), nil
 	}
 
-	boolOutput, captures := lib.RegexMatches(input1string, input2.AcquireStringValue())
+	boolOutput, captures := lib.RegexStringMatchWithCaptures(input1string, input2.AcquireStringValue())
 	return mlrval.FromBool(boolOutput), captures
 }
 

--- a/pkg/bifs/regex.go
+++ b/pkg/bifs/regex.go
@@ -128,7 +128,7 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 		return mlrval.FromNotStringError("match", input2)
 	}
 
-	boolOutput, captures, starts, lengths := lib.RegexMatchesTemp(input1string, input2.AcquireStringValue())
+	boolOutput, captures, starts, ends := lib.RegexMatchesTemp(input1string, input2.AcquireStringValue())
 
 	results := mlrval.NewMlrmap()
 	results.PutReference("matched", mlrval.FromBool(boolOutput))
@@ -137,41 +137,44 @@ func BIF_match(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 
 	captures_array := make([]*mlrval.Mlrval, len(captures))
 	starts_array := make([]*mlrval.Mlrval, len(captures))
-	lengths_array := make([]*mlrval.Mlrval, len(captures))
+	ends_array := make([]*mlrval.Mlrval, len(captures))
 
 	if len(captures) > 0 {
 		for i, _ := range captures {
 			if i == 0 {
-				captures_array[i] = mlrval.FromString("")
+				results.PutReference("full_capture", mlrval.FromString(captures[i]))
 			} else {
 				captures_array[i] = mlrval.FromString(captures[i])
 			}
 		}
-		results.PutReference("captures", mlrval.FromArray(captures_array[1:]))
 
 		starts_array := make([]*mlrval.Mlrval, len(starts))
 		for i, _ := range starts {
 			if i == 0 {
-				starts_array[i] = mlrval.FromInt(0)
+				results.PutReference("full_start", mlrval.FromInt(int64(starts[i])))
 			} else {
 				starts_array[i] = mlrval.FromInt(int64(starts[i]))
 			}
 		}
-		results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
 
-		lengths_array := make([]*mlrval.Mlrval, len(lengths))
-		for i, _ := range lengths {
+		ends_array := make([]*mlrval.Mlrval, len(ends))
+		for i, _ := range ends {
 			if i == 0 {
-				lengths_array[i] = mlrval.FromInt(0)
+				results.PutReference("full_end", mlrval.FromInt(int64(ends[i])))
 			} else {
-				lengths_array[i] = mlrval.FromInt(int64(lengths[i]))
+				ends_array[i] = mlrval.FromInt(int64(ends[i]))
 			}
 		}
-		results.PutReference("lengths", mlrval.FromArray(lengths_array[1:]))
+
+		if len(captures) > 1 {
+		results.PutReference("captures", mlrval.FromArray(captures_array[1:]))
+		results.PutReference("starts", mlrval.FromArray(starts_array[1:]))
+		results.PutReference("ends", mlrval.FromArray(ends_array[1:]))
+		}
 	} else {
 		results.PutReference("captures", mlrval.FromArray(captures_array))
 		results.PutReference("starts", mlrval.FromArray(starts_array))
-		results.PutReference("lengths", mlrval.FromArray(lengths_array))
+		results.PutReference("ends", mlrval.FromArray(ends_array))
 	}
 
 	return mlrval.FromMap(results)

--- a/pkg/dsl/cst/builtin_function_manager.go
+++ b/pkg/dsl/cst/builtin_function_manager.go
@@ -349,6 +349,16 @@ used within subsequent DSL statements. See also "Regular expressions" at ` + lib
 		},
 
 		{
+			name:  "matchx",
+			class: FUNC_CLASS_STRING,
+			help:  `TODO: WRITE ME`,
+			examples: []string{
+				`TODO: WRITE ME`,
+			},
+			binaryFunc: bifs.BIF_matchx,
+		},
+
+		{
 			name:       "&&",
 			class:      FUNC_CLASS_BOOLEAN,
 			help:       `Logical AND.`,

--- a/pkg/dsl/cst/builtin_function_manager.go
+++ b/pkg/dsl/cst/builtin_function_manager.go
@@ -339,6 +339,16 @@ used within subsequent DSL statements. See also "Regular expressions" at ` + lib
 		},
 
 		{
+			name:  "match",
+			class: FUNC_CLASS_STRING,
+			help:  `TODO: WRITE ME`,
+			examples: []string{
+				`TODO: WRITE ME`,
+			},
+			binaryFunc: bifs.BIF_match,
+		},
+
+		{
 			name:       "&&",
 			class:      FUNC_CLASS_BOOLEAN,
 			help:       `Logical AND.`,

--- a/pkg/dsl/cst/leaves.go
+++ b/pkg/dsl/cst/leaves.go
@@ -266,7 +266,7 @@ func (root *RootNode) BuildStringLiteralNode(literal string) IEvaluable {
 	// RegexLiteralNode.  See also https://github.com/johnkerl/miller/issues/297.
 	literal = lib.UnbackslashStringLiteral(literal)
 
-	hasCaptures, replacementCaptureMatrix := lib.RegexReplacementHasCaptures(literal)
+	hasCaptures, replacementCaptureMatrix := lib.ReplacementHasCaptures(literal)
 	if !hasCaptures {
 		return &StringLiteralNode{
 			literal: mlrval.FromString(literal),

--- a/pkg/input/record_reader.go
+++ b/pkg/input/record_reader.go
@@ -158,7 +158,7 @@ type tIPSRegexSplitter struct {
 }
 
 func (s *tIPSRegexSplitter) Split(input string) []string {
-	return lib.RegexSplitString(s.ipsRegex, input, 2)
+	return lib.RegexCompiledSplitString(s.ipsRegex, input, 2)
 }
 
 // IFieldSplitter splits a string into pieces, e.g. for IFS.
@@ -193,5 +193,5 @@ type tIFSRegexSplitter struct {
 }
 
 func (s *tIFSRegexSplitter) Split(input string) []string {
-	return lib.RegexSplitString(s.ifsRegex, input, -1)
+	return lib.RegexCompiledSplitString(s.ifsRegex, input, -1)
 }

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -304,7 +304,7 @@ type tXTABIPSSplitter struct {
 // which we need to produce just a pair of items -- a key and a value -- delimited by one or more
 // IPS. For exaemple, with IPS being a space, in 'abc     123' we need to get key 'abc' and value
 // '123'; for 'abc    123 456' we need key 'abc' and value '123 456'.  It's super-elegant to simply
-// regex-split the line like 'kv = lib.RegexSplitString(reader.readerOptions.IPSRegex, line, 2)' --
+// regex-split the line like 'kv = lib.RegexCompiledSplitString(reader.readerOptions.IPSRegex, line, 2)' --
 // however, that's 3x slower than the current implementation. It turns out regexes are great
 // but we should use them only when we must, since they are expensive.
 func (s *tXTABIPSSplitter) Split(input string) (key, value string, err error) {
@@ -358,7 +358,7 @@ type tXTABIPSRegexSplitter struct {
 }
 
 func (s *tXTABIPSRegexSplitter) Split(input string) (key, value string, err error) {
-	kv := lib.RegexSplitString(s.ipsRegex, input, 2)
+	kv := lib.RegexCompiledSplitString(s.ipsRegex, input, 2)
 	if len(kv) == 0 {
 		return "", "", fmt.Errorf("internal coding error in XTAB reader")
 	} else if len(kv) == 1 {

--- a/pkg/lib/regex.go
+++ b/pkg/lib/regex.go
@@ -166,9 +166,9 @@ func RegexMatchesTemp(
 	sregex string,
 ) (
 	matches bool,
-	capturesOneUp []string,
-	startsOneUp []int,
-	lengthsOneUp []int,
+	captures[]string,
+	starts[]int,
+	ends[]int,
 ) {
 	regex := CompileMillerRegexOrDie(sregex)
 	return RegexMatchesCompiledTemp(input, regex)
@@ -184,12 +184,12 @@ func RegexMatchesCompiledTemp(
 	regex *regexp.Regexp,
 ) (bool, []string, []int, []int) {
 	captures := make([]string, 0, 10)
-	startsOneUp := make([]int, 0, 10)
-	lengthsOneUp := make([]int, 0, 10)
+	starts := make([]int, 0, 10)
+	ends := make([]int, 0, 10)
 
 	matrix := regex.FindAllSubmatchIndex([]byte(input), -1)
 	if matrix == nil || len(matrix) == 0 {
-		return false, captures, startsOneUp, lengthsOneUp
+		return false, captures, starts, ends
 	}
 
 	// If there are multiple matches -- e.g. input is
@@ -225,16 +225,16 @@ func RegexMatchesCompiledTemp(
 		end := row[si+1]
 		if start >= 0 && end >= 0 {
 			captures = append(captures, input[start:end])
-			startsOneUp = append(startsOneUp, start+1)
-			lengthsOneUp = append(lengthsOneUp, end-start)
+			starts= append(starts, start+1)
+			ends= append(ends, end)
 		} else {
 			captures = append(captures, "")
-			startsOneUp = append(startsOneUp, -1)
-			lengthsOneUp = append(lengthsOneUp, -1)
+			starts= append(starts, -1)
+			ends= append(ends, -1)
 		}
 	}
 
-	return true, captures, startsOneUp, lengthsOneUp
+	return true, captures, starts, ends
 }
 
 // RegexMatches implements the =~ DSL operator. The captures are stored in DSL

--- a/pkg/lib/regex.go
+++ b/pkg/lib/regex.go
@@ -236,6 +236,24 @@ func regexCompiledSubOrGsub(
 }
 
 // TODO: UPDATE ME
+func RegexStringMatchSimple(
+	input string,
+	sregex string,
+) bool {
+	regex := CompileMillerRegexOrDie(sregex)
+	return RegexCompiledMatchSimple(input, regex)
+}
+
+// TODO: UPDATE ME
+func RegexCompiledMatchSimple(
+	input string,
+	regex *regexp.Regexp,
+) bool {
+
+	return regex.Match([]byte(input))
+}
+
+// TODO: UPDATE ME
 // TODO: RENAME
 // RegexStringMatchWithCaptures implements the =~ DSL operator. The captures are stored in DSL
 // state and may be used by a DSL statement after the =~. For example, in

--- a/pkg/lib/regex_test.go
+++ b/pkg/lib/regex_test.go
@@ -88,7 +88,7 @@ var dataForMatches = []tDataForMatches{
 
 func TestRegexReplacementHasCaptures(t *testing.T) {
 	for i, entry := range dataForHasCaptures {
-		actualHasCaptures, actualMatrix := RegexReplacementHasCaptures(entry.replacement)
+		actualHasCaptures, actualMatrix := ReplacementHasCaptures(entry.replacement)
 		if actualHasCaptures != entry.expectedHasCaptures {
 			t.Fatalf("case %d replacement \"%s\" expected %v got %v\n",
 				i, entry.replacement, entry.expectedHasCaptures, actualHasCaptures,
@@ -104,7 +104,7 @@ func TestRegexReplacementHasCaptures(t *testing.T) {
 
 func TestRegexSub(t *testing.T) {
 	for i, entry := range dataForSub {
-		actualOutput := RegexSub(entry.input, entry.sregex, entry.replacement)
+		actualOutput := RegexStringSub(entry.input, entry.sregex, entry.replacement)
 		if actualOutput != entry.expectedOutput {
 			t.Fatalf("case %d input \"%s\" sregex \"%s\" replacement \"%s\" expected \"%s\" got \"%s\"\n",
 				i, entry.input, entry.sregex, entry.replacement, entry.expectedOutput, actualOutput,
@@ -115,7 +115,7 @@ func TestRegexSub(t *testing.T) {
 
 func TestRegexGsub(t *testing.T) {
 	for i, entry := range dataForGsub {
-		actualOutput := RegexGsub(entry.input, entry.sregex, entry.replacement)
+		actualOutput := RegexStringGsub(entry.input, entry.sregex, entry.replacement)
 		if actualOutput != entry.expectedOutput {
 			t.Fatalf("case %d input \"%s\" sregex \"%s\" replacement \"%s\" expected \"%s\" got \"%s\"\n",
 				i, entry.input, entry.sregex, entry.replacement, entry.expectedOutput, actualOutput,
@@ -126,7 +126,7 @@ func TestRegexGsub(t *testing.T) {
 
 func TestRegexMatches(t *testing.T) {
 	for i, entry := range dataForMatches {
-		actualOutput, actualCaptures := RegexMatches(entry.input, entry.sregex)
+		actualOutput, actualCaptures := RegexStringMatchWithCaptures(entry.input, entry.sregex)
 		if actualOutput != entry.expectedOutput {
 			t.Fatalf("case %d input \"%s\" sregex \"%s\" expected %v got %v\n",
 				i, entry.input, entry.sregex, entry.expectedOutput, actualOutput,

--- a/pkg/runtime/state.go
+++ b/pkg/runtime/state.go
@@ -43,8 +43,8 @@ func NewEmptyState(options *cli.TOptions, strictMode bool) *State {
 
 		// OutputRecordsAndContexts is assigned after construction
 
-		// See lib.MakeEmptyRegexCaptures for context.
-		RegexCaptures: lib.MakeEmptyRegexCaptures(),
+		// See lib.MakeEmptyCaptures for context.
+		RegexCaptures: lib.MakeEmptyCaptures(),
 		Options:       options,
 
 		StrictMode: strictMode,
@@ -57,5 +57,5 @@ func (state *State) Update(
 ) {
 	state.Inrec = inrec
 	state.Context = context
-	state.RegexCaptures = lib.MakeEmptyRegexCaptures()
+	state.RegexCaptures = lib.MakeEmptyCaptures()
 }

--- a/pkg/transformers/merge_fields.go
+++ b/pkg/transformers/merge_fields.go
@@ -479,7 +479,7 @@ func (tr *TransformerMergeFields) transformByCollapsing(
 			matched = valueFieldNameRegex.MatchString(pe.Key)
 			if matched {
 				// TODO: comment re matrix
-				shortName = lib.RegexSubCompiled(valueFieldName, valueFieldNameRegex, "", nil)
+				shortName = lib.RegexCompiledSub(valueFieldName, valueFieldNameRegex, "", nil)
 				break
 			}
 		}

--- a/pkg/transformers/rename.go
+++ b/pkg/transformers/rename.go
@@ -169,7 +169,7 @@ func NewTransformerRename(
 			regexString := pe.Key
 			regex := lib.CompileMillerRegexOrDie(regexString)
 			replacement := pe.Value.(string)
-			_, replacementCaptureMatrix := lib.RegexReplacementHasCaptures(replacement)
+			_, replacementCaptureMatrix := lib.ReplacementHasCaptures(replacement)
 			regexAndReplacement := tRegexAndReplacement{
 				regex:                    regex,
 				replacement:              replacement,
@@ -241,7 +241,7 @@ func (tr *TransformerRename) transformWithRegexes(
 						inrec.Rename(oldName, newName)
 					}
 				} else {
-					newName := lib.RegexSubCompiled(oldName, regex, replacement, replacementCaptureMatrix)
+					newName := lib.RegexCompiledSub(oldName, regex, replacement, replacementCaptureMatrix)
 					if newName != oldName {
 						inrec.Rename(oldName, newName)
 					}


### PR DESCRIPTION
For #283, #1399, and #1401

Draft (not quite right yet):

Input: 

`mlr --ojson put '$z = match($x, $y)' <<EOF`
```
x=  345 78  ,y=([0-9]+)(.)([0-9]+)
x=  345 78  ,y=([0-9]+) ([0-9]+)
x=  345 78  ,y=([0-9]+)
x=abc,y=ab
x=a,y=b
EOF
```

Output:

```
[
{
  "x": "  345 78  ",
  "y": "([0-9]+)(.)([0-9]+)",
  "z": {
    "matched": true,
    "captures": ["345", " ", "78"],
    "starts": [3, 6, 7],
    "lengths": [3, 1, 2]
  }
},
{
  "x": "  345 78  ",
  "y": "([0-9]+) ([0-9]+)",
  "z": {
    "matched": true,
    "captures": ["345", "78"],
    "starts": [3, 7],
    "lengths": [3, 2]
  }
},
{
  "x": "  345 78  ",
  "y": "([0-9]+)",
  "z": {
    "matched": true,
    "captures": ["345"],
    "starts": [3],
    "lengths": [3]
  }
},
{
  "x": "abc",
  "y": "ab",
  "z": {
    "matched": true,
    "captures": [],
    "starts": [],
    "lengths": []
  }
},
{
  "x": "a",
  "y": "b",
  "z": {
    "matched": false,
    "captures": [],
    "starts": [],
    "lengths": []
  }
}
]
```