### PR TITLE
Enable admonition extension

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -118,5 +118,9 @@ nav:
   - "What's new in Miller 6": "new-in-miller-6.md"
 
 markdown_extensions:
-- toc:
+  - toc:
       permalink: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+


### PR DESCRIPTION
In PR #1634 I have added an admonition note.
I assumed that the admonition extension was enabled, but it was not. I apologize John.

I have now enabled it as per the documentation:
https://squidfunk.github.io/mkdocs-material/reference/admonitions/?h=ad#admonitions