### PR TITLE
Add scoop install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There's a good chance you can get Miller pre-built for your system:
 |---|---|
 |Linux|`yum install miller`<br/> `apt-get install miller`|
 |Mac|`brew install miller`<br/>`port install miller`|
-|Windows|`choco install miller`<br/>`winget install Miller.Miller`|
+|Windows|`choco install miller`<br/>`winget install Miller.Miller`<br/>`scoop install main/miller`|
 
 See also [README-versions.md](./README-versions.md) for a full list of package versions. Note that long-term-support (LtS) releases will likely be on older versions.
 


### PR DESCRIPTION
Add `scoop install main/miller` to Windows installation options.