### PR TITLE
On-line help for `mlr summary --transpose`

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -2099,6 +2099,7 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        -a {mean,sum,etc.} Use only the specified summarizers.
        -x {mean,sum,etc.} Use all summarizers, except the specified ones.
        --all              Use all available summarizers.
+       --transpose        Show output with field names as column names..
        -h|--help Show this message.
 
    1mtac0m

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -2078,6 +2078,7 @@
        -a {mean,sum,etc.} Use only the specified summarizers.
        -x {mean,sum,etc.} Use all summarizers, except the specified ones.
        --all              Use all available summarizers.
+       --transpose        Show output with field names as column names..
        -h|--help Show this message.
 
    1mtac0m

--- a/docs/src/reference-verbs.md
+++ b/docs/src/reference-verbs.md
@@ -3796,6 +3796,7 @@ Options:
 -a {mean,sum,etc.} Use only the specified summarizers.
 -x {mean,sum,etc.} Use all summarizers, except the specified ones.
 --all              Use all available summarizers.
+--transpose        Show output with field names as column names..
 -h|--help Show this message.
 </pre>
 

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -2078,6 +2078,7 @@
        -a {mean,sum,etc.} Use only the specified summarizers.
        -x {mean,sum,etc.} Use all summarizers, except the specified ones.
        --all              Use all available summarizers.
+       --transpose        Show output with field names as column names..
        -h|--help Show this message.
 
    1mtac0m

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2605,6 +2605,7 @@ Options:
 -a {mean,sum,etc.} Use only the specified summarizers.
 -x {mean,sum,etc.} Use all summarizers, except the specified ones.
 --all              Use all available summarizers.
+--transpose        Show output with field names as column names..
 -h|--help Show this message.
 .fi
 .if n \{\

--- a/pkg/transformers/summary.go
+++ b/pkg/transformers/summary.go
@@ -106,6 +106,7 @@ func transformerSummaryUsage(
 	fmt.Fprintf(o, "-a {mean,sum,etc.} Use only the specified summarizers.\n")
 	fmt.Fprintf(o, "-x {mean,sum,etc.} Use all summarizers, except the specified ones.\n")
 	fmt.Fprintf(o, "--all              Use all available summarizers.\n")
+	fmt.Fprintf(o, "--transpose        Show output with field names as column names..\n")
 	fmt.Fprintf(o, "-h|--help Show this message.\n")
 }
 

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -1252,6 +1252,7 @@ Options:
 -a {mean,sum,etc.} Use only the specified summarizers.
 -x {mean,sum,etc.} Use all summarizers, except the specified ones.
 --all              Use all available summarizers.
+--transpose        Show output with field names as column names..
 -h|--help Show this message.
 
 ================================================================


### PR DESCRIPTION
Resolves #1569.

Note there is existing material at https://miller.readthedocs.io/en/latest/reference-verbs/index.html#summary; this PR adds missing material to `mlr summary --help`.