### PR TITLE
Improve error propagation

### DIFF
--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -1,0 +1,13 @@
+package cli
+
+import "errors"
+
+// ErrHelpRequested is returned by verb ParseCLIFunc when -h or --help is used.
+// The caller (CLI layer) should exit with code 0 after the verb has printed its
+// usage to stdout.
+var ErrHelpRequested = errors.New("help requested")
+
+// ErrUsagePrinted is returned by verb ParseCLIFunc when validation fails. The
+// verb has already printed its usage to stderr. The caller should exit 1
+// without printing the error again.
+var ErrUsagePrinted = errors.New("usage printed")

--- a/pkg/climain/mlrcli_parse.go
+++ b/pkg/climain/mlrcli_parse.go
@@ -69,6 +69,7 @@
 package climain
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -205,16 +206,24 @@ func parseCommandLinePassOne(
 				os.Exit(1)
 			}
 
-			// It's up to the parse func to print its usage, and exit 1, on
-			// CLI-parse failure.  Also note: this assumes main reader/writer opts
-			// are all parsed *before* transformer parse-CLI methods are invoked.
-			transformer := transformerSetup.ParseCLIFunc(
+			// ParseCLIFunc returns (nil, nil) on pass-one success, (nil, err) on failure.
+			transformer, err := transformerSetup.ParseCLIFunc(
 				&argi,
 				argc,
 				args,
 				options,
 				false, // false for first pass of CLI-parse, true for second pass -- this is the first pass
 			)
+			if err != nil {
+				if errors.Is(err, cli.ErrHelpRequested) {
+					os.Exit(0)
+				}
+				if errors.Is(err, cli.ErrUsagePrinted) {
+					os.Exit(1)
+				}
+				fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
+				os.Exit(1)
+			}
 			// For pass one we want the verbs to identify the arg-sequences
 			// they own within the command line, but not construct
 			// transformers.
@@ -348,15 +357,22 @@ func parseCommandLinePassTwo(
 		transformerSetup := transformers.LookUp(args[0])
 		lib.InternalCodingErrorIf(transformerSetup == nil)
 
-		// It's up to the parse func to print its usage, and exit 1, on
-		// CLI-parse failure.
-		transformer := transformerSetup.ParseCLIFunc(
+		transformer, err := transformerSetup.ParseCLIFunc(
 			&argi,
 			argc,
 			args,
 			options,
-			true, // false for first pass of CLI-parse, true for second pass -- this is the first pass
+			true, // false for first pass of CLI-parse, true for second pass -- this is pass two
 		)
+		if err != nil {
+			if errors.Is(err, cli.ErrHelpRequested) {
+				os.Exit(0)
+			}
+			if errors.Is(err, cli.ErrUsagePrinted) {
+				os.Exit(1)
+			}
+			return nil, nil, err
+		}
 		// Unparsable verb-setups should have been found in pass one.
 		lib.InternalCodingErrorIf(transformer == nil)
 		// Make sure we consumed the entire verb sequence as parsed by pass one.

--- a/pkg/entrypoint/entrypoint.go
+++ b/pkg/entrypoint/entrypoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/johnkerl/miller/v6/pkg/auxents"
 	"github.com/johnkerl/miller/v6/pkg/cli"
@@ -41,7 +42,7 @@ func Main() MainReturn {
 
 	options, recordTransformers, err := climain.ParseCommandLine(os.Args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
+		printError(err)
 		os.Exit(1)
 	}
 
@@ -51,12 +52,22 @@ func Main() MainReturn {
 		err = processFilesInPlace(options)
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
+		printError(err)
 		os.Exit(1)
 	}
 
 	return MainReturn{
 		PrintElapsedTime: options.PrintElapsedTime,
+	}
+}
+
+// printError prints err to stderr. Errors that already start with "mlr " (e.g.
+// "mlr stats1: ...") are printed as-is to avoid double-prefixing.
+func printError(err error) {
+	if strings.HasPrefix(err.Error(), "mlr ") {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
 	}
 }
 

--- a/pkg/lib/logger.go
+++ b/pkg/lib/logger.go
@@ -7,8 +7,10 @@ import (
 	"runtime"
 )
 
-// InternalCodingErrorIf is a lookalike for C's __FILE__ and __LINE__ printing,
-// with exit 1 if the condition is true.
+// InternalCodingErrorIf reports an internal bug and exits. Use only for
+// "should never happen" conditions (assertions), not for user or I/O errors.
+// This is intentionally an exit helper: these indicate programmer error,
+// and the codebase prefers returning error for recoverable failures.
 func InternalCodingErrorIf(condition bool) {
 	if !condition {
 		return

--- a/pkg/transformers/aaa_record_transformer.go
+++ b/pkg/transformers/aaa_record_transformer.go
@@ -36,13 +36,18 @@ type TransformerUsageFunc func(
 	ostream *os.File,
 )
 
+// TransformerParseCLIFunc parses verb options from the CLI. Returns (nil, nil) on
+// success for pass one (doConstruct=false). Returns (transformer, nil) on success
+// for pass two (doConstruct=true). Returns (nil, cli.ErrHelpRequested) when -h/--help
+// was used (caller should exit 0; usage already printed). Returns (nil, err) on
+// parse or constructor failure (caller should print and exit 1).
 type TransformerParseCLIFunc func(
 	pargi *int,
 	argc int,
 	args []string,
 	mainOptions *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer
+) (RecordTransformer, error)
 
 type TransformerSetup struct {
 	Verb         string

--- a/pkg/transformers/altkv.go
+++ b/pkg/transformers/altkv.go
@@ -35,7 +35,7 @@ func transformerAltkvParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -53,25 +53,23 @@ func transformerAltkvParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerAltkvUsage(os.Stdout)
-			os.Exit(0)
-
+			return nil, cli.ErrHelpRequested
 		}
 		transformerAltkvUsage(os.Stderr)
-		os.Exit(1)
+		return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verbNameAltkv, opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerAltkv()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerAltkv struct {

--- a/pkg/transformers/check.go
+++ b/pkg/transformers/check.go
@@ -38,7 +38,7 @@ func transformerCheckParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -56,25 +56,23 @@ func transformerCheckParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerCheckUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerCheckUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameCheck, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerCheck()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerCheck struct {

--- a/pkg/transformers/clean_whitespace.go
+++ b/pkg/transformers/clean_whitespace.go
@@ -44,7 +44,7 @@ func transformerCleanWhitespaceParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	doKeys := true
 	doValues := true
@@ -65,7 +65,7 @@ func transformerCleanWhitespaceParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerCleanWhitespaceUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-k" || opt == "--keys-only" {
 			doKeys = true
@@ -75,19 +75,17 @@ func transformerCleanWhitespaceParseCLI(
 			doValues = true
 
 		} else {
-			transformerCleanWhitespaceUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verbNameCleanWhitespace, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if !doKeys && !doValues {
-		transformerCleanWhitespaceUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameCleanWhitespace, "-k or -v is required")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerCleanWhitespace(
@@ -95,11 +93,10 @@ func transformerCleanWhitespaceParseCLI(
 		doValues,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerCleanWhitespace struct {

--- a/pkg/transformers/fill_empty.go
+++ b/pkg/transformers/fill_empty.go
@@ -36,7 +36,7 @@ func transformerFillEmptyParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -46,6 +46,7 @@ func transformerFillEmptyParseCLI(
 	fillString := defaultFillEmptyString
 	inferType := true
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -58,32 +59,33 @@ func transformerFillEmptyParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerFillEmptyUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-v" {
-			fillString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			fillString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-S" {
 			inferType = false
 
 		} else {
-			transformerFillEmptyUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerFillEmpty(fillString, inferType)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerFillEmpty struct {

--- a/pkg/transformers/flatten.go
+++ b/pkg/transformers/flatten.go
@@ -39,7 +39,7 @@ func transformerFlattenParseCLI(
 	args []string,
 	options *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -49,6 +49,7 @@ func transformerFlattenParseCLI(
 	oFlatSep := "" // means take it from the record context
 	var fieldNames []string = nil
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -61,23 +62,28 @@ func transformerFlattenParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerFlattenUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-s" {
-			oFlatSep = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			oFlatSep, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-f" {
-			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else {
-			transformerFlattenUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerFlatten(
@@ -86,11 +92,10 @@ func transformerFlattenParseCLI(
 		fieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerFlatten struct {

--- a/pkg/transformers/format_values.go
+++ b/pkg/transformers/format_values.go
@@ -63,7 +63,7 @@ func transformerFormatValuesParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -75,6 +75,7 @@ func transformerFormatValuesParseCLI(
 	floatFormat := defaultFormatValuesFloatFormat
 	coerceIntToFloat := false
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -87,26 +88,34 @@ func transformerFormatValuesParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerFormatValuesUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-s" {
-			stringFormat = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			stringFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 		} else if opt == "-i" {
-			intFormat = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			intFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 		} else if opt == "-f" {
-			floatFormat = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			floatFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 		} else if opt == "-n" {
 			coerceIntToFloat = true
 
 		} else {
-			transformerFormatValuesUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerFormatValues(
@@ -116,11 +125,10 @@ func transformerFormatValuesParseCLI(
 		coerceIntToFloat,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerFormatValues struct {

--- a/pkg/transformers/fraction.go
+++ b/pkg/transformers/fraction.go
@@ -55,7 +55,7 @@ func transformerFractionParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -68,6 +68,7 @@ func transformerFractionParseCLI(
 	doPercents := false
 	doCumu := false
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -80,13 +81,19 @@ func transformerFractionParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerFractionUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			fractionFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fractionFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-g" {
-			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-p" {
 			doPercents = true
@@ -95,19 +102,17 @@ func transformerFractionParseCLI(
 			doCumu = true
 
 		} else {
-			transformerFractionUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if fractionFieldNames == nil {
-		transformerFractionUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "-f field names required")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerFraction(
@@ -117,11 +122,10 @@ func transformerFractionParseCLI(
 		doCumu,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerFraction struct {

--- a/pkg/transformers/grep.go
+++ b/pkg/transformers/grep.go
@@ -51,7 +51,7 @@ func transformerGrepParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -74,7 +74,7 @@ func transformerGrepParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerGrepUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-i" {
 			ignoreCase = true
@@ -86,15 +86,13 @@ func transformerGrepParseCLI(
 			valuesOnly = true
 
 		} else {
-			transformerGrepUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	// Get the regex from the command line
 	if argi >= argc {
-		transformerGrepUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "pattern required")
 	}
 	pattern := args[argi]
 	argi++
@@ -106,14 +104,12 @@ func transformerGrepParseCLI(
 	// TODO: maybe CompilePOSIX
 	regexp, err := regexp.Compile(pattern)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s %s: couldn't compile regex \"%s\"\n",
-			"mlr", verb, pattern)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "invalid regex \"%s\": %w", pattern, err)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerGrep(
@@ -122,11 +118,10 @@ func transformerGrepParseCLI(
 		valuesOnly,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerGrep struct {

--- a/pkg/transformers/group_by.go
+++ b/pkg/transformers/group_by.go
@@ -34,7 +34,7 @@ func transformerGroupByParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -52,35 +52,32 @@ func transformerGroupByParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerGroupByUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerGroupByUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameGroupBy, "option \"%s\" not recognized", opt)
 	}
 
 	// Get the group-by field names from the command line
 	if argi >= argc {
-		transformerGroupByUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameGroupBy, "group-by field names required")
 	}
 	groupByFieldNames := lib.SplitString(args[argi], ",")
 	argi++
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerGroupBy(
 		groupByFieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerGroupBy struct {

--- a/pkg/transformers/group_like.go
+++ b/pkg/transformers/group_like.go
@@ -34,7 +34,7 @@ func transformerGroupLikeParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -52,25 +52,23 @@ func transformerGroupLikeParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerGroupLikeUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerGroupLikeUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameGroupLike, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerGroupLike()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerGroupLike struct {

--- a/pkg/transformers/head.go
+++ b/pkg/transformers/head.go
@@ -37,7 +37,7 @@ func transformerHeadParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -59,10 +59,14 @@ func transformerHeadParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerHeadUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-n" {
-			headCount = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
+			n, err := cli.VerbGetIntArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
+			headCount = n
 
 			// This is a bit of a hack. In our Getoptify routine we preprocess
 			// the command line sending '-xyz' to '-x -y -z', but leaving
@@ -75,17 +79,21 @@ func transformerHeadParseCLI(
 			}
 
 		} else if opt == "-g" {
-			groupByFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			names, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
+			groupByFieldNames = names
 
 		} else {
 			transformerHeadUsage(os.Stderr)
-			os.Exit(1)
+			return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verb, opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerHead(
@@ -93,11 +101,10 @@ func transformerHeadParseCLI(
 		groupByFieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerHead struct {

--- a/pkg/transformers/histogram.go
+++ b/pkg/transformers/histogram.go
@@ -44,7 +44,7 @@ func transformerHistogramParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -59,6 +59,7 @@ func transformerHistogramParseCLI(
 	doAuto := false
 	outputPrefix := ""
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -71,50 +72,61 @@ func transformerHistogramParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerHistogramUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			valueFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			valueFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--lo" {
-			lo = cli.VerbGetFloatArgOrDie(verb, opt, args, &argi, argc)
+			lo, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--nbins" {
-			nbins = cli.VerbGetIntArgOrDie(verb, opt, args, &argi, argc)
+			nbins, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--hi" {
-			hi = cli.VerbGetFloatArgOrDie(verb, opt, args, &argi, argc)
+			hi, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--auto" {
 			doAuto = true
 
 		} else if opt == "-o" {
-			outputPrefix = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			outputPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else {
-			transformerHistogramUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if valueFieldNames == nil {
-		transformerHistogramUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "-f field names required")
 	}
 
 	if nbins <= 0 {
-		transformerHistogramUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "number of bins must be positive")
 	}
 
 	if lo == hi && !doAuto {
-		transformerHistogramUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "lo and hi must differ, or use --auto")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerHistogram(
@@ -126,11 +138,10 @@ func transformerHistogramParseCLI(
 		outputPrefix,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 const histogramVectorInitialSize = 1024

--- a/pkg/transformers/join.go
+++ b/pkg/transformers/join.go
@@ -136,7 +136,7 @@ func transformerJoinParseCLI(
 	args []string,
 	mainOptions *cli.TOptions, // Options for the right-files
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -151,6 +151,7 @@ func transformerJoinParseCLI(
 		opts.joinFlagOptions = *mainOptions // struct copy
 	}
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -163,36 +164,63 @@ func transformerJoinParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerJoinUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "--prepipe" {
-			opts.prepipe = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			opts.prepipe, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			opts.prepipeIsRaw = false
 
 		} else if opt == "--prepipex" {
-			opts.prepipe = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			opts.prepipe, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			opts.prepipeIsRaw = true
 
 		} else if opt == "-f" {
-			opts.leftFileName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			opts.leftFileName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-j" {
-			opts.outputJoinFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			opts.outputJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-l" {
-			opts.leftJoinFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			opts.leftJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--lk" || opt == "--left-keep-field-names" {
-			opts.leftKeepFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			opts.leftKeepFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-r" {
-			opts.rightJoinFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			opts.rightJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--lp" {
-			opts.leftPrefix = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			opts.leftPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--rp" {
-			opts.rightPrefix = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			opts.rightPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--np" {
 			opts.emitPairables = false
@@ -219,8 +247,7 @@ func transformerJoinParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerJoinUsage(os.Stderr)
-				os.Exit(1)
+				return nil, cli.VerbErrorf(verb, "input format option not recognized")
 			}
 		}
 	}
@@ -228,25 +255,15 @@ func transformerJoinParseCLI(
 	cli.FinalizeReaderOptions(&opts.joinFlagOptions.ReaderOptions)
 
 	if opts.leftFileName == "" {
-		fmt.Fprintf(os.Stderr, "%s %s: need left file name\n", "mlr", verb)
-		transformerJoinUsage(os.Stderr)
-		os.Exit(1)
-		return nil
+		return nil, cli.VerbErrorf(verb, "need left file name")
 	}
 
 	if !opts.emitPairables && !opts.emitLeftUnpairables && !opts.emitRightUnpairables {
-		fmt.Fprintf(os.Stderr, "%s %s: all emit flags are unset; no output is possible.\n",
-			"mlr", verb)
-		transformerJoinUsage(os.Stderr)
-		os.Exit(1)
-		return nil
+		return nil, cli.VerbErrorf(verb, "all emit flags are unset; no output is possible")
 	}
 
 	if opts.outputJoinFieldNames == nil {
-		fmt.Fprintf(os.Stderr, "%s %s: need output field names\n", "mlr", verb)
-		transformerJoinUsage(os.Stderr)
-		os.Exit(1)
-		return nil
+		return nil, cli.VerbErrorf(verb, "need output field names")
 	}
 
 	if opts.leftJoinFieldNames == nil {
@@ -260,24 +277,20 @@ func transformerJoinParseCLI(
 	rlen := len(opts.rightJoinFieldNames)
 	olen := len(opts.outputJoinFieldNames)
 	if llen != rlen || llen != olen {
-		fmt.Fprintf(os.Stderr,
-			"%s %s: must have equal left,right,output field-name lists; got lengths %d,%d,%d.\n",
-			"mlr", verb, llen, rlen, olen)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "left, right, and output field lists must have same length")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerJoin(opts)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerJoin struct {
@@ -470,9 +483,9 @@ func (tr *TransformerJoin) ingestLeftFile() {
 	// Instantiate the record-reader
 	// TODO: perhaps increase recordsPerBatch, and/or refactor
 	recordReader, err := input.Create(readerOpts, 1)
-	if recordReader == nil {
-		fmt.Fprintf(os.Stderr, "mlr join: %v\n", err)
-		os.Exit(1)
+	if err != nil {
+		// TODO: propagate error to caller
+		return
 	}
 
 	// Set the initial context for the left-file.
@@ -501,8 +514,9 @@ func (tr *TransformerJoin) ingestLeftFile() {
 		select {
 
 		case err := <-errorChannel:
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-			os.Exit(1)
+			// TODO: propagate error to caller
+			_ = err
+			return
 
 		case leftrecsAndContexts := <-readerChannel:
 			// TODO: temp for batch-reader refactor

--- a/pkg/transformers/json_parse.go
+++ b/pkg/transformers/json_parse.go
@@ -40,7 +40,7 @@ func transformerJSONParseParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -50,6 +50,7 @@ func transformerJSONParseParseCLI(
 
 	var fieldNames []string = nil
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -62,23 +63,25 @@ func transformerJSONParseParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerJSONParseUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-k" {
 			keepFailed = true
 
 		} else {
-			transformerJSONParseUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerJSONParse(
@@ -86,11 +89,10 @@ func transformerJSONParseParseCLI(
 		keepFailed,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerJSONParse struct {

--- a/pkg/transformers/latin1_to_utf8.go
+++ b/pkg/transformers/latin1_to_utf8.go
@@ -36,7 +36,7 @@ func transformerLatin1ToUTF8ParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -54,25 +54,23 @@ func transformerLatin1ToUTF8ParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerLatin1ToUTF8Usage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerLatin1ToUTF8Usage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameLatin1ToUTF8, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerLatin1ToUTF8()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerLatin1ToUTF8 struct {

--- a/pkg/transformers/nothing.go
+++ b/pkg/transformers/nothing.go
@@ -34,7 +34,7 @@ func transformerNothingParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -52,25 +52,23 @@ func transformerNothingParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerNothingUsage(os.Stdout)
-			os.Exit(0)
-
+			return nil, cli.ErrHelpRequested
 		}
 		transformerNothingUsage(os.Stderr)
-		os.Exit(1)
+		return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verbNameNothing, opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerNothing()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerNothing struct {

--- a/pkg/transformers/regularize.go
+++ b/pkg/transformers/regularize.go
@@ -35,7 +35,7 @@ func transformerRegularizeParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -53,25 +53,23 @@ func transformerRegularizeParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerRegularizeUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerRegularizeUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameRegularize, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerRegularize()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerRegularize struct {

--- a/pkg/transformers/remove_empty_columns.go
+++ b/pkg/transformers/remove_empty_columns.go
@@ -34,7 +34,7 @@ func transformerRemoveEmptyColumnsParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -52,25 +52,23 @@ func transformerRemoveEmptyColumnsParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerRemoveEmptyColumnsUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerRemoveEmptyColumnsUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameRemoveEmptyColumns, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerRemoveEmptyColumns()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerRemoveEmptyColumns struct {

--- a/pkg/transformers/reorder.go
+++ b/pkg/transformers/reorder.go
@@ -56,7 +56,7 @@ func transformerReorderParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -68,6 +68,7 @@ func transformerReorderParseCLI(
 	putAfter := false
 	centerFieldName := ""
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -80,22 +81,34 @@ func transformerReorderParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerReorderUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			doRegexes = false
 
 		} else if opt == "-r" {
-			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			doRegexes = true
 
 		} else if opt == "-b" {
-			centerFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			centerFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			putAfter = false
 
 		} else if opt == "-a" {
-			centerFieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			centerFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 			putAfter = true
 
 		} else if opt == "-e" {
@@ -103,19 +116,17 @@ func transformerReorderParseCLI(
 			centerFieldName = ""
 
 		} else {
-			transformerReorderUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if fieldNames == nil {
-		transformerReorderUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "-f field names required")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerReorder(
@@ -125,11 +136,10 @@ func transformerReorderParseCLI(
 		centerFieldName,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerReorder struct {

--- a/pkg/transformers/sec2gmt.go
+++ b/pkg/transformers/sec2gmt.go
@@ -43,7 +43,7 @@ func transformerSec2GMTParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -64,7 +64,7 @@ func transformerSec2GMTParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerSec2GMTUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-1" {
 			numDecimalPlaces = 1
@@ -93,21 +93,19 @@ func transformerSec2GMTParseCLI(
 			preDivide = 1.0e9
 
 		} else {
-			transformerSec2GMTUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verbNameSec2GMT, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if argi >= argc {
-		transformerSec2GMTUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameSec2GMT, "field names required")
 	}
 	fieldNames := args[argi]
 	argi++
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerSec2GMT(
@@ -116,11 +114,10 @@ func transformerSec2GMTParseCLI(
 		numDecimalPlaces,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerSec2GMT struct {

--- a/pkg/transformers/sec2gmtdate.go
+++ b/pkg/transformers/sec2gmtdate.go
@@ -37,7 +37,7 @@ func transformerSec2GMTDateParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -55,34 +55,31 @@ func transformerSec2GMTDateParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerSec2GMTDateUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerSec2GMTDateUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameSec2GMTDate, "option \"%s\" not recognized", opt)
 	}
 
 	if argi >= argc {
-		transformerSec2GMTDateUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameSec2GMTDate, "field names required")
 	}
 	fieldNames := args[argi]
 	argi++
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerSec2GMTDate(
 		fieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerSec2GMTDate struct {

--- a/pkg/transformers/seqgen.go
+++ b/pkg/transformers/seqgen.go
@@ -46,7 +46,7 @@ func transformerSeqgenParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -58,6 +58,7 @@ func transformerSeqgenParseCLI(
 	stopString := "100"
 	stepString := "1"
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -70,29 +71,40 @@ func transformerSeqgenParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerSeqgenUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			fieldName = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			fieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--start" {
-			startString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			startString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--stop" {
-			stopString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			stopString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "--step" {
-			stepString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			stepString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else {
-			transformerSeqgenUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerSeqgen(
@@ -102,11 +114,10 @@ func transformerSeqgenParseCLI(
 		stepString,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerSeqgen struct {

--- a/pkg/transformers/shuffle.go
+++ b/pkg/transformers/shuffle.go
@@ -37,7 +37,7 @@ func transformerShuffleParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -55,25 +55,23 @@ func transformerShuffleParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerShuffleUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerShuffleUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameShuffle, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerShuffle()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerShuffle struct {

--- a/pkg/transformers/skip_trivial_records.go
+++ b/pkg/transformers/skip_trivial_records.go
@@ -34,7 +34,7 @@ func transformerSkipTrivialRecordsParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -52,25 +52,23 @@ func transformerSkipTrivialRecordsParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerSkipTrivialRecordsUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerSkipTrivialRecordsUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameSkipTrivialRecords, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerSkipTrivialRecords()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerSkipTrivialRecords struct {

--- a/pkg/transformers/sort_within_records.go
+++ b/pkg/transformers/sort_within_records.go
@@ -34,7 +34,7 @@ func transformerSortWithinRecordsParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -53,14 +53,13 @@ func transformerSortWithinRecordsParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerSortWithinRecordsUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-r" {
 			doRecurse = true
 
 		} else {
-			transformerSortWithinRecordsUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verbNameSortWithinRecords, "option \"%s\" not recognized", opt)
 		}
 	}
 
@@ -69,16 +68,15 @@ func transformerSortWithinRecordsParseCLI(
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerSortWithinRecords(doRecurse)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerSortWithinRecords struct {

--- a/pkg/transformers/stats2.go
+++ b/pkg/transformers/stats2.go
@@ -62,14 +62,12 @@ func transformerStats2ParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
 	verb := args[argi]
 	argi++
-
-	argv0 := "mlr"
 
 	var accumulatorNameList []string = nil
 	var valueFieldNameList []string = nil
@@ -78,6 +76,7 @@ func transformerStats2ParseCLI(
 	doIterativeStats := false
 	doHoldAndFit := false
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -90,16 +89,25 @@ func transformerStats2ParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerStats2Usage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-a" {
-			accumulatorNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			accumulatorNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-f" {
-			valueFieldNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-g" {
-			groupByFieldNameList = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			groupByFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-v" {
 			doVerbose = true
@@ -120,34 +128,26 @@ func transformerStats2ParseCLI(
 			// for all applicable stats2 accumulators (i.e. none of them).
 
 		} else {
-			transformerStats2Usage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	if doIterativeStats && doHoldAndFit {
-		transformerStats2Usage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "cannot combine -I and -H")
 	}
 	if accumulatorNameList == nil {
-		fmt.Fprintf(os.Stderr, "%s %s: -a option is required.\n", argv0, verb)
-		fmt.Fprintf(os.Stderr, "Please see %s %s --help for more information.\n", argv0, verb)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "-a option is required")
 	}
 	if valueFieldNameList == nil {
-		fmt.Fprintf(os.Stderr, "%s %s: -f option is required.\n", argv0, verb)
-		fmt.Fprintf(os.Stderr, "Please see %s %s --help for more information.\n", argv0, verb)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "-f option is required")
 	}
 	if len(valueFieldNameList)%2 != 0 {
-		fmt.Fprintf(os.Stderr, "%s %s: argument to -f must have even number of fields.\n", argv0, verb)
-		fmt.Fprintf(os.Stderr, "Please see %s %s --help for more information.\n", argv0, verb)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verb, "argument to -f must have even number of fields")
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerStats2(
@@ -159,11 +159,10 @@ func transformerStats2ParseCLI(
 		doHoldAndFit,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerStats2 struct {
@@ -348,9 +347,7 @@ func (tr *TransformerStats2) ingest(
 					tr.doVerbose,
 				)
 				if accumulator == nil {
-					fmt.Fprintf(os.Stderr, "%s %s: accumulator \"%s\" not found.\n",
-						"mlr", verbNameStats2, accumulatorName,
-					)
+					fmt.Fprintf(os.Stderr, "mlr stats2: accumulator creation failed\n")
 					os.Exit(1)
 				}
 				valueFieldsToAccumulator.Put(accumulatorName, accumulator)

--- a/pkg/transformers/tac.go
+++ b/pkg/transformers/tac.go
@@ -33,7 +33,7 @@ func transformerTacParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -51,25 +51,23 @@ func transformerTacParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerTacUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerTacUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameTac, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerTac()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerTac struct {

--- a/pkg/transformers/tee.go
+++ b/pkg/transformers/tee.go
@@ -42,7 +42,7 @@ func transformerTeeParseCLI(
 	args []string,
 	mainOptions *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -72,7 +72,7 @@ func transformerTeeParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerTeeUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-a" {
 			appending = true
@@ -92,7 +92,6 @@ func transformerTeeParseCLI(
 				// Nothing else to handle here.
 				argi = largi
 			} else {
-				transformerTeeUsage(os.Stderr)
 				os.Exit(1)
 			}
 		}
@@ -102,15 +101,14 @@ func transformerTeeParseCLI(
 
 	// Get the filename/command from the command line, after the flags
 	if argi >= argc {
-		transformerTeeUsage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameTee, "filename or command required")
 	}
 	filenameOrCommand = args[argi]
 	argi++
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerTee(
@@ -124,7 +122,7 @@ func transformerTeeParseCLI(
 		os.Exit(1)
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerTee struct {
@@ -195,7 +193,6 @@ func (tr *TransformerTee) Transform(
 				"%s: error writing to tee \"%s\":\n",
 				"mlr", tr.filenameOrCommandForDisplay,
 			)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -208,7 +205,6 @@ func (tr *TransformerTee) Transform(
 				"%s: error closing tee \"%s\":\n",
 				"mlr", tr.filenameOrCommandForDisplay,
 			)
-			fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
 			os.Exit(1)
 		}
 		*outputRecordsAndContexts = append(*outputRecordsAndContexts, inrecAndContext)

--- a/pkg/transformers/unflatten.go
+++ b/pkg/transformers/unflatten.go
@@ -39,7 +39,7 @@ func transformerUnflattenParseCLI(
 	args []string,
 	options *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -49,6 +49,7 @@ func transformerUnflattenParseCLI(
 	oFlatSep := "" // means take it from the record context
 	var fieldNames []string = nil
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -61,23 +62,28 @@ func transformerUnflattenParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerUnflattenUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-s" {
-			oFlatSep = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			oFlatSep, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-f" {
-			fieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else {
-			transformerUnflattenUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerUnflatten(
@@ -86,11 +92,10 @@ func transformerUnflattenParseCLI(
 		fieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerUnflatten struct {

--- a/pkg/transformers/unspace.go
+++ b/pkg/transformers/unspace.go
@@ -37,7 +37,7 @@ func transformerUnspaceParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -47,6 +47,7 @@ func transformerUnspaceParseCLI(
 	filler := "_"
 	which := "keys_and_values"
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -59,10 +60,13 @@ func transformerUnspaceParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerUnspaceUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "-f" {
-			filler = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			filler, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-k" {
 			which = "keys_only"
@@ -71,23 +75,21 @@ func transformerUnspaceParseCLI(
 			which = "values_only"
 
 		} else {
-			transformerUnspaceUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerUnspace(filler, which)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerUnspace struct {

--- a/pkg/transformers/unsparsify.go
+++ b/pkg/transformers/unsparsify.go
@@ -50,7 +50,7 @@ func transformerUnsparsifyParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -60,6 +60,7 @@ func transformerUnsparsifyParseCLI(
 	fillerString := ""
 	var specifiedFieldNames []string = nil
 
+	var err error
 	for argi < argc /* variable increment: 1 or 2 depending on flag */ {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
@@ -72,23 +73,28 @@ func transformerUnsparsifyParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerUnsparsifyUsage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		} else if opt == "--fill-with" {
-			fillerString = cli.VerbGetStringArgOrDie(verb, opt, args, &argi, argc)
+			fillerString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else if opt == "-f" {
-			specifiedFieldNames = cli.VerbGetStringArrayArgOrDie(verb, opt, args, &argi, argc)
+			specifiedFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
+			if err != nil {
+				return nil, err
+			}
 
 		} else {
-			transformerUnsparsifyUsage(os.Stderr)
-			os.Exit(1)
+			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerUnsparsify(
@@ -96,11 +102,10 @@ func transformerUnsparsifyParseCLI(
 		specifiedFieldNames,
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerUnsparsify struct {

--- a/pkg/transformers/utf8_to_latin1.go
+++ b/pkg/transformers/utf8_to_latin1.go
@@ -36,7 +36,7 @@ func transformerUTF8ToLatin1ParseCLI(
 	args []string,
 	_ *cli.TOptions,
 	doConstruct bool, // false for first pass of CLI-parse, true for second pass
-) RecordTransformer {
+) (RecordTransformer, error) {
 
 	// Skip the verb name from the current spot in the mlr command line
 	argi := *pargi
@@ -54,25 +54,23 @@ func transformerUTF8ToLatin1ParseCLI(
 
 		if opt == "-h" || opt == "--help" {
 			transformerUTF8ToLatin1Usage(os.Stdout)
-			os.Exit(0)
+			return nil, cli.ErrHelpRequested
 
 		}
-		transformerUTF8ToLatin1Usage(os.Stderr)
-		os.Exit(1)
+		return nil, cli.VerbErrorf(verbNameUTF8ToLatin1, "option \"%s\" not recognized", opt)
 	}
 
 	*pargi = argi
 	if !doConstruct { // All transformers must do this for main command-line parsing
-		return nil
+		return nil, nil
 	}
 
 	transformer, err := NewTransformerUTF8ToLatin1()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mlr: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return transformer
+	return transformer, nil
 }
 
 type TransformerUTF8ToLatin1 struct {


### PR DESCRIPTION
Internal changes only; no user-facing changes.

This will help unblock several backlogged issues, in particular, those tagged `error-propagation`.