### PR TITLE
Fix #1462: remove limit of 1000 on dedupe field names

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -3689,5 +3689,5 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-23                         MILLER(1)
+                                  2024-01-01                         MILLER(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -3668,4 +3668,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-23                         MILLER(1)
+                                  2024-01-01                         MILLER(1)

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -3668,4 +3668,4 @@ MILLER(1)                                                            MILLER(1)
 
 
 
-                                  2023-12-23                         MILLER(1)
+                                  2024-01-01                         MILLER(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2023-12-23
+.\"      Date: 2024-01-01
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2023-12-23" "\ \&" "\ \&"
+.TH "MILLER" "1" "2024-01-01" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -74,7 +74,7 @@ func (mlrmap *Mlrmap) PutReferenceMaybeDedupe(key string, value *Mlrval, dedupe 
 		return key, nil
 	}
 
-	for i := 2; i < 1000; i++ {
+	for i := 2; ; i++ {
 		newKey := key + "_" + strconv.Itoa(i)
 		pe := mlrmap.findEntry(newKey)
 		if pe == nil {
@@ -82,7 +82,6 @@ func (mlrmap *Mlrmap) PutReferenceMaybeDedupe(key string, value *Mlrval, dedupe 
 			return newKey, nil
 		}
 	}
-	return key, fmt.Errorf("record has too many input fields named \"%s\"", key)
 }
 
 // PutCopy copies the key and value (deep-copying in case the value is array/map).


### PR DESCRIPTION
Fixes #1462