### PR TITLE
Argument parsing is different in `mlr -s` scripts

### DIFF
--- a/docs/src/scripting.md
+++ b/docs/src/scripting.md
@@ -234,7 +234,7 @@ then fraction -f count
 
 Points:
 
-* Same as above, where the `#!` line isn't needed. (But you can include a `#!` line; `mlr -s` will simply see it as a comment line.).
+* Same as above, where the `#!` line isn't needed. (But you can include a `#!` line; `mlr -s` will simply see it as a comment line.)
 * As above, you don't need all the backslashing for line-continuations.
 * As above, you don't need the explicit `--` or `"$@"`.
 

--- a/docs/src/scripting.md.in
+++ b/docs/src/scripting.md.in
@@ -101,7 +101,7 @@ GENMD-EOF
 
 Points:
 
-* Same as above, where the `#!` line isn't needed. (But you can include a `#!` line; `mlr -s` will simply see it as a comment line.).
+* Same as above, where the `#!` line isn't needed. (But you can include a `#!` line; `mlr -s` will simply see it as a comment line.)
 * As above, you don't need all the backslashing for line-continuations.
 * As above, you don't need the explicit `--` or `"$@"`.
 

--- a/pkg/climain/mlrcli_parse.go
+++ b/pkg/climain/mlrcli_parse.go
@@ -94,10 +94,20 @@ func ParseCommandLine(
 ) {
 	// mlr -s scriptfile {data-file names ...} means take the contents of
 	// scriptfile as if it were command-line items.
+
 	args, err = maybeInterpolateDashS(args)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Expand "-xyz" into "-x -y -z" while leaving "--xyz" intact. This is a
+	// keystroke-saver for the user.
+	//
+	// This is OK to do globally here since Miller is quite consistent (in
+	// main, verbs, and auxents) that multi-character options start with two
+	// dashes, e.g. "--csv". (The sole exception is the sort verb's -nf/-nr
+	// which are handled specially there.)
+    args = lib.Getoptify(args)
 
 	// Pass one as described at the top of this file.
 	flagSequences, terminalSequence, verbSequences, dataFileNames := parseCommandLinePassOne(args)

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -36,15 +36,6 @@ func Main() MainReturn {
 	// otherwise, we only raw ANSI escape sequences like ←[0;30m  0←[0m ←[0;31m  1
 	platform.EnableAnsiEscapeSequences()
 
-	// Expand "-xyz" into "-x -y -z" while leaving "--xyz" intact. This is a
-	// keystroke-saver for the user.
-	//
-	// This is OK to do globally here since Miller is quite consistent (in
-	// main, verbs, and auxents) that multi-character options start with two
-	// dashes, e.g. "--csv". (The sole exception is the sort verb's -nf/-nr
-	// which are handled specially there.)
-	os.Args = lib.Getoptify(os.Args)
-
 	// 'mlr repl' or 'mlr lecat' or any other non-miller-per-se toolery which
 	// is delivered (for convenience) within the mlr executable. If argv[1] is
 	// found then this function will not return.


### PR DESCRIPTION
Fixes issue #1789.