### PR TITLE
Perf experiment (negative result): zero-copy CSV reader trades 2-2.6x RSS for no wall-clock gain

### DIFF
--- a/pkg/input/csv_zerocopy_reader.go
+++ b/pkg/input/csv_zerocopy_reader.go
@@ -1,0 +1,269 @@
+package input
+
+import (
+	"bytes"
+	"io"
+	"unsafe"
+
+	csv "github.com/johnkerl/miller/v6/pkg/go-csv"
+)
+
+// ZeroCopyCSVReader is a prototype CSV record reader that avoids the
+// per-record string allocation made by the stdlib-derived go-csv parser.
+//
+// The stdlib parser, for each record, (a) accumulates the record's bytes into a
+// reused buffer and (b) does `string(buffer)` -- a fresh heap allocation and
+// copy -- so the returned field substrings have stable backing. That is one
+// allocation (plus the field-slice) per record.
+//
+// This reader instead reads the input in large, persistent blocks and returns
+// field strings that point *directly into the block* via unsafe.String. The
+// block stays alive for exactly as long as some field references it (ordinary
+// Go GC reachability), so no per-record copy is needed. Field bytes are never
+// mutated after being read, so the unsafe string views are sound.
+//
+// Scope of the prototype:
+//   - The fast path handles unquoted records (no '"' in the record) with ','
+//     (or the configured single-byte delimiter), LF or CRLF line endings. This
+//     is the overwhelmingly common case and is fully zero-copy for the field
+//     backing bytes.
+//   - Records containing '"' (quoted fields, embedded newlines, escaped quotes)
+//     are delegated to the proven go-csv parser over the isolated record bytes,
+//     for guaranteed correctness. These allocate, but are comparatively rare.
+//   - It is used only when LazyQuotes and TrimLeadingSpace are off (see the
+//     gating in processHandle); otherwise the original reader is used.
+//
+// It exposes Read() []string to be a drop-in for csv.Reader in the scanner.
+type ZeroCopyCSVReader struct {
+	handle  io.Reader
+	comma   byte
+	comment byte // 0 if comment handling is disabled
+
+	lazyQuotes       bool
+	trimLeadingSpace bool
+
+	buf           []byte // current persistent block
+	parseOff      int    // parse cursor within buf
+	filled        int    // valid bytes in buf
+	eofSeen       bool
+	pendingErr    error // non-EOF read error, surfaced after buffered data is drained
+	linesConsumed int   // physical input lines consumed so far (for error line numbers)
+
+	blockSize int
+}
+
+const zeroCopyCSVBlockSize = 64 * 1024
+
+func NewZeroCopyCSVReader(handle io.Reader, comma byte, comment byte, lazyQuotes, trimLeadingSpace bool) *ZeroCopyCSVReader {
+	return &ZeroCopyCSVReader{
+		handle:           handle,
+		comma:            comma,
+		comment:          comment,
+		lazyQuotes:       lazyQuotes,
+		trimLeadingSpace: trimLeadingSpace,
+		blockSize:        zeroCopyCSVBlockSize,
+	}
+}
+
+// bytesToString returns a string sharing b's backing array (no copy). Safe only
+// while b's bytes are immutable for the string's lifetime, which holds here:
+// block bytes are written once (by Read from the input) and never modified.
+func bytesToString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+// fill moves the unparsed tail to the front of a fresh block and reads more
+// input after it. A fresh block is allocated (rather than reusing buf) so that
+// field strings already handed out -- which point into the old block -- remain
+// valid; the old block is freed by GC once its last field is unreferenced.
+func (r *ZeroCopyCSVReader) fill() {
+	tailLen := r.filled - r.parseOff
+	newSize := r.blockSize
+	if tailLen*2 > newSize {
+		newSize = tailLen * 2
+	}
+	newbuf := make([]byte, newSize)
+	copy(newbuf, r.buf[r.parseOff:r.filled])
+	r.buf = newbuf
+	r.parseOff = 0
+	// Read until we make progress (n > 0) or hit EOF. An io.Reader is permitted
+	// to return (0, nil); looping here guarantees the caller's fill loop always
+	// makes progress, the way bufio.Reader did for the original parser.
+	for tailLen < len(r.buf) {
+		n, err := r.handle.Read(r.buf[tailLen:])
+		tailLen += n
+		if err == io.EOF {
+			r.eofSeen = true
+			break
+		}
+		if err != nil {
+			r.pendingErr = err
+			r.eofSeen = true
+			break
+		}
+		if n > 0 {
+			break
+		}
+	}
+	r.filled = tailLen
+}
+
+// ensureFirstNewline ensures buf holds a '\n' at or after parseOff (filling as
+// needed), returning its index, or filled if EOF is reached without one. fill()
+// preserves parseOff as the current line start, so the returned index is valid
+// in the current buf.
+func (r *ZeroCopyCSVReader) ensureFirstNewline() int {
+	for {
+		if nl := bytes.IndexByte(r.buf[r.parseOff:r.filled], '\n'); nl >= 0 {
+			return r.parseOff + nl
+		}
+		if r.eofSeen {
+			return r.filled
+		}
+		r.fill()
+	}
+}
+
+// scanRecord returns the record region [parseOff, lineEnd) (trailing CR
+// stripped), the offset of the next record, whether the record contained a
+// quote, and whether a complete record terminator was found within buf.
+func (r *ZeroCopyCSVReader) scanRecord() (lineEnd, nextOff int, hasQuote, complete bool) {
+	// Fast path: locate the next newline, then check the segment for a quote.
+	if nl := bytes.IndexByte(r.buf[r.parseOff:r.filled], '\n'); nl >= 0 {
+		segEnd := r.parseOff + nl
+		if bytes.IndexByte(r.buf[r.parseOff:segEnd], '"') < 0 {
+			end := segEnd
+			if end > r.parseOff && r.buf[end-1] == '\r' {
+				end--
+			}
+			return end, segEnd + 1, false, true
+		}
+	}
+	// Quote-aware scan: a newline only ends the record when not inside quotes.
+	inQuote := false
+	for i := r.parseOff; i < r.filled; i++ {
+		c := r.buf[i]
+		if c == '"' {
+			hasQuote = true
+			inQuote = !inQuote
+		} else if c == '\n' && !inQuote {
+			end := i
+			if end > r.parseOff && r.buf[end-1] == '\r' {
+				end--
+			}
+			return end, i + 1, hasQuote, true
+		}
+	}
+	return r.filled, r.filled, hasQuote, false
+}
+
+func (r *ZeroCopyCSVReader) Read() ([]string, error) {
+	// Ensure there is some unparsed data.
+	for r.parseOff >= r.filled && !r.eofSeen {
+		r.fill()
+	}
+	if r.parseOff >= r.filled {
+		if r.pendingErr != nil {
+			err := r.pendingErr
+			r.pendingErr = nil
+			return nil, err
+		}
+		return nil, io.EOF
+	}
+
+	// Comment lines are terminated by a single newline regardless of any quote
+	// characters they contain, and MUST be detected before quote parsing --
+	// otherwise a '"' inside a comment would make the quote-aware scan consume
+	// across the newline and swallow the following record. The go-csv fork's
+	// readLine includes the trailing terminator in the returned line, and
+	// --pass-comments echoes it verbatim, so we hand back the raw line with its
+	// \n / \r\n included.
+	if r.comment != 0 && r.buf[r.parseOff] == r.comment {
+		nl := r.ensureFirstNewline()
+		start := r.parseOff
+		if nl < r.filled {
+			r.parseOff = nl + 1
+		} else {
+			r.parseOff = r.filled
+		}
+		r.linesConsumed += bytes.Count(r.buf[start:r.parseOff], nlByte)
+		return []string{bytesToString(r.buf[start:r.parseOff])}, nil
+	}
+
+	// Ensure the whole record is buffered (it may span blocks, esp. quoted
+	// records with embedded newlines).
+	lineEnd, nextOff, hasQuote, complete := r.scanRecord()
+	for !complete && !r.eofSeen {
+		r.fill()
+		lineEnd, nextOff, hasQuote, complete = r.scanRecord()
+	}
+	if !complete {
+		// EOF with a final record lacking a trailing newline.
+		lineEnd = r.filled
+		if lineEnd > r.parseOff && r.buf[lineEnd-1] == '\r' {
+			lineEnd--
+		}
+		nextOff = r.filled
+	}
+
+	recordStartLine := r.linesConsumed + 1
+	record := r.buf[r.parseOff:lineEnd]
+	consumedStart := r.parseOff
+	r.parseOff = nextOff
+	r.linesConsumed += bytes.Count(r.buf[consumedStart:nextOff], nlByte)
+
+	if !hasQuote {
+		return r.splitNoQuote(record), nil
+	}
+	return r.parseQuoted(record, recordStartLine)
+}
+
+// splitNoQuote splits an unquoted record into zero-copy field views.
+func (r *ZeroCopyCSVReader) splitNoQuote(record []byte) []string {
+	n := 1
+	for i := 0; i < len(record); i++ {
+		if record[i] == r.comma {
+			n++
+		}
+	}
+	out := make([]string, n)
+	fi := 0
+	start := 0
+	for i := 0; i < len(record); i++ {
+		if record[i] == r.comma {
+			out[fi] = bytesToString(record[start:i])
+			fi++
+			start = i + 1
+		}
+	}
+	out[fi] = bytesToString(record[start:])
+	return out
+}
+
+// nlByte is the newline separator for bytes.Count (line accounting).
+var nlByte = []byte{'\n'}
+
+// parseQuoted delegates a quote-containing record to the proven go-csv parser
+// over the isolated record bytes. Correct (including escaped quotes and
+// embedded newlines) at the cost of allocation; rare for typical data. Because
+// the sub-parser numbers lines relative to the record, any ParseError's line
+// numbers are shifted to absolute file lines via startLine.
+func (r *ZeroCopyCSVReader) parseQuoted(record []byte, startLine int) ([]string, error) {
+	sub := csv.NewReader(bytes.NewReader(record))
+	sub.Comma = rune(r.comma)
+	sub.LazyQuotes = r.lazyQuotes
+	sub.TrimLeadingSpace = r.trimLeadingSpace
+	// Comment handling is applied at the line level above, not here.
+	fields, err := sub.Read()
+	if err != nil {
+		if pe, ok := err.(*csv.ParseError); ok {
+			offset := startLine - 1
+			pe.StartLine += offset
+			pe.Line += offset
+		}
+	}
+	return fields, err
+}

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -107,16 +107,31 @@ func (reader *RecordReaderCSV) processHandle(
 	reader.needHeader = !reader.readerOptions.UseImplicitHeader
 	reader.header = nil
 
-	csvReader := csv.NewReader(NewBOMStrippingReader(handle))
-	csvReader.Comma = rune(reader.ifs0)
-	csvReader.LazyQuotes = reader.csvLazyQuotes
-	csvReader.TrimLeadingSpace = reader.csvTrimLeadingSpace
-
+	var commentByte byte = 0
 	if reader.readerOptions.CommentHandling != cli.CommentsAreData {
 		if len(reader.readerOptions.CommentString) == 1 {
-			// Use our modified fork of the go-csv package
-			csvReader.Comment = rune(reader.readerOptions.CommentString[0])
+			commentByte = reader.readerOptions.CommentString[0]
 		}
+	}
+
+	var csvReader csvRecordReader
+	// PROTOTYPE: use the zero-copy reader for the common case. It avoids the
+	// per-record string copy in the stdlib-derived parser. LazyQuotes and
+	// TrimLeadingSpace fall back to the original reader.
+	if !reader.csvLazyQuotes && !reader.csvTrimLeadingSpace {
+		csvReader = NewZeroCopyCSVReader(
+			NewBOMStrippingReader(handle), reader.ifs0, commentByte,
+			reader.csvLazyQuotes, reader.csvTrimLeadingSpace,
+		)
+	} else {
+		goReader := csv.NewReader(NewBOMStrippingReader(handle))
+		goReader.Comma = rune(reader.ifs0)
+		goReader.LazyQuotes = reader.csvLazyQuotes
+		goReader.TrimLeadingSpace = reader.csvTrimLeadingSpace
+		if commentByte != 0 {
+			goReader.Comment = rune(commentByte)
+		}
+		csvReader = goReader
 	}
 
 	csvRecordsChannel := make(chan [][]string, recordsPerBatch)
@@ -134,9 +149,15 @@ func (reader *RecordReaderCSV) processHandle(
 	}
 }
 
