### PR TITLE
Compiling on newer go versions doesn't work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ module github.com/johnkerl/miller/v6
 // Local development:
 // replace github.com/johnkerl/lumin => /Users/kerl/git/johnkerl/lumin
 
-go 1.19
+go 1.21
 
 require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2ttpEmkA4aQ3j4u9dStX2t4M8UM6qqNsG8=
+github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
 github.com/lestrrat-go/strftime v1.1.0 h1:gMESpZy44/4pXLO/m+sL0yBd1W6LjgjrrD4a68Gapyg=
 github.com/lestrrat-go/strftime v1.1.0/go.mod h1:uzeIB52CeUJenCo1syghlugshMysrqUT51HlxphXVeI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
For whatever reason when compiling with go `1.23` it complains about needing to `go tidy` and running that bumps the go version to `1.21` and adds the `toolchain` directive, while also updating go.sum.

Compiling on go `1.20` works just fine without this update.

Not sure if you want to go all the way to `1.23` or do the minimum of `1.21` so I just picked the latter and can change if you want to.