### PR TITLE
Fix crash on array compare containing absent values

### DIFF
--- a/pkg/bifs/cmp.go
+++ b/pkg/bifs/cmp.go
@@ -243,6 +243,10 @@ func eq_b_aa(input1, input2 *mlrval.Mlrval) *mlrval.Mlrval {
 	// Same-length arrays: return false if any slot is not equal, else true.
 	for i := range a {
 		eq := BIF_equals(a[i], b[i])
+		// Treat invalid comparison as false
+		if eq.Type() == mlrval.MT_ABSENT {
+			return mlrval.FALSE
+		}
 		lib.InternalCodingErrorIf(eq.Type() != mlrval.MT_BOOL)
 		if !eq.AcquireBoolValue() {
 			return mlrval.FALSE


### PR DESCRIPTION
Arary compare makes it cleaner to check multiple fields. But if any of them are missing, it causes miller to crash.

```
❯ <<EOF mlr --d2p filter '[$age, $name, $place] == [42, "foo", "nyc"]'
∙ name=baz,place=la
∙ name=foo,place=nyc,age=42
∙ name=bar,place=la,age=24
∙ EOF
Internal coding error detected at file cmp.go line 246
```

With fix:

```
❯ <<EOF go run ./cmd/mlr/main.go --d2p filter '[$age, $name, $place] == [42, "foo", "nyc"]'
∙ name=baz,place=la
∙ name=foo,place=nyc,age=42
∙ name=bar,place=la,age=24
∙ EOF
name place age
foo  nyc   42
```