### PR TITLE
Add `--omd-aligned` flag for column-padded markdown output

### DIFF
--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -551,6 +551,24 @@ which renders like this when dropped into various web tools (e.g. github.comment
 As of Miller 4.3.0, markdown format is supported only for output, not input; as of Miller 6.11.0, markdown format
 is supported for input as well.
 
+By default, markdown cells are not padded -- which renders identically in a Markdown viewer
+but can be awkward to read or maintain as raw text. Use `--omd-aligned` to pad each column
+to a uniform width so the raw markdown source lines up. This flag implies `--omd`, so you
+do not need to pass `--omd` in addition:
+
+<pre class="pre-highlight-in-pair">
+<b>mlr --omd-aligned cat data/small</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+| a   | b   | i   | x        | y        |
+| --- | --- | --- | ---      | ---      |
+| pan | pan | 1   | 0.346791 | 0.726802 |
+| eks | pan | 2   | 0.758679 | 0.522151 |
+| wye | wye | 3   | 0.204603 | 0.338318 |
+| eks | wye | 4   | 0.381399 | 0.134188 |
+| wye | pan | 5   | 0.573288 | 0.863624 |
+</pre>
+
 ## XTAB: Vertical tabular
 
 This is perhaps most useful for looking a very wide and/or multi-column data which causes line-wraps on the screen (but see also

--- a/docs/src/file-formats.md.in
+++ b/docs/src/file-formats.md.in
@@ -223,6 +223,15 @@ which renders like this when dropped into various web tools (e.g. github.comment
 As of Miller 4.3.0, markdown format is supported only for output, not input; as of Miller 6.11.0, markdown format
 is supported for input as well.
 
+By default, markdown cells are not padded -- which renders identically in a Markdown viewer
+but can be awkward to read or maintain as raw text. Use `--omd-aligned` to pad each column
+to a uniform width so the raw markdown source lines up. This flag implies `--omd`, so you
+do not need to pass `--omd` in addition:
+
+GENMD-RUN-COMMAND
+mlr --omd-aligned cat data/small
+GENMD-EOF
+
 ## XTAB: Vertical tabular
 
 This is perhaps most useful for looking a very wide and/or multi-column data which causes line-wraps on the screen (but see also

--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -178,6 +178,7 @@ This is simply a copy of what you should see on running `man mlr` at a command p
          mlr help format-conversion-keystroke-saver-flags
          mlr help json-only-flags
          mlr help legacy-flags
+         mlr help markdown-only-flags
          mlr help miscellaneous-flags
          mlr help output-colorization-flags
          mlr help pprint-only-flags
@@ -559,6 +560,16 @@ This is simply a copy of what you should see on running `man mlr` at a command p
                                 through the processing flow now.
        --vflatsep               Ignored as of version 6. This functionality is
                                 subsumed into JSON formatting.
+
+1mMARKDOWN-ONLY FLAGS0m
+       These are flags which are applicable to markdown-tabular format.
+
+       --omd-aligned or --omarkdown-aligned
+                                For markdown-tabular output, left-justify cells and
+                                pad each column to a uniform width, making the raw
+                                markdown source easier to read and maintain. (The
+                                rendered table is unaffected.) Implies --omd, so you
+                                do not need to also pass --omd.
 
 1mMISCELLANEOUS FLAGS0m
        These are flags which don't fit into any other category.
@@ -3835,5 +3846,5 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-04-19                         4mMILLER24m(1)
+                                  2026-05-16                         4mMILLER24m(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -157,6 +157,7 @@
          mlr help format-conversion-keystroke-saver-flags
          mlr help json-only-flags
          mlr help legacy-flags
+         mlr help markdown-only-flags
          mlr help miscellaneous-flags
          mlr help output-colorization-flags
          mlr help pprint-only-flags
@@ -538,6 +539,16 @@
                                 through the processing flow now.
        --vflatsep               Ignored as of version 6. This functionality is
                                 subsumed into JSON formatting.
+
+1mMARKDOWN-ONLY FLAGS0m
+       These are flags which are applicable to markdown-tabular format.
+
+       --omd-aligned or --omarkdown-aligned
+                                For markdown-tabular output, left-justify cells and
+                                pad each column to a uniform width, making the raw
+                                markdown source easier to read and maintain. (The
+                                rendered table is unaffected.) Implies --omd, so you
+                                do not need to also pass --omd.
 
 1mMISCELLANEOUS FLAGS0m
        These are flags which don't fit into any other category.
@@ -3814,4 +3825,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-04-19                         4mMILLER24m(1)
+                                  2026-05-16                         4mMILLER24m(1)

--- a/docs/src/reference-main-flag-list.md
+++ b/docs/src/reference-main-flag-list.md
@@ -282,6 +282,15 @@ They are accepted as no-op flags in order to keep old scripts from breaking.
 * `--quote-original`: Ignored as of version 6. Types are inferred/retained through the processing flow now.
 * `--vflatsep`: Ignored as of version 6. This functionality is subsumed into JSON formatting.
 
+## Markdown-only flags
+
+These are flags which are applicable to markdown-tabular format.
+
+
+**Flags:**
+
+* `--omd-aligned or --omarkdown-aligned`: For markdown-tabular output, left-justify cells and pad each column to a uniform width, making the raw markdown source easier to read and maintain. (The rendered table is unaffected.) Implies --omd, so you do not need to also pass --omd.
+
 ## Miscellaneous flags
 
 These are flags which don't fit into any other category.

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -157,6 +157,7 @@
          mlr help format-conversion-keystroke-saver-flags
          mlr help json-only-flags
          mlr help legacy-flags
+         mlr help markdown-only-flags
          mlr help miscellaneous-flags
          mlr help output-colorization-flags
          mlr help pprint-only-flags
@@ -538,6 +539,16 @@
                                 through the processing flow now.
        --vflatsep               Ignored as of version 6. This functionality is
                                 subsumed into JSON formatting.
+
+1mMARKDOWN-ONLY FLAGS0m
+       These are flags which are applicable to markdown-tabular format.
+
+       --omd-aligned or --omarkdown-aligned
+                                For markdown-tabular output, left-justify cells and
+                                pad each column to a uniform width, making the raw
+                                markdown source easier to read and maintain. (The
+                                rendered table is unaffected.) Implies --omd, so you
+                                do not need to also pass --omd.
 
 1mMISCELLANEOUS FLAGS0m
        These are flags which don't fit into any other category.
@@ -3814,4 +3825,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-04-19                         4mMILLER24m(1)
+                                  2026-05-16                         4mMILLER24m(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2026-04-19
+.\"      Date: 2026-05-16
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2026-04-19" "\ \&" "\ \&"
+.TH "MILLER" "1" "2026-05-16" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -194,6 +194,7 @@ Flags:
   mlr help format-conversion-keystroke-saver-flags
   mlr help json-only-flags
   mlr help legacy-flags
+  mlr help markdown-only-flags
   mlr help miscellaneous-flags
   mlr help output-colorization-flags
   mlr help pprint-only-flags
@@ -659,6 +660,24 @@ They are accepted as no-op flags in order to keep old scripts from breaking.
                          through the processing flow now.
 --vflatsep               Ignored as of version 6. This functionality is
                          subsumed into JSON formatting.
+.fi
+.if n \{\
+.RE
+.SH "MARKDOWN-ONLY FLAGS"
+.sp
+
+.if n \{\
+.RS 0
+.\}
+.nf
+These are flags which are applicable to markdown-tabular format.
+
+--omd-aligned or --omarkdown-aligned
+                         For markdown-tabular output, left-justify cells and
+                         pad each column to a uniform width, making the raw
+                         markdown source easier to read and maintain. (The
+                         rendered table is unaffected.) Implies --omd, so you
+                         do not need to also pass --omd.
 .fi
 .if n \{\
 .RE

--- a/pkg/cli/option_parse.go
+++ b/pkg/cli/option_parse.go
@@ -117,6 +117,7 @@ var FLAG_TABLE = FlagTable{
 		&CSVTSVOnlyFlagSection,
 		&JSONOnlyFlagSection,
 		&PPRINTOnlyFlagSection,
+		&MarkdownOnlyFlagSection,
 		&DKVPOnlyFlagSection,
 		&CompressedDataFlagSection,
 		&CommentsInDataFlagSection,
@@ -576,6 +577,35 @@ var PPRINTOnlyFlagSection = FlagSection{
 			help: "Shortcut for --fixed left-align-multi-word",
 			parser: func(args []string, argc int, pargi *int, options *TOptions) {
 				options.ReaderOptions.FixedWidthSpec = "left-align-multi-word"
+				*pargi += 1
+			},
+		},
+	},
+}
+
+// MARKDOWN-ONLY FLAGS
+
+func MarkdownOnlyPrintInfo() {
+	fmt.Println("These are flags which are applicable to markdown-tabular format.")
+}
+
+func init() { MarkdownOnlyFlagSection.Sort() }
+
+var MarkdownOnlyFlagSection = FlagSection{
+	name:        "Markdown-only flags",
+	infoPrinter: MarkdownOnlyPrintInfo,
+	flags: []Flag{
+
+		{
+			name:     "--omd-aligned",
+			altNames: []string{"--omarkdown-aligned"},
+			help: "For markdown-tabular output, left-justify cells and pad each " +
+				"column to a uniform width, making the raw markdown source easier " +
+				"to read and maintain. (The rendered table is unaffected.) Implies " +
+				"--omd, so you do not need to also pass --omd.",
+			parser: func(args []string, argc int, pargi *int, options *TOptions) {
+				options.WriterOptions.OutputFileFormat = "markdown"
+				options.WriterOptions.MarkdownAlignedOutput = true
 				*pargi += 1
 			},
 		},

--- a/pkg/cli/option_types.go
+++ b/pkg/cli/option_types.go
@@ -101,6 +101,7 @@ type TWriterOptions struct {
 	BarredUseUnicode         bool
 	RightAlignedPPRINTOutput bool
 	RightAlignedXTABOutput   bool
+	MarkdownAlignedOutput    bool
 
 	// JSON output: --jlistwrap on, --jvstack on
 	// JSON Lines output: --jlistwrap off, --jvstack off

--- a/pkg/output/record_writer_markdown.go
+++ b/pkg/output/record_writer_markdown.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bufio"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/johnkerl/miller/v6/pkg/cli"
 	"github.com/johnkerl/miller/v6/pkg/colorizer"
@@ -13,8 +14,14 @@ import (
 type RecordWriterMarkdown struct {
 	writerOptions *cli.TWriterOptions
 
+	// Streaming-mode state (when MarkdownAlignedOutput is false)
 	numHeaderLinesOutput int
 	lastJoinedHeader     string
+
+	// Aligned-mode state (when MarkdownAlignedOutput is true)
+	batch             []*mlrval.Mlrmap
+	batchJoinedHeader *string
+	numBatchesOutput  int
 }
 
 func NewRecordWriterMarkdown(writerOptions *cli.TWriterOptions) (*RecordWriterMarkdown, error) {
@@ -23,12 +30,27 @@ func NewRecordWriterMarkdown(writerOptions *cli.TWriterOptions) (*RecordWriterMa
 
 		numHeaderLinesOutput: 0,
 		lastJoinedHeader:     "",
+
+		batch:             []*mlrval.Mlrmap{},
+		batchJoinedHeader: nil,
+		numBatchesOutput:  0,
 	}, nil
 }
 
 func (writer *RecordWriterMarkdown) Write(
 	outrec *mlrval.Mlrmap,
 	_ *types.Context,
+	bufferedOutputStream *bufio.Writer,
+	outputIsStdout bool,
+) error {
+	if writer.writerOptions.MarkdownAlignedOutput {
+		return writer.writeAligned(outrec, bufferedOutputStream, outputIsStdout)
+	}
+	return writer.writeStreaming(outrec, bufferedOutputStream, outputIsStdout)
+}
+
+func (writer *RecordWriterMarkdown) writeStreaming(
+	outrec *mlrval.Mlrmap,
 	bufferedOutputStream *bufio.Writer,
 	outputIsStdout bool,
 ) error {
@@ -75,4 +97,102 @@ func (writer *RecordWriterMarkdown) Write(
 	bufferedOutputStream.WriteString(writer.writerOptions.ORS)
 
 	return nil
+}
+
+// writeAligned accumulates records into a same-schema batch and flushes when
+// the schema changes or the stream ends. We need the whole batch in hand
+// before emitting any row, since column widths depend on every value.
+func (writer *RecordWriterMarkdown) writeAligned(
+	outrec *mlrval.Mlrmap,
+	bufferedOutputStream *bufio.Writer,
+	outputIsStdout bool,
+) error {
+	if outrec == nil {
+		if len(writer.batch) > 0 {
+			writer.flushBatch(bufferedOutputStream, outputIsStdout)
+		}
+		return nil
+	}
+
+	joinedHeader := outrec.GetKeysJoined()
+	if writer.batchJoinedHeader == nil {
+		writer.batch = append(writer.batch, outrec)
+		writer.batchJoinedHeader = &joinedHeader
+	} else if *writer.batchJoinedHeader != joinedHeader {
+		writer.flushBatch(bufferedOutputStream, outputIsStdout)
+		writer.batch = []*mlrval.Mlrmap{outrec}
+		writer.batchJoinedHeader = &joinedHeader
+	} else {
+		writer.batch = append(writer.batch, outrec)
+	}
+	return nil
+}
+
+func (writer *RecordWriterMarkdown) flushBatch(
+	bufferedOutputStream *bufio.Writer,
+	outputIsStdout bool,
+) {
+	if writer.numBatchesOutput > 0 {
+		bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+	}
+
+	first := writer.batch[0]
+
+	// Floor of 3 so "---" never overflows the column.
+	maxWidths := make(map[string]int)
+	for pe := first.Head; pe != nil; pe = pe.Next {
+		maxWidths[pe.Key] = max(utf8.RuneCountInString(pe.Key), 3)
+	}
+	for _, rec := range writer.batch {
+		for pe := rec.Head; pe != nil; pe = pe.Next {
+			value := strings.ReplaceAll(pe.Value.String(), "|", "\\|")
+			width := utf8.RuneCountInString(value)
+			if width > maxWidths[pe.Key] {
+				maxWidths[pe.Key] = width
+			}
+		}
+	}
+
+	// Header
+	bufferedOutputStream.WriteString("|")
+	for pe := first.Head; pe != nil; pe = pe.Next {
+		bufferedOutputStream.WriteString(" ")
+		bufferedOutputStream.WriteString(colorizer.MaybeColorizeKey(pe.Key, outputIsStdout))
+		writePadding(bufferedOutputStream, maxWidths[pe.Key]-utf8.RuneCountInString(pe.Key))
+		bufferedOutputStream.WriteString(" |")
+	}
+	bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+
+	// Separator
+	bufferedOutputStream.WriteString("|")
+	for pe := first.Head; pe != nil; pe = pe.Next {
+		bufferedOutputStream.WriteString(" ---")
+		writePadding(bufferedOutputStream, maxWidths[pe.Key]-3)
+		bufferedOutputStream.WriteString(" |")
+	}
+	bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+
+	// Data
+	for _, rec := range writer.batch {
+		bufferedOutputStream.WriteString("|")
+		for pe := rec.Head; pe != nil; pe = pe.Next {
+			value := strings.ReplaceAll(pe.Value.String(), "|", "\\|")
+			bufferedOutputStream.WriteString(" ")
+			bufferedOutputStream.WriteString(colorizer.MaybeColorizeValue(value, outputIsStdout))
+			writePadding(bufferedOutputStream, maxWidths[pe.Key]-utf8.RuneCountInString(value))
+			bufferedOutputStream.WriteString(" |")
+		}
+		bufferedOutputStream.WriteString(writer.writerOptions.ORS)
+	}
+
+	writer.batch = nil
+	writer.batchJoinedHeader = nil
+	writer.numBatchesOutput++
+}
+
+func writePadding(bufferedOutputStream *bufio.Writer, n int) {
+	if n <= 0 {
+		return
+	}
+	bufferedOutputStream.WriteString(strings.Repeat(" ", n))
 }


### PR DESCRIPTION
## Summary

Adds a new Markdown-only flag `--omd-aligned` (alias `--omarkdown-aligned`) that left-justifies cells and pads each column to a uniform width. The rendered Markdown table is unaffected; the goal is readability of the raw Markdown source for humans reading or maintaining it. The flag implies `--omd`, so users do not need to pass both.

Before (`--omd`):

```
| ABCD | EFG | HIJKL |
| --- | --- | --- |
| xy | 1234 | 5 |
| stuvw | 67 | 8900 |
| def | 0 | 12345 |
```

After (`--omd-aligned`):
```
| ABCD  | EFG  | HIJKL |
| ---   | ---  | ---   |
| xy    | 1234 | 5     |
| stuvw | 67   | 8900  |
| def   | 0    | 12345 |
```

## Implementation

- New `MarkdownAlignedOutput` field on `TWriterOptions`.
- New `MarkdownOnlyFlagSection` in `pkg/cli/option_parse.go`.
- `record_writer_markdown.go` batches records by schema (like pprint), computes max column widths (with a floor of 3 so `---` always fits), then emits header / separator / data rows with bars vertically aligned. Default streaming markdown writer behavior is unchanged.
- Docs regenerated: `file-formats.md`, `reference-main-flag-list.md`, `manpage.md`, `manpage.txt`, `mlr.1`.

## Test plan

- [x] Manual smoke test with the example data above
- [x] Manual test of heterogeneous-schema input (each schema gets its own aligned table)
- [x] Manual test of pipe-escaping and empty cells
- [x] `mlr regtest` — 4654 cases pass, 0 fail
- [x] `mlr help flag --omd-aligned` prints the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)