### PR TITLE
Update subs.go

### DIFF
--- a/pkg/transformers/subs.go
+++ b/pkg/transformers/subs.go
@@ -50,7 +50,7 @@ func transformerSubUsage(
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-f {a,b,c}  Field names to convert.\n")
 	fmt.Fprintf(o, "-r {regex}  Regular expression for field names to convert.\n")
-	fmt.Fprintf(o, "-a          Convert all field names.\n")
+	fmt.Fprintf(o, "-a          Convert all fields.\n")
 	fmt.Fprintf(o, "-h|--help   Show this message.\n")
 }
 
@@ -64,7 +64,7 @@ func transformerGsubUsage(
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-f {a,b,c}  Field names to convert.\n")
 	fmt.Fprintf(o, "-r {regex}  Regular expression for field names to convert.\n")
-	fmt.Fprintf(o, "-a          Convert all field names.\n")
+	fmt.Fprintf(o, "-a          Convert all fields.\n")
 	fmt.Fprintf(o, "-h|--help   Show this message.\n")
 }
 
@@ -77,7 +77,7 @@ func transformerSsubUsage(
 	fmt.Fprintf(o, "Options:\n")
 	fmt.Fprintf(o, "-f {a,b,c}  Field names to convert.\n")
 	fmt.Fprintf(o, "-r {regex}  Regular expression for field names to convert.\n")
-	fmt.Fprintf(o, "-a          Convert all field names.\n")
+	fmt.Fprintf(o, "-a          Convert all fields.\n")
 	fmt.Fprintf(o, "-h|--help   Show this message.\n")
 }
 


### PR DESCRIPTION
If I read “Convert all field names,” I think the verb acts on the field names. I think it would be better to write “Convert all fields.”