### PR TITLE
Add unicode printing support for barred output

### DIFF
--- a/pkg/cli/option_parse.go
+++ b/pkg/cli/option_parse.go
@@ -541,6 +541,16 @@ var PPRINTOnlyFlagSection = FlagSection{
 		},
 
 		{
+			name: "--barred-unicode",
+			help: "Uses unicode printing chars for barred output",
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.WriterOptions.BarredPprintOutput = true
+				options.WriterOptions.BarredUseUnicode = true
+				*pargi += 1
+			},
+		},
+
+		{
 			name: "--barred-input",
 			help: "When used in conjunction with --pprint, accepts barred input.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {

--- a/pkg/cli/option_types.go
+++ b/pkg/cli/option_types.go
@@ -96,6 +96,7 @@ type TWriterOptions struct {
 
 	HeaderlessOutput         bool
 	BarredPprintOutput       bool
+	BarredUseUnicode         bool
 	RightAlignedPPRINTOutput bool
 	RightAlignedXTABOutput   bool
 


### PR DESCRIPTION
Add flag `--barred-unicode` that makes the output table prettier using unicode characters.

@johnkerl 
1. Please confirm if the cli flag and implementation looks good. I will update docs and add tests.
2. Should there be `reader` support as well. If so, can that be deferred for later?

```
❯ echo "foo,bar\n1,2" | go run cmd/mlr/main.go --c2p --barred cat
+-----+-----+
| foo | bar |
+-----+-----+
| 1   | 2   |
+-----+-----+

miller on  barred-unicode via 🐹 v1.26.0-X:nodwarf5
❯ echo "foo,bar\n1,2" | go run cmd/mlr/main.go --c2p --barred-unicode cat
┌─────┬─────┐
│ foo │ bar │
├─────┼─────┤
│ 1   │ 2   │
└─────┴─────┘

miller on  barred-unicode via 🐹 v1.26.0-X:nodwarf5
❯ echo "foo,bar\n1,2" | go run cmd/mlr/main.go --c2p --barred cat | cat
+-----+-----+
| foo | bar |
+-----+-----+
| 1   | 2   |
+-----+-----+

miller on  barred-unicode via 🐹 v1.26.0-X:nodwarf5
❯ echo "foo,bar\n1,2" | go run cmd/mlr/main.go --c2p --barred-unicode cat | cat
┌─────┬─────┐
│ foo │ bar │
├─────┼─────┤
│ 1   │ 2   │
└─────┴─────┘

```

<img width="684" height="630" alt="image" src="https://github.com/user-attachments/assets/e0436d83-da3e-4de1-807b-9e9786fbb805" />

---

