### PR TITLE
Fix section-title typos for docs in #1735

### DIFF
--- a/docs/src/flatten-unflatten.md
+++ b/docs/src/flatten-unflatten.md
@@ -392,15 +392,6 @@ f.g  6
 ]
 </pre>
 
-## Non-inferencing cases
-
-An additional heuristic is that if a field name starts with a `.`, ends with
-a `.`, or has two or more consecutive `.` characters, no attempt is made
-to unflatten it on conversion from non-JSON to JSON.
-
-## Manual control
-
-
 ## Manual control
 
 To see what our options are for manually controlling flattening and

--- a/docs/src/flatten-unflatten.md.in
+++ b/docs/src/flatten-unflatten.md.in
@@ -174,15 +174,6 @@ GENMD-RUN-COMMAND
 mlr --icsv --ojson cat data/flatten-dots.csv
 GENMD-EOF
 
-## Non-inferencing cases
-
-An additional heuristic is that if a field name starts with a `.`, ends with
-a `.`, or has two or more consecutive `.` characters, no attempt is made
-to unflatten it on conversion from non-JSON to JSON.
-
-## Manual control
-
-
 ## Manual control
 
 To see what our options are for manually controlling flattening and


### PR DESCRIPTION
Some section titles were appearing twice, due to a miskey.