### PR TITLE
Fraction bugfix

### DIFF
--- a/pkg/transformers/fraction.go
+++ b/pkg/transformers/fraction.go
@@ -264,9 +264,12 @@ func (tr *TransformerFraction) Transform(
 						} else {
 							numerator = value
 						}
-
 						denominator := sumsForGroup[fractionFieldName]
-						if !mlrval.Equals(value, tr.zero) {
+
+						// Return 0 for 0/n
+						if mlrval.Equals(numerator, tr.zero) {
+							outputValue = tr.zero
+						} else if !mlrval.Equals(denominator, tr.zero) {
 							outputValue = bifs.BIF_divide(numerator, denominator)
 							outputValue = bifs.BIF_times(outputValue, tr.multiplier)
 						} else {


### PR DESCRIPTION
Fix `mlr fraction` returning an error for 0 values:
```
$ echo -e 'a=1,b=0\na=2,b=1' | mlr --opprint fraction -f a,b
a b a_fraction         b_fraction
1 0 0.3333333333333333 (error)
2 1 0.6666666666666666 1

$ echo -e 'a=1,b=0' | mlr --opprint fraction -f a,b
a b a_fraction b_fraction
1 0 1          (error)
```
There seem to be two issues:
- Division-by-zero check  looks at numerator instead of the denominator.
- 0/0 fails, but really should return 0 instead of an error.

Fix both issues:
```
$ echo -e 'a=1,b=0\na=2,b=1' | ./mlr --opprint fraction -f a,b
a b a_fraction         b_fraction
1 0 0.3333333333333333 0
2 1 0.6666666666666666 1

$ echo -e 'a=1,b=0' | ./mlr --opprint fraction -f a,b
a b a_fraction b_fraction
1 0 1          0
```

