### PR TITLE
Pool DSL stack frames across records (~8-9% perf on `mlr put`)

### DIFF
--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -214,6 +214,12 @@ func (reader *RecordReaderCSV) getRecordBatch(
 	}
 	arena := mlrval.NewRecordArena(nfields)
 
+	// Batch-allocate the RecordAndContext wrappers too: one slab for the whole
+	// batch instead of one heap object per record. Comment/output-string entries
+	// (rare) still allocate individually via maybeConsumeComment.
+	racSlab := make([]types.RecordAndContext, len(csvRecords))
+	racIndex := 0
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,7 +248,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		nh := int64(len(reader.header))
 		nd := int64(len(csvRecord))
@@ -281,7 +287,11 @@ func (reader *RecordReaderCSV) getRecordBatch(
 
 		context.UpdateForInputRecord()
 
-		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+		rac := &racSlab[racIndex]
+		racIndex++
+		rac.Record = record
+		rac.Context = *context
+		recordsAndContexts = append(recordsAndContexts, rac)
 	}
 
 	return recordsAndContexts, false

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -224,7 +224,7 @@ func getRecordBatchExplicitCSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					if reader.useVoidRep && field == reader.voidRep {
@@ -335,7 +335,7 @@ func getRecordBatchImplicitCSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				if reader.useVoidRep && field == reader.voidRep {

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -170,7 +170,7 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 }
 
 func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	pairs := reader.fieldSplitter.Split(line)
@@ -212,7 +212,7 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 }
 
 func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 
 	values := reader.fieldSplitter.Split(line)
 

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -171,7 +171,7 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 	arena := mlrval.NewRecordArena(nfields)
 
 	for _, omap := range dkvpxRecords {
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
 			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -239,7 +239,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -472,7 +472,7 @@ func getRecordBatchExplicitPprintHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -596,7 +596,7 @@ func getRecordBatchImplicitPprintHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -193,7 +193,7 @@ func getRecordBatchExplicitTSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
@@ -300,7 +300,7 @@ func getRecordBatchImplicitTSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -275,7 +275,7 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 func (reader *RecordReaderXTAB) recordFromXTABLines(
 	stanza []string,
 ) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	for _, line := range stanza {

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -28,7 +28,16 @@ type RecordArena struct {
 	ei      int
 	vi      int
 	chunk   int
+
+	// records is a slab of Mlrmap structs vended by NewRecord, so the record
+	// container itself is batch-allocated alongside its fields.
+	records []Mlrmap
+	ri      int
 }
+
+// arenaChunkRecords is the slab size (in records) for NewRecord. It tracks the
+// nominal records-per-batch so a batch typically draws from one slab.
+const arenaChunkRecords = 512
 
 // NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
 // (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
@@ -41,6 +50,24 @@ func NewRecordArena(nfieldsHint int) *RecordArena {
 		chunk = arenaChunkFields
 	}
 	return &RecordArena{chunk: chunk}
+}
+
+// NewRecord vends a fresh empty record (lazily-hashed, like NewMlrmapAsRecord)
+// from the arena's record slab, batch-allocating the Mlrmap struct itself. It
+// respects the global hashRecords setting: with --no-hash-records it returns an
+// unhashed map, matching NewMlrmapAsRecord.
+func (a *RecordArena) NewRecord() *Mlrmap {
+	if !hashRecords {
+		return newMlrmapUnhashed()
+	}
+	if a.ri >= len(a.records) {
+		a.records = make([]Mlrmap, arenaChunkRecords)
+		a.ri = 0
+	}
+	m := &a.records[a.ri]
+	a.ri++
+	m.autoHash = true
+	return m
 }
 
 // PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type

--- a/pkg/output/record_writer_csv.go
+++ b/pkg/output/record_writer_csv.go
@@ -19,6 +19,12 @@ type RecordWriterCSV struct {
 	firstRecordKeys   []string
 	firstRecordNF     int64
 	quoteAll          bool // For double-quote around all fields
+	// fieldsBuffer is a reusable scratch slice for the stringified field values
+	// of the record currently being written. WriteCSVRecordMaybeColorized
+	// consumes it synchronously and does not retain it, and the writer processes
+	// one record at a time, so a single buffer can be shared across records to
+	// avoid a per-record allocation.
+	fieldsBuffer []string
 }
 
 func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
@@ -76,7 +82,10 @@ func (writer *RecordWriterCSV) Write(
 		outputNF = writer.firstRecordNF
 	}
 
-	fields := make([]string, outputNF)
+	if int64(cap(writer.fieldsBuffer)) < outputNF {
+		writer.fieldsBuffer = make([]string, outputNF)
+	}
+	fields := writer.fieldsBuffer[:outputNF]
 	var i int64 = 0
 	for pe := outrec.Head; pe != nil; pe = pe.Next {
 		if i < writer.firstRecordNF && pe.Key != writer.firstRecordKeys[i] {

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -179,6 +179,12 @@ const stackFrameSetInitCap = 6
 
 type StackFrameSet struct {
 	stackFrames []*StackFrame
+	// pool retains popped frames for reuse. Push/pop is strictly LIFO and a
+	// StackFrameSet is reused across all records (it lives on the persistent
+	// runtime.State), so without pooling each record's block entry/exit would
+	// allocate and discard a StackFrame (a slice + a map). Pooling makes
+	// per-record block execution allocation-free after the first record.
+	pool []*StackFrame
 }
 
 func newStackFrameSet() *StackFrameSet {
@@ -190,11 +196,22 @@ func newStackFrameSet() *StackFrameSet {
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {
-	frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	n := len(frameset.pool)
+	if n > 0 {
+		frame := frameset.pool[n-1]
+		frameset.pool = frameset.pool[:n-1]
+		frame.clear()
+		frameset.stackFrames = append(frameset.stackFrames, frame)
+	} else {
+		frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	}
 }
 
 func (frameset *StackFrameSet) popStackFrame() {
-	frameset.stackFrames = frameset.stackFrames[0 : len(frameset.stackFrames)-1]
+	n := len(frameset.stackFrames)
+	frame := frameset.stackFrames[n-1]
+	frameset.stackFrames = frameset.stackFrames[0 : n-1]
+	frameset.pool = append(frameset.pool, frame)
 }
 
 // Returns nil on no-such
@@ -322,6 +339,17 @@ func newStackFrame() *StackFrame {
 		vars:           vars,
 		namesToOffsets: namesToOffsets,
 	}
+}
+
+// clear resets a frame for reuse from the pool, retaining its backing slice and
+// map allocations. The vars elements are nilled so reuse does not pin the
+// previous scope's variable values.
+func (frame *StackFrame) clear() {
+	for i := range frame.vars {
+		frame.vars[i] = nil
+	}
+	frame.vars = frame.vars[:0]
+	clear(frame.namesToOffsets)
 }
 
 // Returns nil on no such


### PR DESCRIPTION
**Stacked on #2083** (→ #2082 → #2081). Review/merge those first. First change targeting the **DSL / `put` allocation path** rather than the read/write path.

## What

A `StackFrameSet` lives on the persistent `runtime.State` and is reused across all records, but every block entry allocated a fresh `StackFrame` (a `[]*var` slice + a `map[string]int`) and discarded it on exit. `StatementBlockNode.Execute` does `PushStackFrame`/`PopStackFrame` — which runs **once per record** for the main block, plus once per `if`/`for`/etc. — so `put`/`filter` churned millions of throwaway frame allocations.

Since push/pop is strictly LIFO, retain popped frames in a per-frameset free list and clear-and-reuse them on the next push. After the first record establishes the max block-nesting depth, per-record block execution is allocation-free for frames. `len(stackFrames)` stays the logical depth, so `get`/`set`/`defineTyped`/`unset`/etc. are untouched — only `pushStackFrame`/`popStackFrame` change (plus a `StackFrame.clear()`).

## Why / impact

Profiling `put -f chain-1.mlr` over `big.csv` (1M rows) showed `newStackFrame` at ~2.86M allocations/run (~12% of objects). Pooling eliminates it:

| workload | before | after |
|---|---|---|
| put chain-1 | 0.78s | 0.72s (~8%) |
| put chain-4 | 0.96s | 0.87s (~9%) |

Allocation objects for `put chain-1` drop ~23.1M → ~20.0M.

## Notes / scope

- UDF/subroutine calls still allocate a fresh frameset per call (`PushStackFrameSet`); pooling those is a separate change (chain-1 has no UDFs).
- The dominant *remaining* DSL allocator is `FromFloat` (~6.8M — interior arithmetic temporaries from `**`, `/`, `log10`, `+`). Eliminating it needs node-owned result slots + in-place bif variants — a much larger, aliasing-sensitive refactor, deliberately left for follow-up.

## Verification

- `go test ./pkg/...` ✅ and full `regression_test.go` suite ✅
- `put` output byte-identical, including UDFs with locals/loops/blocks (`func f(n){var s=0; for(...){s+=i} return s}` → correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
