### PR TITLE
Use Go 1.21 in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Build
       run: make build


### PR DESCRIPTION
It's certainly time -- Go is at 1.24 now, releases twice a year, and only supports a couple versions back.

The nly reason for conservatism in the Go-version area is that Miller aims to support older/LTS operating systems -- Miller should never be insisting on latest-and-greatest Go versions.

Additionally: moving to 1.21 ensures that `toolchain` directives willl be recognized, e.g.

* https://github.com/johnkerl/miller/pull/1765
* https://github.com/johnkerl/miller/pull/1766
* https://github.com/johnkerl/miller/pull/1767