### PR TITLE
Try to build readthedocs `.epub` and `.pdf`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,5 @@ python:
 
 mkdocs:
   configuration: docs/mkdocs.yml
+
+formats: all


### PR DESCRIPTION
Following https://docs.readthedocs.io/en/stable/config-file/v2.html#formats