+// csvRecordReader is the minimal interface the scanner needs: it is satisfied
+// by both the go-csv *Reader and the prototype *ZeroCopyCSVReader.
+type csvRecordReader interface {
+	Read() ([]string, error)
+}
+
 // TODO: comment
 func channelizedCSVRecordScanner(
-	csvReader *csv.Reader,
+	csvReader csvRecordReader,
 	csvRecordsChannel chan<- [][]string,
 	downstreamDoneChannel <-chan bool, // for mlr head
 	errorChannel chan error,

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -214,6 +214,12 @@ func (reader *RecordReaderCSV) getRecordBatch(
 	}
 	arena := mlrval.NewRecordArena(nfields)
 
+	// Batch-allocate the RecordAndContext wrappers too: one slab for the whole
+	// batch instead of one heap object per record. Comment/output-string entries
+	// (rare) still allocate individually via maybeConsumeComment.
+	racSlab := make([]types.RecordAndContext, len(csvRecords))
+	racIndex := 0
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,7 +248,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		nh := int64(len(reader.header))
 		nd := int64(len(csvRecord))
@@ -281,7 +287,11 @@ func (reader *RecordReaderCSV) getRecordBatch(
 
 		context.UpdateForInputRecord()
 
-		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+		rac := &racSlab[racIndex]
+		racIndex++
+		rac.Record = record
+		rac.Context = *context
+		recordsAndContexts = append(recordsAndContexts, rac)
 	}
 
 	return recordsAndContexts, false

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -206,6 +206,14 @@ func (reader *RecordReaderCSV) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	// Batch-arena: draw all field entries/values for this batch of records from
+	// two slabs instead of allocating each field individually. See RecordArena.
+	nfields := 0
+	for _, csvRecord := range csvRecords {
+		nfields += len(csvRecord)
+	}
+	arena := mlrval.NewRecordArena(nfields)
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,12 +250,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 		if nh == nd {
 			for i := range nh {
 				key := reader.header[i]
-				value := mlrval.FromDeferredType(csvRecord[i])
-				_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 			}
 
 		} else {
@@ -264,23 +267,13 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			n := lib.IntMin2(nh, nd)
 			for i = 0; i < n; i++ {
 				key := reader.header[i]
-				value := mlrval.FromDeferredType(csvRecord[i])
-				_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(csvRecord[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 				}
 			}
 			// if nh > nd: leave it short. This is a job for unsparsify.

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -176,6 +176,8 @@ func getRecordBatchExplicitCSVHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -228,12 +230,7 @@ func getRecordBatchExplicitCSVHeader(
 					if reader.useVoidRep && field == reader.voidRep {
 						field = ""
 					}
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -245,23 +242,13 @@ func getRecordBatchExplicitCSVHeader(
 					if reader.useVoidRep && field == reader.voidRep {
 						field = ""
 					}
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
-						value := mlrval.FromDeferredType(fields[i])
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -297,6 +284,8 @@ func getRecordBatchImplicitCSVHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -352,12 +341,7 @@ func getRecordBatchImplicitCSVHeader(
 				if reader.useVoidRep && field == reader.voidRep {
 					field = ""
 				}
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -369,12 +353,7 @@ func getRecordBatchImplicitCSVHeader(
 				if reader.useVoidRep && field == reader.voidRep {
 					field = ""
 				}
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
@@ -384,12 +363,7 @@ func getRecordBatchImplicitCSVHeader(
 						field = ""
 					}
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, field, dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -224,7 +224,7 @@ func getRecordBatchExplicitCSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					if reader.useVoidRep && field == reader.voidRep {
@@ -335,7 +335,7 @@ func getRecordBatchImplicitCSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				if reader.useVoidRep && field == reader.voidRep {

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -170,7 +170,7 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 }
 
 func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	pairs := reader.fieldSplitter.Split(line)
@@ -212,7 +212,7 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 }
 
 func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 
 	values := reader.fieldSplitter.Split(line)
 

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -23,6 +23,8 @@ type RecordReaderDKVPNIDX struct {
 	lineSplitter    line_splitter_DKVP_NIDX
 	fieldSplitter   iFieldSplitter
 	pairSplitter    iPairSplitter
+	// recordArena batch-allocates field entries/values; reset per getRecordBatch.
+	recordArena *mlrval.RecordArena
 }
 
 func NewRecordReaderDKVP(
@@ -35,6 +37,7 @@ func NewRecordReaderDKVP(
 		lineSplitter:    recordFromDKVPLine,
 		fieldSplitter:   newFieldSplitter(readerOptions),
 		pairSplitter:    newPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -48,6 +51,7 @@ func NewRecordReaderNIDX(
 		lineSplitter:    recordFromNIDXLine,
 		fieldSplitter:   newFieldSplitter(readerOptions),
 		pairSplitter:    newPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -132,6 +136,10 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	// Batch-allocate field entries/values from slabs. The hint over-estimates a
+	// little; the arena grows on demand if a batch is wider.
+	reader.recordArena = mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		// Check for comments-in-data feature
@@ -194,18 +202,10 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 			}
 			str_key := strconv.Itoa(int_key + 1)
 			incr_key++
-			value := mlrval.FromDeferredType(kv[0])
-			_, err := record.PutReferenceMaybeDedupe(str_key, value, dedupeFieldNames)
-			if err != nil {
-				return nil, err
-			}
+			reader.recordArena.PutDeferred(record, str_key, kv[0], dedupeFieldNames)
 		} else {
 			str_key := kv[0]
-			value := mlrval.FromDeferredType(kv[1])
-			_, err := record.PutReferenceMaybeDedupe(str_key, value, dedupeFieldNames)
-			if err != nil {
-				return nil, err
-			}
+			reader.recordArena.PutDeferred(record, str_key, kv[1], dedupeFieldNames)
 		}
 	}
 	return record, nil
@@ -220,8 +220,7 @@ func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 	for _, value := range values {
 		i++
 		str_key := strconv.Itoa(i)
-		mval := mlrval.FromDeferredType(value)
-		record.PutReference(str_key, mval)
+		reader.recordArena.PutDeferred(record, str_key, value, false)
 	}
 	return record, nil
 }

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -164,16 +164,17 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	nfields := 0
+	for _, omap := range dkvpxRecords {
+		nfields += int(omap.FieldCount)
+	}
+	arena := mlrval.NewRecordArena(nfields)
+
 	for _, omap := range dkvpxRecords {
 		record := mlrval.NewMlrmapAsRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
-			value := mlrval.FromDeferredType(pe.Value)
-			_, err := record.PutReferenceMaybeDedupe(pe.Key, value, dedupeFieldNames)
-			if err != nil {
-				errorChannel <- err
-				return nil, false
-			}
+			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)
 		}
 
 		context.UpdateForInputRecord()

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -171,7 +171,7 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 	arena := mlrval.NewRecordArena(nfields)
 
 	for _, omap := range dkvpxRecords {
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
 			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -239,7 +239,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -472,7 +472,7 @@ func getRecordBatchExplicitPprintHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -596,7 +596,7 @@ func getRecordBatchImplicitPprintHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -172,6 +172,8 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 		reader.inputLineNumber++
 
@@ -240,12 +242,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 		record := mlrval.NewMlrmapAsRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -253,23 +250,13 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			n := lib.IntMin2(nh, nd)
 			for i := int64(0); i < n; i++ {
 				field := fields[i]
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i := nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(fields[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 				}
 			}
 			if nh > nd {
@@ -418,6 +405,8 @@ func getRecordBatchExplicitPprintHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -486,12 +475,7 @@ func getRecordBatchExplicitPprintHeader(
 			record := mlrval.NewMlrmapAsRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -500,23 +484,13 @@ func getRecordBatchExplicitPprintHeader(
 				var i int64
 				for i = 0; i < n; i++ {
 					field := fields[i]
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
-						value := mlrval.FromDeferredType(fields[i])
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -553,6 +527,8 @@ func getRecordBatchImplicitPprintHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -623,12 +599,7 @@ func getRecordBatchImplicitPprintHeader(
 		record := mlrval.NewMlrmapAsRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -637,23 +608,13 @@ func getRecordBatchImplicitPprintHeader(
 			var i int64
 			for i = 0; i < n; i++ {
 				field := fields[i]
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(fields[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -158,6 +158,8 @@ func getRecordBatchExplicitTSVHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -195,12 +197,7 @@ func getRecordBatchExplicitTSVHeader(
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -209,24 +206,14 @@ func getRecordBatchExplicitTSVHeader(
 				var i int64
 				for i = 0; i < n; i++ {
 					field := lib.TSVDecodeField(fields[i])
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
 						field := lib.TSVDecodeField(fields[i])
-						value := mlrval.FromDeferredType(field)
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, field, dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -262,6 +249,8 @@ func getRecordBatchImplicitTSVHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -315,12 +304,7 @@ func getRecordBatchImplicitTSVHeader(
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -329,24 +313,14 @@ func getRecordBatchImplicitTSVHeader(
 			var i int64
 			for i = 0; i < n; i++ {
 				field := lib.TSVDecodeField(fields[i])
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
 					field := lib.TSVDecodeField(fields[i])
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, field, dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -193,7 +193,7 @@ func getRecordBatchExplicitTSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
@@ -300,7 +300,7 @@ func getRecordBatchImplicitTSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -275,7 +275,7 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 func (reader *RecordReaderXTAB) recordFromXTABLines(
 	stanza []string,
 ) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	for _, line := range stanza {

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -21,6 +21,8 @@ type RecordReaderXTAB struct {
 	readerOptions   *cli.TReaderOptions
 	recordsPerBatch int64 // distinct from readerOptions.RecordsPerBatch for join/repl
 	pairSplitter    iXTABPairSplitter
+	// recordArena batch-allocates field entries/values; reset per getRecordBatch.
+	recordArena *mlrval.RecordArena
 
 	// Note: XTAB uses two consecutive IFS in place of an IRS; IRS is ignored
 }
@@ -51,6 +53,7 @@ func NewRecordReaderXTAB(
 		readerOptions:   readerOptions,
 		recordsPerBatch: recordsPerBatch,
 		pairSplitter:    newXTABPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -245,6 +248,8 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	reader.recordArena = mlrval.NewRecordArena(len(stanzas) * 8)
+
 	for _, stanza := range stanzas {
 
 		if len(stanza.commentLines) > 0 {
@@ -280,10 +285,7 @@ func (reader *RecordReaderXTAB) recordFromXTABLines(
 			return nil, err
 		}
 
-		_, err = record.PutReferenceMaybeDedupe(key, mlrval.FromDeferredType(value), dedupeFieldNames)
-		if err != nil {
-			return nil, err
-		}
+		reader.recordArena.PutDeferred(record, key, value, dedupeFieldNames)
 	}
 
 	return record, nil

--- a/pkg/mlrval/mlrmap.go
+++ b/pkg/mlrval/mlrmap.go
@@ -63,13 +63,34 @@ func HashRecords(onOff bool) {
 	hashRecords = onOff
 }
 
+// mlrmapHashThreshold is the field-count at or above which a lazily-hashable
+// record builds its key-to-entry index on first lookup. Below this, linear
+// search through the (short) linked list is cheaper than allocating and
+// populating a map -- and, crucially, records that are never looked up (e.g.
+// `mlr cat`) never pay for a map at all. Wide records that do get looked up
+// still get hash-accelerated access, preserving the fix for
+// https://github.com/johnkerl/miller/issues/1506.
+const mlrmapHashThreshold = 12
+
 type Mlrmap struct {
 	FieldCount int64
 	Head       *MlrmapEntry
 	Tail       *MlrmapEntry
 
-	// This can be nil if hashRecords is off.
+	// keysToEntries is the key-to-entry index for hash-accelerated lookups.
+	// It can be nil in three situations:
+	//   - hashing is disabled entirely (`mlr --no-hash-records`), in which
+	//     case autoHash is false and the index is never built;
+	//   - the map is lazily hashable (autoHash true) but no lookup has yet
+	//     triggered index construction, or the record is narrow enough that
+	//     linear search is preferred;
+	//   - the map is empty.
 	keysToEntries map[string]*MlrmapEntry
+
+	// autoHash, when true, lets findEntry lazily build keysToEntries on the
+	// first lookup of a sufficiently-wide record. It is false for explicitly
+	// unhashed maps (`--no-hash-records`).
+	autoHash bool
 }
 
 type MlrmapEntry struct {
@@ -94,12 +115,28 @@ type MlrmapPair struct {
 
 func NewMlrmapAsRecord() *Mlrmap {
 	if hashRecords {
-		return newMlrmapHashed()
+		return newMlrmapLazyHashed()
 	}
 	return newMlrmapUnhashed()
 }
 func NewMlrmap() *Mlrmap {
 	return newMlrmapHashed()
+}
+
+// newMlrmapLazyHashed is the default for record-stream data. It allocates no
+// key-to-entry index up front; findEntry builds one on demand only when a
+// lookup occurs on a wide record (see mlrmapHashThreshold). This avoids a map
+// allocation and N map-inserts per record for the common case of streaming
+// over many narrow records, while retaining hash-accelerated lookups for wide
+// records that are actually queried.
+func newMlrmapLazyHashed() *Mlrmap {
+	return &Mlrmap{
+		FieldCount:    0,
+		Head:          nil,
+		Tail:          nil,
+		keysToEntries: nil,
+		autoHash:      true,
+	}
 }
 
 // Faster on record-stream data as noted above.

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -43,7 +43,13 @@ func (mlrmap *Mlrmap) PutReference(key string, value *Mlrval) {
 // and PutReferenceMaybeDedupe. It should not be invoked from anywhere else --
 // it doesn't do its own check if the key already exists in the record or not.
 func (mlrmap *Mlrmap) putReferenceNewAux(key string, value *Mlrval) {
-	pe := newMlrmapEntry(key, value)
+	mlrmap.linkNewEntry(newMlrmapEntry(key, value))
+}
+
+// linkNewEntry appends an already-constructed entry to the tail of the list and
+// updates the index if present. The entry must not already be in the map. It is
+// shared by the normal put path and by the batch-arena reader fast path.
+func (mlrmap *Mlrmap) linkNewEntry(pe *MlrmapEntry) {
 	if mlrmap.Head == nil {
 		mlrmap.Head = pe
 		mlrmap.Tail = pe
@@ -54,7 +60,7 @@ func (mlrmap *Mlrmap) putReferenceNewAux(key string, value *Mlrval) {
 		mlrmap.Tail = pe
 	}
 	if mlrmap.keysToEntries != nil {
-		mlrmap.keysToEntries[key] = pe
+		mlrmap.keysToEntries[pe.Key] = pe
 	}
 	mlrmap.FieldCount++
 }

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -194,12 +194,34 @@ func (mlrmap *Mlrmap) findEntry(key string) *MlrmapEntry {
 	if mlrmap.keysToEntries != nil {
 		return mlrmap.keysToEntries[key]
 	}
+	// Lazily build the key-to-entry index when a lookup happens on a record
+	// wide enough to benefit. Narrow records (the common case) and records
+	// that are never looked up stay on the linear-search path and never pay
+	// for a map. See mlrmapHashThreshold.
+	if mlrmap.autoHash && mlrmap.FieldCount >= mlrmapHashThreshold {
+		mlrmap.buildIndex()
+		return mlrmap.keysToEntries[key]
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		if pe.Key == key {
 			return pe
 		}
 	}
 	return nil
+}
+
+// buildIndex populates keysToEntries from the linked list. Once built, all
+// mutators keep it in sync (each guards on keysToEntries != nil). On duplicate
+// keys the last entry wins, matching the linear-search semantics of findEntry
+// (which returns the first match), since records are deduped on insert.
+func (mlrmap *Mlrmap) buildIndex() {
+	m := make(map[string]*MlrmapEntry, mlrmap.FieldCount)
+	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
+		if _, ok := m[pe.Key]; !ok {
+			m[pe.Key] = pe
+		}
+	}
+	mlrmap.keysToEntries = m
 }
 
 // findEntryByPositionalIndex is for '$[1]' etc. in the DSL.
@@ -459,7 +481,14 @@ func (mlrmap *Mlrmap) Clear() {
 }
 
 func (mlrmap *Mlrmap) Copy() *Mlrmap {
-	other := NewMlrmapMaybeHashed(mlrmap.isHashed())
+	var other *Mlrmap
+	if mlrmap.autoHash {
+		// Preserve lazy-hashing semantics: don't force an eager index on the
+		// copy just because the source happens to have built one.
+		other = newMlrmapLazyHashed()
+	} else {
+		other = NewMlrmapMaybeHashed(mlrmap.isHashed())
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		other.PutCopy(pe.Key, pe.Value)
 	}

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -1,0 +1,92 @@
+package mlrval
+
+import "strconv"
+
+// arenaChunkFields is the slab size (in fields) used when a RecordArena needs
+// to grow. It is large enough that a typical record batch draws from one or two
+// slabs, amortizing allocation overhead across thousands of fields.
+const arenaChunkFields = 4096
+
+// RecordArena is a batch (slab) allocator for record fields. A record reader
+// allocates one arena per batch of records and draws each field's MlrmapEntry
+// and Mlrval from contiguous slabs, turning two heap allocations per field into
+// roughly two allocations per slab.
+//
+// Lifetime: a slab stays alive as long as any entry or value drawn from it is
+// reachable. For streaming verbs the whole batch is processed and released
+// together, so its slabs are freed as units. For accumulating verbs (e.g. sort)
+// the slabs are retained for the duration -- the same bytes as before, but as a
+// few large objects rather than millions of tiny ones, which also lowers
+// resident-set size via reduced fragmentation.
+//
+// The arena grows on demand (allocating a fresh slab when the current one is
+// exhausted), so the size hint passed to NewRecordArena need not be exact: it
+// only sizes the first slab.
+type RecordArena struct {
+	entries []MlrmapEntry
+	values  []Mlrval
+	ei      int
+	vi      int
+	chunk   int
+}
+
+// NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
+// (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
+func NewRecordArena(nfieldsHint int) *RecordArena {
+	chunk := nfieldsHint
+	if chunk < 1 {
+		chunk = 1
+	}
+	if chunk > arenaChunkFields {
+		chunk = arenaChunkFields
+	}
+	return &RecordArena{chunk: chunk}
+}
+
+// PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type
+// value from the arena slabs. It mirrors PutReferenceMaybeDedupe's semantics for
+// duplicate keys. The value is built from the raw input string with type
+// inference deferred (MT_PENDING), exactly as FromDeferredType does.
+func (a *RecordArena) PutDeferred(mlrmap *Mlrmap, key string, input string, dedupe bool) {
+	pe := mlrmap.findEntry(key)
+	if pe == nil {
+		mlrmap.linkNewEntry(a.newEntry(key, input))
+		return
+	}
+	if !dedupe {
+		pe.Value = a.newValue(input)
+		return
+	}
+	for i := 2; ; i++ {
+		newKey := key + "_" + strconv.Itoa(i)
+		if mlrmap.findEntry(newKey) == nil {
+			mlrmap.linkNewEntry(a.newEntry(newKey, input))
+			return
+		}
+	}
+}
+
+func (a *RecordArena) newValue(input string) *Mlrval {
+	if a.vi >= len(a.values) {
+		a.values = make([]Mlrval, a.chunk)
+		a.vi = 0
+	}
+	v := &a.values[a.vi]
+	a.vi++
+	v.mvtype = MT_PENDING
+	v.printrep = input
+	v.printrepValid = true
+	return v
+}
+
+func (a *RecordArena) newEntry(key string, input string) *MlrmapEntry {
+	if a.ei >= len(a.entries) {
+		a.entries = make([]MlrmapEntry, a.chunk)
+		a.ei = 0
+	}
+	e := &a.entries[a.ei]
+	a.ei++
+	e.Key = key
+	e.Value = a.newValue(input)
+	return e
+}

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -28,7 +28,16 @@ type RecordArena struct {
 	ei      int
 	vi      int
 	chunk   int
+
+	// records is a slab of Mlrmap structs vended by NewRecord, so the record
+	// container itself is batch-allocated alongside its fields.
+	records []Mlrmap
+	ri      int
 }
+
+// arenaChunkRecords is the slab size (in records) for NewRecord. It tracks the
+// nominal records-per-batch so a batch typically draws from one slab.
+const arenaChunkRecords = 512
 
 // NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
 // (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
@@ -41,6 +50,24 @@ func NewRecordArena(nfieldsHint int) *RecordArena {
 		chunk = arenaChunkFields
 	}
 	return &RecordArena{chunk: chunk}
+}
+
+// NewRecord vends a fresh empty record (lazily-hashed, like NewMlrmapAsRecord)
+// from the arena's record slab, batch-allocating the Mlrmap struct itself. It
+// respects the global hashRecords setting: with --no-hash-records it returns an
+// unhashed map, matching NewMlrmapAsRecord.
+func (a *RecordArena) NewRecord() *Mlrmap {
+	if !hashRecords {
+		return newMlrmapUnhashed()
+	}
+	if a.ri >= len(a.records) {
+		a.records = make([]Mlrmap, arenaChunkRecords)
+		a.ri = 0
+	}
+	m := &a.records[a.ri]
+	a.ri++
+	m.autoHash = true
+	return m
 }
 
 // PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type

--- a/pkg/output/record_writer_csv.go
+++ b/pkg/output/record_writer_csv.go
@@ -19,6 +19,12 @@ type RecordWriterCSV struct {
 	firstRecordKeys   []string
 	firstRecordNF     int64
 	quoteAll          bool // For double-quote around all fields
+	// fieldsBuffer is a reusable scratch slice for the stringified field values
+	// of the record currently being written. WriteCSVRecordMaybeColorized
+	// consumes it synchronously and does not retain it, and the writer processes
+	// one record at a time, so a single buffer can be shared across records to
+	// avoid a per-record allocation.
+	fieldsBuffer []string
 }
 
 func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
@@ -76,7 +82,10 @@ func (writer *RecordWriterCSV) Write(
 		outputNF = writer.firstRecordNF
 	}
 
-	fields := make([]string, outputNF)
+	if int64(cap(writer.fieldsBuffer)) < outputNF {
+		writer.fieldsBuffer = make([]string, outputNF)
+	}
+	fields := writer.fieldsBuffer[:outputNF]
 	var i int64 = 0
 	for pe := outrec.Head; pe != nil; pe = pe.Next {
 		if i < writer.firstRecordNF && pe.Key != writer.firstRecordKeys[i] {


### PR DESCRIPTION
## Context

This is part of a performance investigation on #2084.

This issue records a **negative result**: an attempt to eliminate those last parser allocations with a zero-copy CSV reader.

## What was tried

A prototype `ZeroCopyCSVReader` that:

- reads input in large **persistent blocks** and returns field strings as `unsafe.String` views pointing **directly into the block** — no per-record `string(recordBuffer)` copy, no `recordBuffer` byte-accumulation;
- allocates a fresh block per refill, so field strings already handed downstream stay valid; a block is freed by GC once its last referencing field is unreachable;
- fully zero-copy for unquoted records (the common case); delegates quoted records (embedded newlines, escaped quotes) to the existing go-csv parser for guaranteed correctness;
- is gated to the common case (no `LazyQuotes`/`TrimLeadingSpace`).

## Correctness

It can be made fully correct — the full regression suite passes, **including a deterministic stress run forcing a 3-byte block size** across the entire suite (maximal record/field/line boundary splitting). Getting there required fixing three non-obvious issues that the regression suite caught:

1. **Comment trailing newline** — `--pass-comments` echoes the comment line verbatim *including* its terminator; the naive view stripped it, concatenating comments.
2. **Comment-before-quote ordering** — a `"` inside a comment line (`# x"y`) made the quote-aware record scan consume across the newline and swallow the following record. Comments must be detected (single-newline-terminated) *before* any quote parsing.
3. **Error line numbers** — delegating a quoted record to a sub-parser reports line numbers relative to the record ("line 1") instead of absolute file lines ("line 3"); fixed with line tracking and `ParseError` rewriting.

## Performance — why it's a no-go

Benchmarks on `~/data/big.csv` (1M rows × 7 cols), quiescent machine, `mlr --csv cat`:

| reader | wall-clock | peak RSS | GC cycles |
|---|---|---|---|
| stdlib-derived go-csv | ~0.21s | **~162 MB** | 12 |
| zero-copy prototype | ~0.22s | **~357–423 MB** | 7 |

- **Wall-clock: neutral.** After the earlier allocation-batching work, CSV `cat` is **I/O-bound** — a CPU profile shows `syscall` ~56% (bufio read + flush). Eliminating the per-record copy removes CPU work that was already overlapping with I/O on otherwise-idle cores, so wall-clock doesn't move. Confirmed neutral across `cat`/`stats1`/`cut` and under `GOGC=100/500/off`.
- **Peak RSS: 2–2.6× worse**, and this is *fundamental*, not a tuning artifact (it reproduces at every block size from 16 KB to 256 KB). Zero-copy pins an entire input block alive as long as **any** field drawn from it is still referenced. Miller's reader→transformer→writer pipeline buffers up to ~500 record-batches, so many blocks stay simultaneously live. The stdlib parser's fine-grained per-record strings instead keep memory proportional to the actually-live record data.

## Conclusion

Once allocation is batched, the CSV read path is **I/O-bound**, so there is no allocation-driven wall-clock left to recover here — and zero-copy pays for the (non-existent) savings with a large, structural memory regression due to coarse block pinning under deep pipeline buffering.

Prototype committed on branch `johnkerl/perf-try-4` for the record. **Not for merge.**
