### PR TITLE
Lazy per-record hashing: ~15-30% faster on common workloads

### DIFF
--- a/pkg/mlrval/mlrmap.go
+++ b/pkg/mlrval/mlrmap.go
@@ -63,13 +63,34 @@ func HashRecords(onOff bool) {
 	hashRecords = onOff
 }
 
+// mlrmapHashThreshold is the field-count at or above which a lazily-hashable
+// record builds its key-to-entry index on first lookup. Below this, linear
+// search through the (short) linked list is cheaper than allocating and
+// populating a map -- and, crucially, records that are never looked up (e.g.
+// `mlr cat`) never pay for a map at all. Wide records that do get looked up
+// still get hash-accelerated access, preserving the fix for
+// https://github.com/johnkerl/miller/issues/1506.
+const mlrmapHashThreshold = 12
+
 type Mlrmap struct {
 	FieldCount int64
 	Head       *MlrmapEntry
 	Tail       *MlrmapEntry
 
-	// This can be nil if hashRecords is off.
+	// keysToEntries is the key-to-entry index for hash-accelerated lookups.
+	// It can be nil in three situations:
+	//   - hashing is disabled entirely (`mlr --no-hash-records`), in which
+	//     case autoHash is false and the index is never built;
+	//   - the map is lazily hashable (autoHash true) but no lookup has yet
+	//     triggered index construction, or the record is narrow enough that
+	//     linear search is preferred;
+	//   - the map is empty.
 	keysToEntries map[string]*MlrmapEntry
+
+	// autoHash, when true, lets findEntry lazily build keysToEntries on the
+	// first lookup of a sufficiently-wide record. It is false for explicitly
+	// unhashed maps (`--no-hash-records`).
+	autoHash bool
 }
 
 type MlrmapEntry struct {
@@ -94,12 +115,28 @@ type MlrmapPair struct {
 
 func NewMlrmapAsRecord() *Mlrmap {
 	if hashRecords {
-		return newMlrmapHashed()
+		return newMlrmapLazyHashed()
 	}
 	return newMlrmapUnhashed()
 }
 func NewMlrmap() *Mlrmap {
 	return newMlrmapHashed()
+}
+
+// newMlrmapLazyHashed is the default for record-stream data. It allocates no
+// key-to-entry index up front; findEntry builds one on demand only when a
+// lookup occurs on a wide record (see mlrmapHashThreshold). This avoids a map
+// allocation and N map-inserts per record for the common case of streaming
+// over many narrow records, while retaining hash-accelerated lookups for wide
+// records that are actually queried.
+func newMlrmapLazyHashed() *Mlrmap {
+	return &Mlrmap{
+		FieldCount:    0,
+		Head:          nil,
+		Tail:          nil,
+		keysToEntries: nil,
+		autoHash:      true,
+	}
 }
 
 // Faster on record-stream data as noted above.

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -194,12 +194,34 @@ func (mlrmap *Mlrmap) findEntry(key string) *MlrmapEntry {
 	if mlrmap.keysToEntries != nil {
 		return mlrmap.keysToEntries[key]
 	}
+	// Lazily build the key-to-entry index when a lookup happens on a record
+	// wide enough to benefit. Narrow records (the common case) and records
+	// that are never looked up stay on the linear-search path and never pay
+	// for a map. See mlrmapHashThreshold.
+	if mlrmap.autoHash && mlrmap.FieldCount >= mlrmapHashThreshold {
+		mlrmap.buildIndex()
+		return mlrmap.keysToEntries[key]
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		if pe.Key == key {
 			return pe
 		}
 	}
 	return nil
+}
+
+// buildIndex populates keysToEntries from the linked list. Once built, all
+// mutators keep it in sync (each guards on keysToEntries != nil). On duplicate
+// keys the last entry wins, matching the linear-search semantics of findEntry
+// (which returns the first match), since records are deduped on insert.
+func (mlrmap *Mlrmap) buildIndex() {
+	m := make(map[string]*MlrmapEntry, mlrmap.FieldCount)
+	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
+		if _, ok := m[pe.Key]; !ok {
+			m[pe.Key] = pe
+		}
+	}
+	mlrmap.keysToEntries = m
 }
 
 // findEntryByPositionalIndex is for '$[1]' etc. in the DSL.
@@ -459,7 +481,14 @@ func (mlrmap *Mlrmap) Clear() {
 }
 
 func (mlrmap *Mlrmap) Copy() *Mlrmap {
-	other := NewMlrmapMaybeHashed(mlrmap.isHashed())
+	var other *Mlrmap
+	if mlrmap.autoHash {
+		// Preserve lazy-hashing semantics: don't force an eager index on the
+		// copy just because the source happens to have built one.
+		other = newMlrmapLazyHashed()
+	} else {
+		other = NewMlrmapMaybeHashed(mlrmap.isHashed())
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		other.PutCopy(pe.Key, pe.Value)
 	}


### PR DESCRIPTION
## What

Context: #2084.

Make per-record hashing **lazy**. Records (`NewMlrmapAsRecord`) no longer eagerly allocate and populate a `map[string]*MlrmapEntry` on construction. Instead, `findEntry` builds the index on the first lookup, and only when the record is wide enough (`FieldCount >= mlrmapHashThreshold`, currently 12) that linear search would be costly.

## Why

Profiling 1M-record CSV (`~/data/big.csv`) with `go tool pprof` (per [README-profiling.md](../blob/main/README-profiling.md)) showed runtime allocation/GC machinery — `pthread_cond_signal`, `madvise`, `scanobject`, `heapBitsSmallForAddr`, `memclrNoHeapPointers` — dominating every workload. `mlr cat` alone allocates ~20M objects / ~1.4 GB to copy 1M records.

A notable chunk of that is the per-record hash map, which the default (`hashRecords=true`) allocates and populates for **every** record — even though streaming verbs like `cat` never look records up by key. Confirming this, `--no-hash-records` was 25–30% faster across the board. But that flag makes wide-record lookups O(n), which is the regression that originally motivated turning hashing on (#1506).

Lazy hashing gets the best of both: narrow / never-looked-up records never pay for a map; wide records that are actually queried still get hash-accelerated lookups, matching the old eager-hash default.

(Worth noting: `GOGC=off` barely moved wall-clock — the concurrent collector overlaps on idle cores. The win is from making *fewer allocations* and skipping the per-key map work, not from collecting less.)

## Impact

`big.csv`, 1M × 7 cols, default flags, best of 3:

| workload | before | after | speedup |
|---|---|---|---|
| cat | 0.62 | 0.47 | ~24% |
| put chain-1 | 1.08 | 0.82 | ~24% |
| stats1 | 0.66 | 0.57 | ~14% |
| sort -n | 2.9 | 2.0 | ~30% |

Wide-column case protected: on a 60-col file with field lookups, lazy (1.42s) matches the old eager default (1.40s) and beats pure linear (1.55s).

## Design notes

- Transparent: `findEntry` already fell back to linear scan when `keysToEntries == nil`, and every mutator already guards on `keysToEntries != nil`, so a lazily-built index stays in sync automatically.
- DSL maps (`NewMlrmap`) keep eager hashing, to limit the behavioral surface to the record-stream path where the perf matters and lookups-per-record are low.
- `Copy()` preserves lazy-hash semantics rather than forcing an eager index on the copy.

## Verification

- `go test ./pkg/...` ✅
- Full `regression_test.go` suite ✅ (97s)
- Byte-identical output vs. forced `--hash-records` for `sort`, `stats1`, `cut`, wide-column `put`, and duplicate-key dedupe (`x=8,x=9` → `x=8,x_2=9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)