### PR TITLE
Add DKVPX file format

### DIFF
--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -103,6 +103,12 @@ DKVP: delimited key-value pairs (Miller default format)
 | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
 +---------------------+
 
+DKVPX: delimited key-value pairs with CSV-style quoting
++----------------------------------+
+| apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+| "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
++----------------------------------+
+
 NIDX: implicitly numerically indexed (Unix-toolkit style)
 +---------------------+
 | the quick brown     | Record 1: "1":"the", "2":"quick", "3":"brown"
@@ -660,6 +666,10 @@ resource=/some/other/path,loadsec=0.97,ok=false
 etc., and I log them as needed. Then later, I can use `grep`, `mlr --opprint group-like`, etc. to analyze my logs.
 
 See the [separators page](reference-main-separators.md) regarding how to specify separators other than the default equals sign and comma.
+
+## DKVPX: Key-value pairs with CSV-style quoting
+
+DKVPX is like DKVP but with CSV-style double-quote handling. Keys and values that contain comma, equals, newline, or double-quote are quoted as needed; unquoted keys and values work as in DKVP. Examples: `x=1,y=2,z=3` and `"x,y"="a,b,c",z=3`. Use the `--dkvpx` flag for input and output. See the [separators page](reference-main-separators.md) for IFS/IPS. For simpler data without special characters, use [DKVP](#dkvp-key-value-pairs) instead.
 
 ## NIDX: Index-numbered (toolkit style)
 

--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -671,6 +671,8 @@ See the [separators page](reference-main-separators.md) regarding how to specify
 
 DKVPX is like DKVP but with CSV-style double-quote handling. Keys and values that contain comma, equals, newline, or double-quote are quoted as needed; unquoted keys and values work as in DKVP. Examples: `x=1,y=2,z=3` and `"x,y"="a,b,c",z=3`. Use the `--dkvpx` flag for input and output. See the [separators page](reference-main-separators.md) for IFS/IPS. For simpler data without special characters, use [DKVP](#dkvp-key-value-pairs) instead.
 
+The default is DKVP, not DKVPX, since performance tests show DKVP is approximately 30% faster for cases when quoting is not necessary.
+
 ## NIDX: Index-numbered (toolkit style)
 
 With `--inidx --ifs ' ' --repifs`, Miller splits lines on spaces and assigns integer field names starting with 1.

--- a/docs/src/file-formats.md.in
+++ b/docs/src/file-formats.md.in
@@ -326,6 +326,10 @@ etc., and I log them as needed. Then later, I can use `grep`, `mlr --opprint gro
 
 See the [separators page](reference-main-separators.md) regarding how to specify separators other than the default equals sign and comma.
 
+## DKVPX: Key-value pairs with CSV-style quoting
+
+DKVPX is like DKVP but with CSV-style double-quote handling. Keys and values that contain comma, equals, newline, or double-quote are quoted as needed; unquoted keys and values work as in DKVP. Examples: `x=1,y=2,z=3` and `"x,y"="a,b,c",z=3`. Use the `--dkvpx` flag for input and output. See the [separators page](reference-main-separators.md) for IFS/IPS. For simpler data without special characters, use [DKVP](#dkvp-key-value-pairs) instead.
+
 ## NIDX: Index-numbered (toolkit style)
 
 With `--inidx --ifs ' ' --repifs`, Miller splits lines on spaces and assigns integer field names starting with 1.

--- a/docs/src/file-formats.md.in
+++ b/docs/src/file-formats.md.in
@@ -330,6 +330,8 @@ See the [separators page](reference-main-separators.md) regarding how to specify
 
 DKVPX is like DKVP but with CSV-style double-quote handling. Keys and values that contain comma, equals, newline, or double-quote are quoted as needed; unquoted keys and values work as in DKVP. Examples: `x=1,y=2,z=3` and `"x,y"="a,b,c",z=3`. Use the `--dkvpx` flag for input and output. See the [separators page](reference-main-separators.md) for IFS/IPS. For simpler data without special characters, use [DKVP](#dkvp-key-value-pairs) instead.
 
+The default is DKVP, not DKVPX, since performance tests show DKVP is approximately 30% faster for cases when quoting is not necessary.
+
 ## NIDX: Index-numbered (toolkit style)
 
 With `--inidx --ifs ' ' --repifs`, Miller splits lines on spaces and assigns integer field names starting with 1.

--- a/docs/src/flags.txt
+++ b/docs/src/flags.txt
@@ -37,6 +37,7 @@
 "--d2t"
 "--d2x"
 "--dkvp"
+"--dkvpx"
 "--fail-color"
 "--flatsep"
 "--from"

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -154,6 +154,10 @@ of the form `x=1,y=2,z=3`.  For historical reasons, this is Miller's default
 format unless [flags](reference-main-flag-list.md) such as `--csv` are
 supplied.  You can also make CSV your default format using a [.mlrrc file](customization.md).
 
+## DKVPX
+
+Miller [file format](file-formats.md#dkvpx-key-value-pairs-with-csv-style-quoting) for delimited key-value pairs with CSV-style quoting. An extension of [DKVP](#dkvp) where keys and values may contain commas, equals, newlines, and quotes via double-quote escaping. Use the `--dkvpx` [flag](reference-main-flag-list.md).
+
 ## do
 
 A [keyword](#keyword) which is used to indicate the start of a [do-while loop](reference-dsl-control-structures.md)

--- a/docs/src/glossary.md.in
+++ b/docs/src/glossary.md.in
@@ -138,6 +138,10 @@ of the form `x=1,y=2,z=3`.  For historical reasons, this is Miller's default
 format unless [flags](reference-main-flag-list.md) such as `--csv` are
 supplied.  You can also make CSV your default format using a [.mlrrc file](customization.md).
 
+## DKVPX
+
+Miller [file format](file-formats.md#dkvpx-key-value-pairs-with-csv-style-quoting) for delimited key-value pairs with CSV-style quoting. An extension of [DKVP](#dkvp) where keys and values may contain commas, equals, newlines, and quotes via double-quote escaping. Use the `--dkvpx` [flag](reference-main-flag-list.md).
+
 ## do
 
 A [keyword](#keyword) which is used to indicate the start of a [do-while loop](reference-dsl-control-structures.md)

--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -135,6 +135,12 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
        +---------------------+
 
+       DKVPX: delimited key-value pairs with CSV-style quoting
+       +----------------------------------+
+       | apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+       | "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
+       +----------------------------------+
+
        NIDX: implicitly numerically indexed (Unix-toolkit style)
        +---------------------+
        | the quick brown     | Record 1: "1":"the", "2":"quick", "3":"brown"
@@ -407,6 +413,7 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        --dcf                    Use Debian control file (DCF) format for input and
                                 output data.
        --dkvp or --d2d          Use DKVP format for input and output data.
+       --dkvpx                  Use DKVPX format for input and output data.
        --gen-field-name         Specify field name for --igen. Defaults to "i".
        --gen-start              Specify start value for --igen. Defaults to 1.
        --gen-step               Specify step value for --igen. Defaults to 1.
@@ -750,6 +757,11 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        --barred-input           When used in conjunction with --pprint, accepts
                                 barred input.
        --barred-unicode         Uses unicode printing chars for barred output
+       --fixed {string}         Fixed width specification. One of
+                                'widths:&lt;col1-width&gt;,&lt;col2-width&gt;,...', left-align,
+                                left-align-multi-word, right-align,
+                                right-align-multi-word
+       --fw {string}            Shortcut for --fixed left-align-multi-word
        --right                  Right-justifies all fields for PPRINT output.
 
 1mPROFILING FLAGS0m
@@ -855,6 +867,7 @@ This is simply a copy of what you should see on running `man mlr` at a command p
                csvlite  ","    N/A    "\n"
                dcf      N/A    N/A    N/A
                dkvp     ","    "="    "\n"
+               dkvpx    ","    "="    "\n"
                gen      ","    N/A    "\n"
                json     N/A    N/A    N/A
                markdown " "    N/A    "\n"
@@ -3804,5 +3817,5 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-02-22                         4mMILLER24m(1)
+                                  2026-03-03                         4mMILLER24m(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -114,6 +114,12 @@
        | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
        +---------------------+
 
+       DKVPX: delimited key-value pairs with CSV-style quoting
+       +----------------------------------+
+       | apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+       | "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
+       +----------------------------------+
+
        NIDX: implicitly numerically indexed (Unix-toolkit style)
        +---------------------+
        | the quick brown     | Record 1: "1":"the", "2":"quick", "3":"brown"
@@ -386,6 +392,7 @@
        --dcf                    Use Debian control file (DCF) format for input and
                                 output data.
        --dkvp or --d2d          Use DKVP format for input and output data.
+       --dkvpx                  Use DKVPX format for input and output data.
        --gen-field-name         Specify field name for --igen. Defaults to "i".
        --gen-start              Specify start value for --igen. Defaults to 1.
        --gen-step               Specify step value for --igen. Defaults to 1.
@@ -729,6 +736,11 @@
        --barred-input           When used in conjunction with --pprint, accepts
                                 barred input.
        --barred-unicode         Uses unicode printing chars for barred output
+       --fixed {string}         Fixed width specification. One of
+                                'widths:<col1-width>,<col2-width>,...', left-align,
+                                left-align-multi-word, right-align,
+                                right-align-multi-word
+       --fw {string}            Shortcut for --fixed left-align-multi-word
        --right                  Right-justifies all fields for PPRINT output.
 
 1mPROFILING FLAGS0m
@@ -834,6 +846,7 @@
                csvlite  ","    N/A    "\n"
                dcf      N/A    N/A    N/A
                dkvp     ","    "="    "\n"
+               dkvpx    ","    "="    "\n"
                gen      ","    N/A    "\n"
                json     N/A    N/A    N/A
                markdown " "    N/A    "\n"
@@ -3783,4 +3796,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-02-22                         4mMILLER24m(1)
+                                  2026-03-03                         4mMILLER24m(1)

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -157,6 +157,7 @@ are overridden in all cases by setting output format to `format2`.
 * `--csvlite`: Use CSV-lite format for input and output data.
 * `--dcf`: Use Debian control file (DCF) format for input and output data.
 * `--dkvp or --d2d`: Use DKVP format for input and output data.
+* `--dkvpx`: Use DKVPX format for input and output data.
 * `--gen-field-name`: Specify field name for --igen. Defaults to "i".
 * `--gen-start`: Specify start value for --igen. Defaults to 1.
 * `--gen-step`: Specify step value for --igen. Defaults to 1.
@@ -398,6 +399,8 @@ These are flags which are applicable to PPRINT format.
 * `--barred or --barred-output`: Prints a border around PPRINT output.
 * `--barred-input`: When used in conjunction with --pprint, accepts barred input.
 * `--barred-unicode`: Uses unicode printing chars for barred output
+* `--fixed {string}`: Fixed width specification. One of 'widths:<col1-width>,<col2-width>,...', left-align, left-align-multi-word, right-align, right-align-multi-word
+* `--fw {string}`: Shortcut for --fixed left-align-multi-word
 * `--right`: Right-justifies all fields for PPRINT output.
 
 ## Profiling flags
@@ -500,6 +503,7 @@ Notes about all other separators:
         csvlite  ","    N/A    "\n"
         dcf      N/A    N/A    N/A
         dkvp     ","    "="    "\n"
+        dkvpx    ","    "="    "\n"
         gen      ","    N/A    "\n"
         json     N/A    N/A    N/A
         markdown " "    N/A    "\n"

--- a/docs/src/reference-main-separators.md
+++ b/docs/src/reference-main-separators.md
@@ -278,6 +278,7 @@ Notes:
 | [**YAML**](file-formats.md#yaml)   | N/A; documents separated by `---` or single array   | N/A; not alterable    | Always `:`; not alterable |
 | [**DCF**](file-formats.md#dcf-debian-control-file)   | N/A; paragraphs separated by blank lines   | N/A; not alterable    | Always `:`; not alterable |
 | [**DKVP**](file-formats.md#dkvp-key-value-pairs)   | Default `\n`    | Default `,`    | Default `=` |
+| [**DKVPX**](file-formats.md#dkvpx-key-value-pairs-with-csv-style-quoting)   | Default `\n`    | Default `,`    | Default `=` |
 | [**NIDX**](file-formats.md#nidx-index-numbered-toolkit-style)   | Default `\n`    | Default space    | None     |
 | [**XTAB**](file-formats.md#xtab-vertical-tabular)   | Not used; records are separated by an extra FS    | `\n` *    | Default: space with repeats  |
 | [**PPRINT**](file-formats.md#pprint-pretty-printed-tabular) | Default `\n` *    | Space with repeats    | None     |

--- a/docs/src/reference-main-separators.md.in
+++ b/docs/src/reference-main-separators.md.in
@@ -168,6 +168,7 @@ Notes:
 | [**YAML**](file-formats.md#yaml)   | N/A; documents separated by `---` or single array   | N/A; not alterable    | Always `:`; not alterable |
 | [**DCF**](file-formats.md#dcf-debian-control-file)   | N/A; paragraphs separated by blank lines   | N/A; not alterable    | Always `:`; not alterable |
 | [**DKVP**](file-formats.md#dkvp-key-value-pairs)   | Default `\n`    | Default `,`    | Default `=` |
+| [**DKVPX**](file-formats.md#dkvpx-key-value-pairs-with-csv-style-quoting)   | Default `\n`    | Default `,`    | Default `=` |
 | [**NIDX**](file-formats.md#nidx-index-numbered-toolkit-style)   | Default `\n`    | Default space    | None     |
 | [**XTAB**](file-formats.md#xtab-vertical-tabular)   | Not used; records are separated by an extra FS    | `\n` *    | Default: space with repeats  |
 | [**PPRINT**](file-formats.md#pprint-pretty-printed-tabular) | Default `\n` *    | Space with repeats    | None     |

--- a/docs/src/special-symbols-and-formatting.md
+++ b/docs/src/special-symbols-and-formatting.md
@@ -80,6 +80,8 @@ Name=Xiao, Lin|Role=administrator
 Name=Khavari, Darius|Role=tester
 </pre>
 
+Alternatively, use DKVPX format with `--dkvpx`, which supports CSV-style quoting so keys and values may contain commas, equals, newlines, and quotes natively. Example: `echo '"a,b"="x,y",z=3' | mlr --dkvpx cat`
+
 To be extra-sure to avoid data/delimiter clashes, you can also use control
 characters as delimiters -- here, control-A:
 

--- a/docs/src/special-symbols-and-formatting.md.in
+++ b/docs/src/special-symbols-and-formatting.md.in
@@ -32,6 +32,8 @@ GENMD-RUN-COMMAND
 mlr --icsv --odkvp --ofs pipe cat commas.csv
 GENMD-EOF
 
+Alternatively, use DKVPX format with `--dkvpx`, which supports CSV-style quoting so keys and values may contain commas, equals, newlines, and quotes natively. Example: `echo '"a,b"="x,y",z=3' | mlr --dkvpx cat`
+
 To be extra-sure to avoid data/delimiter clashes, you can also use control
 characters as delimiters -- here, control-A:
 

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -114,6 +114,12 @@
        | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
        +---------------------+
 
+       DKVPX: delimited key-value pairs with CSV-style quoting
+       +----------------------------------+
+       | apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+       | "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
+       +----------------------------------+
+
        NIDX: implicitly numerically indexed (Unix-toolkit style)
        +---------------------+
        | the quick brown     | Record 1: "1":"the", "2":"quick", "3":"brown"
@@ -386,6 +392,7 @@
        --dcf                    Use Debian control file (DCF) format for input and
                                 output data.
        --dkvp or --d2d          Use DKVP format for input and output data.
+       --dkvpx                  Use DKVPX format for input and output data.
        --gen-field-name         Specify field name for --igen. Defaults to "i".
        --gen-start              Specify start value for --igen. Defaults to 1.
        --gen-step               Specify step value for --igen. Defaults to 1.
@@ -729,6 +736,11 @@
        --barred-input           When used in conjunction with --pprint, accepts
                                 barred input.
        --barred-unicode         Uses unicode printing chars for barred output
+       --fixed {string}         Fixed width specification. One of
+                                'widths:<col1-width>,<col2-width>,...', left-align,
+                                left-align-multi-word, right-align,
+                                right-align-multi-word
+       --fw {string}            Shortcut for --fixed left-align-multi-word
        --right                  Right-justifies all fields for PPRINT output.
 
 1mPROFILING FLAGS0m
@@ -834,6 +846,7 @@
                csvlite  ","    N/A    "\n"
                dcf      N/A    N/A    N/A
                dkvp     ","    "="    "\n"
+               dkvpx    ","    "="    "\n"
                gen      ","    N/A    "\n"
                json     N/A    N/A    N/A
                markdown " "    N/A    "\n"
@@ -3783,4 +3796,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-02-22                         4mMILLER24m(1)
+                                  2026-03-03                         4mMILLER24m(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2026-02-22
+.\"      Date: 2026-03-03
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2026-02-22" "\ \&" "\ \&"
+.TH "MILLER" "1" "2026-03-03" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,6 +144,12 @@ DKVP: delimited key-value pairs (Miller default format)
 | apple=1,bat=2,cog=3 | Record 1: "apple":"1", "bat":"2", "cog":"3"
 | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
 +---------------------+
+
+DKVPX: delimited key-value pairs with CSV-style quoting
++----------------------------------+
+| apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+| "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
++----------------------------------+
 
 NIDX: implicitly numerically indexed (Unix-toolkit style)
 +---------------------+
@@ -475,6 +481,7 @@ are overridden in all cases by setting output format to `format2`.
 --dcf                    Use Debian control file (DCF) format for input and
                          output data.
 --dkvp or --d2d          Use DKVP format for input and output data.
+--dkvpx                  Use DKVPX format for input and output data.
 --gen-field-name         Specify field name for --igen. Defaults to "i".
 --gen-start              Specify start value for --igen. Defaults to 1.
 --gen-step               Specify step value for --igen. Defaults to 1.
@@ -874,6 +881,11 @@ These are flags which are applicable to PPRINT format.
 --barred-input           When used in conjunction with --pprint, accepts
                          barred input.
 --barred-unicode         Uses unicode printing chars for barred output
+--fixed {string}         Fixed width specification. One of
+                         'widths:<col1-width>,<col2-width>,...', left-align,
+                         left-align-multi-word, right-align,
+                         right-align-multi-word
+--fw {string}            Shortcut for --fixed left-align-multi-word
 --right                  Right-justifies all fields for PPRINT output.
 .fi
 .if n \{\
@@ -995,6 +1007,7 @@ Notes about all other separators:
         csvlite  ","    N/A    "\en"
         dcf      N/A    N/A    N/A
         dkvp     ","    "="    "\en"
+        dkvpx    ","    "="    "\en"
         gen      ","    N/A    "\en"
         json     N/A    N/A    N/A
         markdown " "    N/A    "\en"

--- a/pkg/cli/option_parse.go
+++ b/pkg/cli/option_parse.go
@@ -1220,8 +1220,8 @@ var FileFormatFlagSection = FlagSection{
 		},
 
 		{
-			name:     "--dkvpx",
-			help:     "Use DKVPX format for input and output data.",
+			name: "--dkvpx",
+			help: "Use DKVPX format for input and output data.",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
 				options.ReaderOptions.InputFileFormat = "dkvpx"
 				options.WriterOptions.OutputFileFormat = "dkvpx"

--- a/pkg/cli/option_parse.go
+++ b/pkg/cli/option_parse.go
@@ -1220,6 +1220,16 @@ var FileFormatFlagSection = FlagSection{
 		},
 
 		{
+			name:     "--dkvpx",
+			help:     "Use DKVPX format for input and output data.",
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.ReaderOptions.InputFileFormat = "dkvpx"
+				options.WriterOptions.OutputFileFormat = "dkvpx"
+				*pargi += 1
+			},
+		},
+
+		{
 			name:     "--json",
 			help:     "Use JSON format for input and output data.",
 			altNames: []string{"-j", "--j2j"},

--- a/pkg/cli/separators.go
+++ b/pkg/cli/separators.go
@@ -86,6 +86,7 @@ var defaultFSes = map[string]string{
 	"csv":      ",",
 	"csvlite":  ",",
 	"dkvp":     ",",
+	"dkvpx":    ",",
 	"json":     "N/A", // not alterable; not parameterizable in JSON format
 	"yaml":     "N/A",
 	"dcf":      "N/A",
@@ -101,6 +102,7 @@ var defaultPSes = map[string]string{
 	"csv":      "N/A",
 	"csvlite":  "N/A",
 	"dkvp":     "=",
+	"dkvpx":    "=",
 	"json":     "N/A", // not alterable; not parameterizable in JSON format
 	"yaml":     "N/A",
 	"dcf":      "N/A",
@@ -116,6 +118,7 @@ var defaultRSes = map[string]string{
 	"csv":      "\n",
 	"csvlite":  "\n",
 	"dkvp":     "\n",
+	"dkvpx":    "\n",
 	"json":     "N/A", // not alterable; not parameterizable in JSON format
 	"yaml":     "N/A",
 	"dcf":      "N/A",
@@ -131,6 +134,7 @@ var defaultAllowRepeatIFSes = map[string]bool{
 	"csv":      false,
 	"csvlite":  false,
 	"dkvp":     false,
+	"dkvpx":    false,
 	"json":     false,
 	"yaml":     false,
 	"dcf":      false,

--- a/pkg/dkvpx/dkvpx_reader.go
+++ b/pkg/dkvpx/dkvpx_reader.go
@@ -34,8 +34,8 @@ type Reader struct {
 
 	r *bufio.Reader
 
-	numLine int
-	offset  int64
+	numLine   int
+	offset    int64
 	rawBuffer []byte
 }
 

--- a/pkg/dkvpx/dkvpx_reader.go
+++ b/pkg/dkvpx/dkvpx_reader.go
@@ -1,0 +1,242 @@
+// Package dkvpx reads DKVPX records: comma-delimited key=value pairs with
+// CSV-style quoting. Each record maps to lib.OrderedMap[string].
+//
+// Input format examples:
+//
+//	x=1,y=2,z=3              -> OrderedMap: x->1, y->2, z->3
+//	x=1,2,z=3                 -> OrderedMap: x->1, "2"->2, z->3  (implicit keys from 1-up index)
+//	"x,y"="a,b,c",z=3         -> OrderedMap: "x,y"->"a,b,c", z->3  (quoting for keys/values with commas)
+//
+// Quoting uses " with "" as escape. Keys and values may be quoted independently.
+// Inside quotes, commas, equals, and newlines are literal.
+package dkvpx
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/johnkerl/miller/v6/pkg/lib"
+)
+
+// A Reader reads DKVPX records from an io.Reader.
+type Reader struct {
+	// Comma is the pair delimiter (default ',').
+	Comma rune
+
+	// Comment, if not 0, causes lines beginning with this character to be skipped.
+	Comment rune
+
+	// TrimLeadingSpace, if true, trims leading space from each key and value.
+	TrimLeadingSpace bool
+
+	r *bufio.Reader
+
+	numLine int
+	offset  int64
+	rawBuffer []byte
+}
+
+// NewReader returns a new Reader that reads from r.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{
+		Comma: ',',
+		r:     bufio.NewReader(r),
+	}
+}
+
+// Read reads one DKVPX record. It returns nil, io.EOF when there is no more input.
+func (r *Reader) Read() (*lib.OrderedMap[string], error) {
+	return r.readRecord()
+}
+
+// readLine reads the next line (with trailing newline). Normalizes \r\n to \n.
+// The result is only valid until the next call to readLine.
+func (r *Reader) readLine() ([]byte, error) {
+	line, err := r.r.ReadSlice('\n')
+	if err == bufio.ErrBufferFull {
+		r.rawBuffer = append(r.rawBuffer[:0], line...)
+		for err == bufio.ErrBufferFull {
+			line, err = r.r.ReadSlice('\n')
+			r.rawBuffer = append(r.rawBuffer, line...)
+		}
+		line = r.rawBuffer
+	}
+	readSize := len(line)
+	if readSize > 0 && err == io.EOF {
+		err = nil
+		if line[readSize-1] == '\r' {
+			line = line[:readSize-1]
+		}
+	}
+	r.numLine++
+	r.offset += int64(readSize)
+	if n := len(line); n >= 2 && line[n-2] == '\r' && line[n-1] == '\n' {
+		line[n-2] = '\n'
+		line = line[:n-1]
+	}
+	return line, err
+}
+
+func lengthNL(b []byte) int {
+	if len(b) > 0 && b[len(b)-1] == '\n' {
+		return 1
+	}
+	return 0
+}
+
+func nextRune(b []byte) rune {
+	r, _ := utf8.DecodeRune(b)
+	return r
+}
+
+func (r *Reader) readRecord() (*lib.OrderedMap[string], error) {
+	const quoteLen = len(`"`)
+
+	// Read lines until we have a non-comment line or EOF.
+	var line []byte
+	var errRead error
+	for errRead == nil {
+		line, errRead = r.readLine()
+		if errRead == io.EOF {
+			return nil, io.EOF
+		}
+		if r.Comment != 0 && len(line) > lengthNL(line) && nextRune(line) == r.Comment {
+			continue // skip comment lines
+		}
+		break
+	}
+
+	result := lib.NewOrderedMap[string]()
+	var keyBuf, valBuf []byte
+	inQuotes := false
+	haveKey := false
+	pairIndex := 0
+
+	finishRecord := func() {
+		if len(keyBuf) > 0 || len(valBuf) > 0 || haveKey {
+			key, val := r.finalizePair(keyBuf, valBuf, haveKey, pairIndex)
+			result.Put(key, val)
+		}
+	}
+
+	for {
+		if r.TrimLeadingSpace && !inQuotes {
+			for len(line) > 0 && line[0] != '\n' && (line[0] == ' ' || line[0] == '\t') {
+				line = line[1:]
+			}
+		}
+
+		if len(line) == 0 {
+			if errRead != nil {
+				finishRecord()
+				return result, errRead
+			}
+			line, errRead = r.readLine()
+			if errRead == io.EOF {
+				errRead = nil
+				finishRecord()
+				return result, nil
+			}
+			continue
+		}
+
+		if inQuotes {
+			i := bytes.IndexByte(line, '"')
+			if i >= 0 {
+				if haveKey {
+					valBuf = append(valBuf, line[:i]...)
+				} else {
+					keyBuf = append(keyBuf, line[:i]...)
+				}
+				line = line[i+quoteLen:]
+				if len(line) > 0 && line[0] == '"' {
+					// Escaped quote ""
+					if haveKey {
+						valBuf = append(valBuf, '"')
+					} else {
+						keyBuf = append(keyBuf, '"')
+					}
+					line = line[quoteLen:]
+				} else {
+					inQuotes = false
+				}
+			} else {
+				contentLen := len(line) - lengthNL(line)
+				if haveKey {
+					valBuf = append(valBuf, line[:contentLen]...)
+				} else {
+					keyBuf = append(keyBuf, line[:contentLen]...)
+				}
+				if contentLen > 0 && len(line) > contentLen {
+					if haveKey {
+						valBuf = append(valBuf, '\n')
+					} else {
+						keyBuf = append(keyBuf, '\n')
+					}
+				}
+				line = nil
+			}
+			continue
+		}
+
+		// Not in quotes: process one rune at a time
+		rn, rnLen := utf8.DecodeRune(line)
+		if rn == utf8.RuneError {
+			rnLen = 1
+		}
+
+		if line[0] == '"' {
+			inQuotes = true
+			line = line[quoteLen:]
+			continue
+		}
+
+		if line[0] == '\n' {
+			finishRecord()
+			return result, errRead
+		}
+
+		if rn == r.Comma {
+			key, val := r.finalizePair(keyBuf, valBuf, haveKey, pairIndex)
+			result.Put(key, val)
+			keyBuf = keyBuf[:0]
+			valBuf = valBuf[:0]
+			haveKey = false
+			pairIndex++
+			line = line[rnLen:]
+			continue
+		}
+
+		if rn == '=' && !haveKey {
+			haveKey = true
+			line = line[rnLen:]
+			continue
+		}
+
+		// Regular character
+		if haveKey {
+			valBuf = append(valBuf, line[:rnLen]...)
+		} else {
+			keyBuf = append(keyBuf, line[:rnLen]...)
+		}
+		line = line[rnLen:]
+	}
+}
+
+func (r *Reader) finalizePair(keyBuf, valBuf []byte, haveKey bool, pairIndex int) (key, val string) {
+	if haveKey {
+		key = string(keyBuf)
+		if key == "" {
+			key = strconv.Itoa(pairIndex + 1)
+		}
+		val = string(valBuf)
+	} else {
+		// No = seen: entire pair is value, key is 1-up positional
+		key = strconv.Itoa(pairIndex + 1)
+		val = string(keyBuf)
+	}
+	return key, val
+}

--- a/pkg/dkvpx/dkvpx_reader_test.go
+++ b/pkg/dkvpx/dkvpx_reader_test.go
@@ -1,0 +1,118 @@
+package dkvpx
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/johnkerl/miller/v6/pkg/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+// orderedMapToMap converts OrderedMap to map for easier assertion (order-agnostic).
+func orderedMapToMap(om *lib.OrderedMap[string]) map[string]string {
+	if om == nil {
+		return nil
+	}
+	m := make(map[string]string)
+	for pe := om.Head; pe != nil; pe = pe.Next {
+		m[pe.Key] = pe.Value
+	}
+	return m
+}
+
+func TestRead_Basic(t *testing.T) {
+	r := NewReader(strings.NewReader("x=1,y=2,z=3\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.NotNil(t, rec)
+	assert.Equal(t, map[string]string{"x": "1", "y": "2", "z": "3"}, orderedMapToMap(rec))
+
+	rec, err = r.Read()
+	assert.Nil(t, rec)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestRead_ImplicitKeys(t *testing.T) {
+	r := NewReader(strings.NewReader("x=1,2,z=3\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"x": "1", "2": "2", "z": "3"}, orderedMapToMap(rec))
+}
+
+func TestRead_QuotedKeyAndValue(t *testing.T) {
+	r := NewReader(strings.NewReader(`"x,y"="a,b,c",z=3` + "\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"x,y": "a,b,c", "z": "3"}, orderedMapToMap(rec))
+}
+
+func TestRead_EscapedQuotes(t *testing.T) {
+	r := NewReader(strings.NewReader(`x="the ""word""",y=2` + "\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"x": `the "word"`, "y": "2"}, orderedMapToMap(rec))
+}
+
+func TestRead_MultilineValue(t *testing.T) {
+	r := NewReader(strings.NewReader("x=\"a\n b\",y=2\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"x": "a\n b", "y": "2"}, orderedMapToMap(rec))
+}
+
+func TestRead_EmptyLine(t *testing.T) {
+	r := NewReader(strings.NewReader("\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{}, orderedMapToMap(rec))
+}
+
+func TestRead_EmptyEOF(t *testing.T) {
+	r := NewReader(strings.NewReader(""))
+	rec, err := r.Read()
+	assert.Nil(t, rec)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestRead_ReadAll(t *testing.T) {
+	r := NewReader(strings.NewReader("a=1,b=2\nx=10,y=20\n"))
+	rec1, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, orderedMapToMap(rec1))
+
+	rec2, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"x": "10", "y": "20"}, orderedMapToMap(rec2))
+
+	rec3, err := r.Read()
+	assert.Nil(t, rec3)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestRead_ValueWithEquals(t *testing.T) {
+	r := NewReader(strings.NewReader("a=b=c,d=1\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "b=c", "d": "1"}, orderedMapToMap(rec))
+}
+
+func TestRead_CommentSkipped(t *testing.T) {
+	r := NewReader(strings.NewReader("# comment\na=1,b=2\n"))
+	r.Comment = '#'
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, orderedMapToMap(rec))
+}
+
+func TestRead_OrderPreserved(t *testing.T) {
+	r := NewReader(strings.NewReader("z=3,x=1,y=2\n"))
+	rec, err := r.Read()
+	assert.NoError(t, err)
+	// OrderedMap should preserve insertion order
+	keys := make([]string, 0)
+	for pe := rec.Head; pe != nil; pe = pe.Next {
+		keys = append(keys, pe.Key)
+	}
+	assert.Equal(t, []string{"z", "x", "y"}, keys)
+}

--- a/pkg/dkvpx/dkvpx_writer.go
+++ b/pkg/dkvpx/dkvpx_writer.go
@@ -1,0 +1,130 @@
+// Package dkvpx (see also dkvpx_reader.go) writes DKVPX records: comma-delimited
+// key=value pairs with selective quoting. Keys and values are double-quoted only
+// when they contain comma, equals, newline, or double-quote.
+package dkvpx
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"github.com/johnkerl/miller/v6/pkg/lib"
+)
+
+// A Writer writes DKVPX records. It mirrors the structure of csv.Writer.
+type Writer struct {
+	Comma   rune // Pair delimiter (set to ',' by NewWriter)
+	UseCRLF bool // True to use \r\n as the line terminator
+	w       *bufio.Writer
+}
+
+// NewWriter returns a new Writer that writes to w.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{
+		Comma: ',',
+		w:     bufio.NewWriter(w),
+	}
+}
+
+// Write writes a single DKVPX record. Keys and values are quoted only when
+// they contain comma, equals, newline, or double-quote.
+func (w *Writer) Write(record *lib.OrderedMap[string]) error {
+	if record == nil || record.IsEmpty() {
+		return w.writeLineEnd()
+	}
+
+	first := true
+	for pe := record.Head; pe != nil; pe = pe.Next {
+		if !first {
+			if _, err := w.w.WriteRune(w.Comma); err != nil {
+				return err
+			}
+		}
+		first = false
+
+		if err := w.writeQuotedIfNeeded(pe.Key); err != nil {
+			return err
+		}
+		if err := w.w.WriteByte('='); err != nil {
+			return err
+		}
+		if err := w.writeQuotedIfNeeded(pe.Value); err != nil {
+			return err
+		}
+	}
+
+	return w.writeLineEnd()
+}
+
+// writeQuotedIfNeeded writes the string, adding surrounding quotes and escaping
+// internal quotes only when the string contains comma, equals, newline, or quote.
+func (w *Writer) writeQuotedIfNeeded(s string) error {
+	if !needsQuoting(s) {
+		_, err := w.w.WriteString(s)
+		return err
+	}
+
+	if err := w.w.WriteByte('"'); err != nil {
+		return err
+	}
+	// Escape " as ""
+	for len(s) > 0 {
+		i := strings.IndexAny(s, "\"\r\n")
+		if i < 0 {
+			i = len(s)
+		}
+		if _, err := w.w.WriteString(s[:i]); err != nil {
+			return err
+		}
+		s = s[i:]
+		if len(s) > 0 {
+			switch s[0] {
+			case '"':
+				if _, err := w.w.WriteString(`""`); err != nil {
+					return err
+				}
+			case '\r', '\n':
+				if err := w.w.WriteByte(s[0]); err != nil {
+					return err
+				}
+			}
+			s = s[1:]
+		}
+	}
+	return w.w.WriteByte('"')
+}
+
+// needsQuoting reports whether the string must be quoted (contains comma,
+// equals, newline, or double-quote).
+func needsQuoting(s string) bool {
+	return strings.ContainsAny(s, ",\n\r=\"")
+}
+
+func (w *Writer) writeLineEnd() error {
+	if w.UseCRLF {
+		_, err := w.w.WriteString("\r\n")
+		return err
+	}
+	return w.w.WriteByte('\n')
+}
+
+// Flush writes any buffered data to the underlying io.Writer.
+func (w *Writer) Flush() {
+	w.w.Flush()
+}
+
+// Error reports any error that has occurred during a previous Write or Flush.
+func (w *Writer) Error() error {
+	_, err := w.w.Write(nil)
+	return err
+}
+
+// WriteAll writes multiple DKVPX records and then calls Flush.
+func (w *Writer) WriteAll(records []*lib.OrderedMap[string]) error {
+	for _, record := range records {
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	return w.w.Flush()
+}

--- a/pkg/dkvpx/dkvpx_writer.go
+++ b/pkg/dkvpx/dkvpx_writer.go
@@ -100,6 +100,27 @@ func needsQuoting(s string) bool {
 	return strings.ContainsAny(s, ",\n\r=\"")
 }
 
+// FormatField returns the string formatted for DKVPX output: quoted and escaped
+// if it contains comma, equals, newline, or quote; otherwise unchanged.
+// Useful for callers that need to apply colorization or other wrapping.
+func FormatField(s string) string {
+	if !needsQuoting(s) {
+		return s
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			b.WriteString(`""`)
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
 func (w *Writer) writeLineEnd() error {
 	if w.UseCRLF {
 		_, err := w.w.WriteString("\r\n")

--- a/pkg/dkvpx/dkvpx_writer_test.go
+++ b/pkg/dkvpx/dkvpx_writer_test.go
@@ -1,0 +1,71 @@
+package dkvpx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/johnkerl/miller/v6/pkg/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite_Basic(t *testing.T) {
+	var buf strings.Builder
+	wr := NewWriter(&buf)
+	rec := lib.NewOrderedMap[string]()
+	rec.Put("x", "1")
+	rec.Put("y", "2")
+	rec.Put("z", "3")
+	err := wr.Write(rec)
+	assert.NoError(t, err)
+	wr.Flush()
+	assert.NoError(t, wr.Error())
+	assert.Equal(t, "x=1,y=2,z=3\n", buf.String())
+}
+
+func TestWrite_QuotesWhenNeeded(t *testing.T) {
+	var buf strings.Builder
+	wr := NewWriter(&buf)
+	rec := lib.NewOrderedMap[string]()
+	rec.Put("x,y", "a,b,c")
+	rec.Put("z", "3")
+	err := wr.Write(rec)
+	assert.NoError(t, err)
+	wr.Flush()
+	assert.Equal(t, `"x,y"="a,b,c",z=3`+"\n", buf.String())
+}
+
+func TestWrite_ValueWithEquals(t *testing.T) {
+	var buf strings.Builder
+	wr := NewWriter(&buf)
+	rec := lib.NewOrderedMap[string]()
+	rec.Put("a", "b=c")
+	err := wr.Write(rec)
+	assert.NoError(t, err)
+	wr.Flush()
+	assert.Equal(t, `a="b=c"`+"\n", buf.String())
+}
+
+func TestWrite_EscapedQuotes(t *testing.T) {
+	var buf strings.Builder
+	wr := NewWriter(&buf)
+	rec := lib.NewOrderedMap[string]()
+	rec.Put("x", `the "word"`)
+	err := wr.Write(rec)
+	assert.NoError(t, err)
+	wr.Flush()
+	assert.Equal(t, `x="the ""word"""`+"\n", buf.String())
+}
+
+func TestWrite_RoundTrip(t *testing.T) {
+	input := `"x,y"="a,b,c",z=3` + "\n"
+	rdr := NewReader(strings.NewReader(input))
+	rec, err := rdr.Read()
+	assert.NoError(t, err)
+
+	var buf strings.Builder
+	wr := NewWriter(&buf)
+	err = wr.Write(rec)
+	assert.NoError(t, err)
+	wr.Flush()
+	assert.Equal(t, input, buf.String())
+}

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -1,0 +1,184 @@
+// RecordReaderDKVPX reads DKVPX format: comma-delimited key=value pairs with
+// CSV-style quoting. It uses the dkvpx package for parsing.
+package input
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/johnkerl/miller/v6/pkg/cli"
+	"github.com/johnkerl/miller/v6/pkg/dkvpx"
+	"github.com/johnkerl/miller/v6/pkg/lib"
+	"github.com/johnkerl/miller/v6/pkg/mlrval"
+	"github.com/johnkerl/miller/v6/pkg/types"
+)
+
+type RecordReaderDKVPX struct {
+	readerOptions   *cli.TReaderOptions
+	recordsPerBatch int64
+}
+
+func NewRecordReaderDKVPX(
+	readerOptions *cli.TReaderOptions,
+	recordsPerBatch int64,
+) (*RecordReaderDKVPX, error) {
+	if readerOptions.IRS != "\n" && readerOptions.IRS != "\r\n" {
+		return nil, fmt.Errorf("for DKVPX, IRS cannot be altered; LF vs CR/LF is autodetected")
+	}
+	return &RecordReaderDKVPX{
+		readerOptions:   readerOptions,
+		recordsPerBatch: recordsPerBatch,
+	}, nil
+}
+
+func (reader *RecordReaderDKVPX) Read(
+	filenames []string,
+	context types.Context,
+	readerChannel chan<- []*types.RecordAndContext,
+	errorChannel chan error,
+	downstreamDoneChannel <-chan bool,
+) {
+	if filenames != nil {
+		if len(filenames) == 0 {
+			handle, err := lib.OpenStdin(
+				reader.readerOptions.Prepipe,
+				reader.readerOptions.PrepipeIsRaw,
+				reader.readerOptions.FileInputEncoding,
+			)
+			if err != nil {
+				errorChannel <- err
+			} else {
+				reader.processHandle(handle, "(stdin)", &context, readerChannel, errorChannel, downstreamDoneChannel)
+			}
+		} else {
+			for _, filename := range filenames {
+				handle, err := lib.OpenFileForRead(
+					filename,
+					reader.readerOptions.Prepipe,
+					reader.readerOptions.PrepipeIsRaw,
+					reader.readerOptions.FileInputEncoding,
+				)
+				if err != nil {
+					errorChannel <- err
+				} else {
+					reader.processHandle(handle, filename, &context, readerChannel, errorChannel, downstreamDoneChannel)
+					handle.Close()
+				}
+			}
+		}
+	}
+	readerChannel <- types.NewEndOfStreamMarkerList(&context)
+}
+
+func (reader *RecordReaderDKVPX) processHandle(
+	handle io.Reader,
+	filename string,
+	context *types.Context,
+	readerChannel chan<- []*types.RecordAndContext,
+	errorChannel chan<- error,
+	downstreamDoneChannel <-chan bool,
+) {
+	context.UpdateForStartOfFile(filename)
+	recordsPerBatch := reader.recordsPerBatch
+
+	dkvpxReader := dkvpx.NewReader(NewBOMStrippingReader(handle))
+	dkvpxReader.Comma = ','
+	if reader.readerOptions.CommentHandling != cli.CommentsAreData &&
+		len(reader.readerOptions.CommentString) == 1 {
+		dkvpxReader.Comment = rune(reader.readerOptions.CommentString[0])
+	}
+
+	dkvpxRecordsChannel := make(chan []*lib.OrderedMap[string], recordsPerBatch)
+	go channelizedDKVPXRecordScanner(dkvpxReader, dkvpxRecordsChannel, downstreamDoneChannel, errorChannel, recordsPerBatch)
+
+	for {
+		recordsAndContexts, eof := reader.getRecordBatch(dkvpxRecordsChannel, errorChannel, context)
+		if len(recordsAndContexts) > 0 {
+			readerChannel <- recordsAndContexts
+		}
+		if eof {
+			break
+		}
+	}
+}
+
+func channelizedDKVPXRecordScanner(
+	dkvpxReader *dkvpx.Reader,
+	dkvpxRecordsChannel chan<- []*lib.OrderedMap[string],
+	downstreamDoneChannel <-chan bool,
+	errorChannel chan<- error,
+	recordsPerBatch int64,
+) {
+	i := int64(0)
+	done := false
+
+	dkvpxRecords := make([]*lib.OrderedMap[string], 0, recordsPerBatch)
+
+	for {
+		i++
+
+		dkvpxRecord, err := dkvpxReader.Read()
+		if lib.IsEOF(err) {
+			break
+		}
+		if err != nil {
+			errorChannel <- err
+			break
+		}
+
+		dkvpxRecords = append(dkvpxRecords, dkvpxRecord)
+
+		if i%recordsPerBatch == 0 {
+			select {
+			case <-downstreamDoneChannel:
+				done = true
+				break
+			default:
+				break
+			}
+			if done {
+				break
+			}
+			dkvpxRecordsChannel <- dkvpxRecords
+			dkvpxRecords = make([]*lib.OrderedMap[string], 0, recordsPerBatch)
+		}
+
+		if done {
+			break
+		}
+	}
+	dkvpxRecordsChannel <- dkvpxRecords
+	close(dkvpxRecordsChannel)
+}
+
+func (reader *RecordReaderDKVPX) getRecordBatch(
+	dkvpxRecordsChannel <-chan []*lib.OrderedMap[string],
+	errorChannel chan<- error,
+	context *types.Context,
+) ([]*types.RecordAndContext, bool) {
+	recordsAndContexts := []*types.RecordAndContext{}
+	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
+
+	dkvpxRecords, more := <-dkvpxRecordsChannel
+	if !more {
+		return recordsAndContexts, true
+	}
+
+	for _, omap := range dkvpxRecords {
+		record := mlrval.NewMlrmapAsRecord()
+
+		for pe := omap.Head; pe != nil; pe = pe.Next {
+			value := mlrval.FromDeferredType(pe.Value)
+			_, err := record.PutReferenceMaybeDedupe(pe.Key, value, dedupeFieldNames)
+			if err != nil {
+				errorChannel <- err
+				return nil, false
+			}
+		}
+
+		context.UpdateForInputRecord()
+		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+	}
+
+	return recordsAndContexts, false
+}

--- a/pkg/input/record_reader_dkvpx_test.go
+++ b/pkg/input/record_reader_dkvpx_test.go
@@ -1,0 +1,43 @@
+package input
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/johnkerl/miller/v6/pkg/cli"
+	"github.com/johnkerl/miller/v6/pkg/types"
+)
+
+func TestNewRecordReaderDKVPX(t *testing.T) {
+	readerOptions := cli.DefaultReaderOptions()
+	readerOptions.InputFileFormat = "dkvpx"
+	assert.NoError(t, cli.FinalizeReaderOptions(&readerOptions))
+
+	reader, err := NewRecordReaderDKVPX(&readerOptions, 1)
+	assert.NotNil(t, reader)
+	assert.NoError(t, err)
+}
+
+func TestRecordReaderDKVPX_ReadStdin(t *testing.T) {
+	readerOptions := cli.DefaultReaderOptions()
+	readerOptions.InputFileFormat = "dkvpx"
+	assert.NoError(t, cli.FinalizeReaderOptions(&readerOptions))
+
+	reader, err := NewRecordReaderDKVPX(&readerOptions, 1)
+	assert.NoError(t, err)
+
+	ctx := types.Context{}
+	readerChannel := make(chan []*types.RecordAndContext, 4)
+	errorChannel := make(chan error, 1)
+
+	input := strings.NewReader("x=1,y=2,z=3\n")
+	go reader.processHandle(input, "(test)", &ctx, readerChannel, errorChannel, nil)
+
+	records := <-readerChannel
+	assert.Len(t, records, 1)
+	assert.False(t, records[0].EndOfStream)
+	assert.Equal(t, "x", records[0].Record.Head.Key)
+	assert.Equal(t, "1", records[0].Record.Head.Value.String())
+}

--- a/pkg/input/record_reader_factory.go
+++ b/pkg/input/record_reader_factory.go
@@ -14,6 +14,8 @@ func Create(readerOptions *cli.TReaderOptions, recordsPerBatch int64) (IRecordRe
 		return NewRecordReaderCSVLite(readerOptions, recordsPerBatch)
 	case "dkvp":
 		return NewRecordReaderDKVP(readerOptions, recordsPerBatch)
+	case "dkvpx":
+		return NewRecordReaderDKVPX(readerOptions, recordsPerBatch)
 	case "json":
 		return NewRecordReaderJSON(readerOptions, recordsPerBatch)
 	case "yaml":

--- a/pkg/output/record_writer_dkvpx.go
+++ b/pkg/output/record_writer_dkvpx.go
@@ -1,0 +1,55 @@
+package output
+
+import (
+	"bufio"
+
+	"github.com/johnkerl/miller/v6/pkg/cli"
+	"github.com/johnkerl/miller/v6/pkg/colorizer"
+	"github.com/johnkerl/miller/v6/pkg/dkvpx"
+	"github.com/johnkerl/miller/v6/pkg/mlrval"
+	"github.com/johnkerl/miller/v6/pkg/types"
+)
+
+type RecordWriterDKVPX struct {
+	writerOptions *cli.TWriterOptions
+}
+
+func NewRecordWriterDKVPX(writerOptions *cli.TWriterOptions) (*RecordWriterDKVPX, error) {
+	return &RecordWriterDKVPX{
+		writerOptions: writerOptions,
+	}, nil
+}
+
+func (writer *RecordWriterDKVPX) Write(
+	outrec *mlrval.Mlrmap,
+	_ *types.Context,
+	bufferedOutputStream *bufio.Writer,
+	outputIsStdout bool,
+) error {
+	if outrec == nil {
+		return nil
+	}
+
+	if outrec.IsEmpty() {
+		bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+		return nil
+	}
+
+	first := true
+	for pe := outrec.Head; pe != nil; pe = pe.Next {
+		if !first {
+			bufferedOutputStream.WriteString(writer.writerOptions.OFS)
+		}
+		first = false
+
+		keyStr := dkvpx.FormatField(pe.Key)
+		valStr := dkvpx.FormatField(pe.Value.String())
+
+		bufferedOutputStream.WriteString(colorizer.MaybeColorizeKey(keyStr, outputIsStdout))
+		bufferedOutputStream.WriteString(writer.writerOptions.OPS)
+		bufferedOutputStream.WriteString(colorizer.MaybeColorizeValue(valStr, outputIsStdout))
+	}
+	bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+
+	return nil
+}

--- a/pkg/output/record_writer_factory.go
+++ b/pkg/output/record_writer_factory.go
@@ -14,6 +14,8 @@ func Create(writerOptions *cli.TWriterOptions) (IRecordWriter, error) {
 		return NewRecordWriterCSVLite(writerOptions)
 	case "dkvp":
 		return NewRecordWriterDKVP(writerOptions)
+	case "dkvpx":
+		return NewRecordWriterDKVPX(writerOptions)
 	case "json":
 		return NewRecordWriterJSON(writerOptions)
 	case "jsonl":

--- a/pkg/terminals/help/entry.go
+++ b/pkg/terminals/help/entry.go
@@ -430,6 +430,12 @@ DKVP: delimited key-value pairs (Miller default format)
 | dish=7,egg=8,flint  | Record 2: "dish":"7", "egg":"8", "3":"flint"
 +---------------------+
 
+DKVPX: delimited key-value pairs with CSV-style quoting
++----------------------------------+
+| apple=1,bat=2,cog=3              | Record 1: "apple":"1", "bat":"2", "cog":"3"
+| "x,y"="a,b,c",z=3                | Record 2: "x,y":"a,b,c", "z":"3"
++----------------------------------+
+
 NIDX: implicitly numerically indexed (Unix-toolkit style)
 +---------------------+
 | the quick brown     | Record 1: "1":"the", "2":"quick", "3":"brown"


### PR DESCRIPTION
Resolves issue #266.

This is like Miller's original DKVP except it handles quoted keys and/or values, like CSV does.

DKVP has a naïve split on `=` and `,`:

```
$ echo 'a=1,"b,c"=2,d="3,4",e' | mlr -i dkvp -o json cat
[
{
  "a": 1,
  "2": "\"b",
  "c\"": 2,
  "d": "\"3",
  "5": "4\"",
  "6": "e"
}
]
```

But DKVPX handles these:

```
$ echo 'a=1,"b,c"=2,d="3,4",e' | mlr -i dkvpx -o json cat
[
{
  "a": 1,
  "b,c": 2,
  "d": "3,4",
  "4": "e"
}
]
```

## Performance

Performance numbers, and why I'm not making DPVKX replace the existing DKVP:

```
repeat 10 justtime mlr -i dkvp  nothing ~/data/big.dkvp
repeat 10 justtime mlr -i dkvp  cat     ~/data/big.dkvp
repeat 10 justtime mlr -i dkvpx nothing ~/data/big.dkvp
repeat 10 justtime mlr -i dkvpx cat     ~/data/big.dkvp
```

where `big.dkvp` is a million-line DKVP file with no quoting on keys or values.

```
#dkvp-r dkvp-rw dkvpx-r dkvpx-rw
1.102   1.165   1.567   1.650
1.103   1.150   1.579   1.652
1.093   1.151   1.577   1.677
1.096   1.150   1.707   1.660
1.146   1.152   1.602   1.659
1.170   1.139   1.591   1.665
1.106   1.151   1.590   1.665
1.101   1.146   1.583   1.665
1.112   1.145   1.587   1.717
1.113   1.144   1.584   1.677
```

<img width="597" height="399" alt="Screenshot 2026-03-02 at 10 12 23 PM" src="https://github.com/user-attachments/assets/35f64a83-dd21-47fd-aab3-8fcbfde0beed" />
