### PR TITLE
Replace deprecated `io/ioutil` functions

### DIFF
--- a/pkg/climain/mlrcli_shebang.go
+++ b/pkg/climain/mlrcli_shebang.go
@@ -2,7 +2,7 @@ package climain
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -49,7 +49,7 @@ func maybeInterpolateDashS(args []string) ([]string, error) {
 	remainingArgs := args[3:]
 
 	// Read the bytes in the filename given after -s.
-	byteContents, rerr := ioutil.ReadFile(filename)
+	byteContents, rerr := os.ReadFile(filename)
 	if rerr != nil {
 		return nil, fmt.Errorf("mlr: cannot read %s: %v", filename, rerr)
 	}
@@ -68,7 +68,7 @@ func maybeInterpolateDashS(args []string) ([]string, error) {
 
 	if stripComments {
 		re := regexp.MustCompile(`#.*`)
-		for i, _ := range lines {
+		for i := range lines {
 			lines[i] = re.ReplaceAllString(lines[i], "")
 		}
 	}

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -7,7 +7,6 @@ package entrypoint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -135,7 +134,7 @@ func processInPlace(
 		containingDirectory := path.Dir(fileName)
 		// Names like ./mlr-in-place-2148227797 and ./mlr-in-place-1792078347,
 		// as revealed by printing handle.Name().
-		handle, err := ioutil.TempFile(containingDirectory, "mlr-in-place-")
+		handle, err := os.CreateTemp(containingDirectory, "mlr-in-place-")
 		if err != nil {
 			return err
 		}

--- a/pkg/lib/readfiles.go
+++ b/pkg/lib/readfiles.go
@@ -6,7 +6,6 @@
 package lib
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -34,10 +33,10 @@ func LoadStringsFromFileOrDir(path string, extension string) ([]string, error) {
 	}
 }
 
-// LoadStringFromFile is just a wrapper around ioutil.ReadFile,
+// LoadStringFromFile is just a wrapper around os.ReadFile,
 // with a cast from []byte to string.
 func LoadStringFromFile(filename string) (string, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -51,14 +50,18 @@ func LoadStringFromFile(filename string) (string, error) {
 func LoadStringsFromDir(dirname string, extension string) ([]string, error) {
 	dslStrings := make([]string, 0)
 
-	entries, err := ioutil.ReadDir(dirname)
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(-1)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range entries {
-		entry := &entries[i]
-		name := (*entry).Name()
+	for _, name := range names {
 		if !strings.HasSuffix(name, extension) {
 			continue
 		}

--- a/pkg/lib/util.go
+++ b/pkg/lib/util.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -186,9 +185,9 @@ func GetArrayKeysSorted(input map[string]string) []string {
 // WriteTempFile places the contents string into a temp file, which the caller
 // must remove.
 func WriteTempFileOrDie(contents string) string {
-	// Use "" as first argument to ioutil.TempFile to use default directory.
+	// Use "" as first argument to os.CreateTemp to use default directory.
 	// Nominally "/tmp" or somesuch on all unix-like systems, but not for Windows.
-	handle, err := ioutil.TempFile("", "mlr-temp")
+	handle, err := os.CreateTemp("", "mlr-temp")
 	if err != nil {
 		fmt.Printf("mlr: could not create temp file.\n")
 		os.Exit(1)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil