### PR TITLE
Allow any Go 1.24 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ module github.com/johnkerl/miller/v6
 // Local development:
 // replace github.com/johnkerl/lumin => /Users/kerl/git/johnkerl/lumin
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb


### PR DESCRIPTION
Miller doesn't require 1.24.5 specifically, reduce the language level to 1.24.0. This allows building with any 1.24 toolchain.