### PR TITLE
Fix local time when TZ is not set

### DIFF
--- a/pkg/lib/time.go
+++ b/pkg/lib/time.go
@@ -16,6 +16,9 @@ import (
 // statement does 'ENV["TZ"] = Asia/Istanbul'.
 func SetTZFromEnv() error {
 	tzenv := os.Getenv("TZ")
+	if tzenv == "" {
+		return nil
+	}
 	location, err := time.LoadLocation(tzenv)
 	if err != nil {
 		return fmt.Errorf("TZ environment variable appears malformed: \"%s\"", tzenv)


### PR DESCRIPTION
sec2localtime is returning UTC time unless TZ was explicitly set either via environment variable `TZ` or `--tz` cli fag. Golang sets `time.Local` correctly even without `TZ`. But it is overridden at `SetTZFromEnv`. When TZ is unset (i.e. ""), LoadLocation returns `UTC` [doc](https://pkg.go.dev/time#LoadLocation). 

> If the name is "" or "UTC", LoadLocation returns UTC. If the name is "Local", LoadLocation returns Local. 

---

```bash
❯ date
Tue 17 Sep 2024 10:41:02 AM EDT

❯ printf '{"ts": %s }' $(date +"%s") | go run cmd/mlr/main.go --jsonl put '$ts = sec2localtime($ts)'
{"ts": "2024-09-17 10:41:06"}

❯ printf '{"ts": %s }' $(date +"%s") | mlr --jsonl put '$ts = sec2localtime($ts)'
{"ts": "2024-09-17 14:41:09"}

❯ mlr --version
mlr 6.12.0

❯ env | grep TZ

❯ env | grep TZ || echo "not found"
not found
```