### PR TITLE
No exit from `mlr repl` when function is not found

### DIFF
--- a/pkg/dsl/cst/udf.go
+++ b/pkg/dsl/cst/udf.go
@@ -123,7 +123,11 @@ func (site *UDFCallsite) Evaluate(
 
 	udf := site.findUDF(state)
 	if udf == nil {
-		fmt.Fprintln(os.Stderr, "mlr: function name not found: "+site.functionName)
+		msg := "mlr: function name not found: " + site.functionName
+		if state.NoExitOnFunctionNotFound {
+			return mlrval.FromErrorString(msg)
+		}
+		fmt.Fprintln(os.Stderr, msg)
 		os.Exit(1)
 	}
 	lib.InternalCodingErrorIf(udf.functionBody == nil)

--- a/pkg/runtime/state.go
+++ b/pkg/runtime/state.go
@@ -37,6 +37,10 @@ type State struct {
 
 	// StrictMode allows for runtime handling of absent-reads and untyped assignments.
 	StrictMode bool
+
+	// NoExitOnFunctionNotFound is used by the REPL: when true, a call to an
+	// undefined function returns an error mlrval instead of exiting the process.
+	NoExitOnFunctionNotFound bool
 }
 
 func NewEmptyState(options *cli.TOptions, strictMode bool) *State {

--- a/pkg/terminals/repl/session.go
+++ b/pkg/terminals/repl/session.go
@@ -62,6 +62,7 @@ func NewRepl(
 	context := types.NewContext()
 
 	runtimeState := runtime.NewEmptyState(options, strictMode)
+	runtimeState.NoExitOnFunctionNotFound = true
 	runtimeState.Update(inrec, context)
 	// The filter expression for the main Miller DSL is any non-assignment
 	// statement like 'true' or '$x > 0.5' etc. For the REPL, we re-use this for


### PR DESCRIPTION
Resolves #1820