### PR TITLE
Source-file update for PR 1634

### DIFF
--- a/docs/src/reference-dsl-variables.md
+++ b/docs/src/reference-dsl-variables.md
@@ -157,7 +157,7 @@ a=wye,b=pan,i=5,x=0.573288,y=0.863624
 
 !!! note
 
-    You can use positional field names only in `DSL` syntax, so only with the verbs `put` and `filter`.
+    You can use positional field names only in the [Miller DSL](reference-dsl.md), i.e. only with the verbs `put` and `filter`.
 
 ## Out-of-stream variables
 

--- a/docs/src/reference-dsl-variables.md.in
+++ b/docs/src/reference-dsl-variables.md.in
@@ -80,6 +80,10 @@ GENMD-RUN-COMMAND
 mlr put '$[[[6]]] = "NEW"' data/small
 GENMD-EOF
 
+!!! note
+
+    You can use positional field names only in the [Miller DSL](reference-dsl.md), i.e. only with the verbs `put` and `filter`.
+
 ## Out-of-stream variables
 
 These are prefixed with an at-sign, e.g. `@sum`.  Furthermore, unlike built-in variables and stream-record fields, they are maintained in an arbitrarily nested map: you can do `@sum += $quantity`, or `@sum[$color] += $quantity`, or `@sum[$color][$shape] += $quantity`. The keys for the multi-level map can be any expression which evaluates to string or integer: e.g.  `@sum[NR] = $a + $b`, `@sum[$a."-".$b] = $x`, etc.


### PR DESCRIPTION
#1634 edited a `.md` file whereas these are all generated from their corresponding `md.in` source files.

https://github.com/johnkerl/miller/blob/v6.12.0/docs/src/reference-dsl-variables.md?plain=1#L1