### PR TITLE
EXPERIMENT (negative result): DSL FromFloat temporary-elimination — ~10% ceiling, not worth it

### DIFF
--- a/EXPERIMENT-dsl-fromfloat-ceiling.md
+++ b/EXPERIMENT-dsl-fromfloat-ceiling.md
@@ -1,0 +1,59 @@
+# Experiment (negative result): eliminating DSL numeric-temporary allocations
+
+Status: **not pursued** — bounded ceiling too low to justify the cost/risk.
+No code change beyond this note; branch opened so the analysis is reviewable,
+then closed.
+
+## Background
+
+This continues the allocation-focused performance work (see PRs #2081, #2082,
+#2083, #2086). After pooling DSL stack frames (#2086), the dominant remaining
+allocator on the `put`/`filter` path is **`FromFloat`** (~6.8M objects for
+`put -f chain-1.mlr` over 1M-record CSV), with `FromInt` close behind. These
+are the interior temporaries of arithmetic expression evaluation: every binary
+op (`+`, `/`, `**`, …) and math function (`log10`, …) returns a freshly
+heap-allocated `*mlrval.Mlrval`.
+
+The proposed fix was the classic tree-walking-interpreter optimization:
+node-owned result slots + in-place bif variants, so an expression node computes
+into reusable storage instead of allocating per evaluation.
+
+## Why it was not pursued
+
+### 1. The performance ceiling is ~10%
+
+Before building anything, the ceiling was measured cheaply by hacking
+`FromFloat` and `FromInt` to reuse package-global `Mlrval`s — i.e. making those
+allocations *completely free*. (Output is garbage, but `chain-1` has no
+value-dependent branching, so wall-clock timing is representative.)
+
+| workload | baseline (post #2086) | FromFloat+FromInt allocation-free |
+|---|---|---|
+| `put` chain-1 | 0.71s | **0.64s (~10%)** |
+| `put` chain-4 | 0.86s | ~0.79s (~8%) |
+
+So eliminating *every* DSL numeric-temporary allocation — the entire point of
+the refactor — yields ~10% on the put-heavy workload and ~0 on `cat`/`sort`.
+A CPU profile explains why: `put` is ~27% I/O-bound (output writing), and on a
+multicore box the allocation/GC work largely overlaps idle cores, so the huge
+`FromFloat` *count* is not the wall-clock gate.
+
+### 2. The cost and risk are large
+
+- **Surface area:** `bifs.BinaryFunc` / `UnaryFunc` are `func(...) *Mlrval`,
+  dispatched through `[MT_DIM]`/`[MT_DIM][MT_DIM]` disposition matrices whose
+  cells each allocate via `FromFloat`/`FromInt`/etc. Making results in-place
+  means changing the function-type signatures and **hundreds** of cells.
+- **Aliasing / correctness:** reusing result storage is only safe if nothing
+  retains a result past its immediate consumer. Scalar retention points *do*
+  copy (verified: field `PutCopy`, oosvar direct `PutCopy`, local
+  `value.Copy()`), but indexed/collection stores (e.g. `Oosvars.PutIndexed`)
+  appear to store **by reference**, relying on the current always-fresh
+  invariant. Breaking that would cause silent cross-record data corruption —
+  the worst kind of bug — and would require a full audit + copy-on-store fixes.
+
+## Verdict
+
+~10% bounded upside on one workload, for a large refactor with real
+data-corruption risk. Not worth it. The clean, safe DSL win (stack-frame
+pooling, #2086) is kept; this avenue is closed.

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -214,6 +214,12 @@ func (reader *RecordReaderCSV) getRecordBatch(
 	}
 	arena := mlrval.NewRecordArena(nfields)
 
+	// Batch-allocate the RecordAndContext wrappers too: one slab for the whole
+	// batch instead of one heap object per record. Comment/output-string entries
+	// (rare) still allocate individually via maybeConsumeComment.
+	racSlab := make([]types.RecordAndContext, len(csvRecords))
+	racIndex := 0
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,7 +248,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		nh := int64(len(reader.header))
 		nd := int64(len(csvRecord))
@@ -281,7 +287,11 @@ func (reader *RecordReaderCSV) getRecordBatch(
 
 		context.UpdateForInputRecord()
 
-		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+		rac := &racSlab[racIndex]
+		racIndex++
+		rac.Record = record
+		rac.Context = *context
+		recordsAndContexts = append(recordsAndContexts, rac)
 	}
 
 	return recordsAndContexts, false

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -206,6 +206,14 @@ func (reader *RecordReaderCSV) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	// Batch-arena: draw all field entries/values for this batch of records from
+	// two slabs instead of allocating each field individually. See RecordArena.
+	nfields := 0
+	for _, csvRecord := range csvRecords {
+		nfields += len(csvRecord)
+	}
+	arena := mlrval.NewRecordArena(nfields)
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,12 +250,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 		if nh == nd {
 			for i := range nh {
 				key := reader.header[i]
-				value := mlrval.FromDeferredType(csvRecord[i])
-				_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 			}
 
 		} else {
@@ -264,23 +267,13 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			n := lib.IntMin2(nh, nd)
 			for i = 0; i < n; i++ {
 				key := reader.header[i]
-				value := mlrval.FromDeferredType(csvRecord[i])
-				_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(csvRecord[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, csvRecord[i], dedupeFieldNames)
 				}
 			}
 			// if nh > nd: leave it short. This is a job for unsparsify.

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -176,6 +176,8 @@ func getRecordBatchExplicitCSVHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -228,12 +230,7 @@ func getRecordBatchExplicitCSVHeader(
 					if reader.useVoidRep && field == reader.voidRep {
 						field = ""
 					}
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -245,23 +242,13 @@ func getRecordBatchExplicitCSVHeader(
 					if reader.useVoidRep && field == reader.voidRep {
 						field = ""
 					}
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
-						value := mlrval.FromDeferredType(fields[i])
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -297,6 +284,8 @@ func getRecordBatchImplicitCSVHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -352,12 +341,7 @@ func getRecordBatchImplicitCSVHeader(
 				if reader.useVoidRep && field == reader.voidRep {
 					field = ""
 				}
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -369,12 +353,7 @@ func getRecordBatchImplicitCSVHeader(
 				if reader.useVoidRep && field == reader.voidRep {
 					field = ""
 				}
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
@@ -384,12 +363,7 @@ func getRecordBatchImplicitCSVHeader(
 						field = ""
 					}
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, field, dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -224,7 +224,7 @@ func getRecordBatchExplicitCSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					if reader.useVoidRep && field == reader.voidRep {
@@ -335,7 +335,7 @@ func getRecordBatchImplicitCSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				if reader.useVoidRep && field == reader.voidRep {

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -170,7 +170,7 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 }
 
 func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	pairs := reader.fieldSplitter.Split(line)
@@ -212,7 +212,7 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 }
 
 func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 
 	values := reader.fieldSplitter.Split(line)
 

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -23,6 +23,8 @@ type RecordReaderDKVPNIDX struct {
 	lineSplitter    line_splitter_DKVP_NIDX
 	fieldSplitter   iFieldSplitter
 	pairSplitter    iPairSplitter
+	// recordArena batch-allocates field entries/values; reset per getRecordBatch.
+	recordArena *mlrval.RecordArena
 }
 
 func NewRecordReaderDKVP(
@@ -35,6 +37,7 @@ func NewRecordReaderDKVP(
 		lineSplitter:    recordFromDKVPLine,
 		fieldSplitter:   newFieldSplitter(readerOptions),
 		pairSplitter:    newPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -48,6 +51,7 @@ func NewRecordReaderNIDX(
 		lineSplitter:    recordFromNIDXLine,
 		fieldSplitter:   newFieldSplitter(readerOptions),
 		pairSplitter:    newPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -132,6 +136,10 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	// Batch-allocate field entries/values from slabs. The hint over-estimates a
+	// little; the arena grows on demand if a batch is wider.
+	reader.recordArena = mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		// Check for comments-in-data feature
@@ -194,18 +202,10 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 			}
 			str_key := strconv.Itoa(int_key + 1)
 			incr_key++
-			value := mlrval.FromDeferredType(kv[0])
-			_, err := record.PutReferenceMaybeDedupe(str_key, value, dedupeFieldNames)
-			if err != nil {
-				return nil, err
-			}
+			reader.recordArena.PutDeferred(record, str_key, kv[0], dedupeFieldNames)
 		} else {
 			str_key := kv[0]
-			value := mlrval.FromDeferredType(kv[1])
-			_, err := record.PutReferenceMaybeDedupe(str_key, value, dedupeFieldNames)
-			if err != nil {
-				return nil, err
-			}
+			reader.recordArena.PutDeferred(record, str_key, kv[1], dedupeFieldNames)
 		}
 	}
 	return record, nil
@@ -220,8 +220,7 @@ func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 	for _, value := range values {
 		i++
 		str_key := strconv.Itoa(i)
-		mval := mlrval.FromDeferredType(value)
-		record.PutReference(str_key, mval)
+		reader.recordArena.PutDeferred(record, str_key, value, false)
 	}
 	return record, nil
 }

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -164,16 +164,17 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	nfields := 0
+	for _, omap := range dkvpxRecords {
+		nfields += int(omap.FieldCount)
+	}
+	arena := mlrval.NewRecordArena(nfields)
+
 	for _, omap := range dkvpxRecords {
 		record := mlrval.NewMlrmapAsRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
-			value := mlrval.FromDeferredType(pe.Value)
-			_, err := record.PutReferenceMaybeDedupe(pe.Key, value, dedupeFieldNames)
-			if err != nil {
-				errorChannel <- err
-				return nil, false
-			}
+			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)
 		}
 
 		context.UpdateForInputRecord()

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -171,7 +171,7 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 	arena := mlrval.NewRecordArena(nfields)
 
 	for _, omap := range dkvpxRecords {
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
 			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -239,7 +239,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -472,7 +472,7 @@ func getRecordBatchExplicitPprintHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -596,7 +596,7 @@ func getRecordBatchImplicitPprintHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -172,6 +172,8 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 		reader.inputLineNumber++
 
@@ -240,12 +242,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 		record := mlrval.NewMlrmapAsRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -253,23 +250,13 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			n := lib.IntMin2(nh, nd)
 			for i := int64(0); i < n; i++ {
 				field := fields[i]
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i := nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(fields[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 				}
 			}
 			if nh > nd {
@@ -418,6 +405,8 @@ func getRecordBatchExplicitPprintHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -486,12 +475,7 @@ func getRecordBatchExplicitPprintHeader(
 			record := mlrval.NewMlrmapAsRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -500,23 +484,13 @@ func getRecordBatchExplicitPprintHeader(
 				var i int64
 				for i = 0; i < n; i++ {
 					field := fields[i]
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
-						value := mlrval.FromDeferredType(fields[i])
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -553,6 +527,8 @@ func getRecordBatchImplicitPprintHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -623,12 +599,7 @@ func getRecordBatchImplicitPprintHeader(
 		record := mlrval.NewMlrmapAsRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -637,23 +608,13 @@ func getRecordBatchImplicitPprintHeader(
 			var i int64
 			for i = 0; i < n; i++ {
 				field := fields[i]
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
-					value := mlrval.FromDeferredType(fields[i])
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, fields[i], dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -158,6 +158,8 @@ func getRecordBatchExplicitTSVHeader(
 		return recordsAndContexts, true
 	}
 
+	arena := mlrval.NewRecordArena(len(lines) * 8)
+
 	for _, line := range lines {
 
 		reader.inputLineNumber++
@@ -195,12 +197,7 @@ func getRecordBatchExplicitTSVHeader(
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 			} else {
 				nh := int64(len(reader.headerStrings))
@@ -209,24 +206,14 @@ func getRecordBatchExplicitTSVHeader(
 				var i int64
 				for i = 0; i < n; i++ {
 					field := lib.TSVDecodeField(fields[i])
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 				}
 				if nh < nd {
 					// if header shorter than data: use 1-up itoa keys
 					for i = nh; i < nd; i++ {
 						key := strconv.FormatInt(i+1, 10)
 						field := lib.TSVDecodeField(fields[i])
-						value := mlrval.FromDeferredType(field)
-						_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-						if err != nil {
-							errorChannel <- err
-							return
-						}
+						arena.PutDeferred(record, key, field, dedupeFieldNames)
 					}
 				}
 				if nh > nd {
@@ -262,6 +249,8 @@ func getRecordBatchImplicitTSVHeader(
 	if !more {
 		return recordsAndContexts, true
 	}
+
+	arena := mlrval.NewRecordArena(len(lines) * 8)
 
 	for _, line := range lines {
 
@@ -315,12 +304,7 @@ func getRecordBatchImplicitTSVHeader(
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 		} else {
 			nh := int64(len(reader.headerStrings))
@@ -329,24 +313,14 @@ func getRecordBatchImplicitTSVHeader(
 			var i int64
 			for i = 0; i < n; i++ {
 				field := lib.TSVDecodeField(fields[i])
-				value := mlrval.FromDeferredType(field)
-				_, err := record.PutReferenceMaybeDedupe(reader.headerStrings[i], value, dedupeFieldNames)
-				if err != nil {
-					errorChannel <- err
-					return
-				}
+				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
 			}
 			if nh < nd {
 				// if header shorter than data: use 1-up itoa keys
 				for i = nh; i < nd; i++ {
 					key := strconv.FormatInt(i+1, 10)
 					field := lib.TSVDecodeField(fields[i])
-					value := mlrval.FromDeferredType(field)
-					_, err := record.PutReferenceMaybeDedupe(key, value, dedupeFieldNames)
-					if err != nil {
-						errorChannel <- err
-						return
-					}
+					arena.PutDeferred(record, key, field, dedupeFieldNames)
 				}
 			}
 			if nh > nd {

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -193,7 +193,7 @@ func getRecordBatchExplicitTSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
@@ -300,7 +300,7 @@ func getRecordBatchImplicitTSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -275,7 +275,7 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 func (reader *RecordReaderXTAB) recordFromXTABLines(
 	stanza []string,
 ) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	for _, line := range stanza {

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -21,6 +21,8 @@ type RecordReaderXTAB struct {
 	readerOptions   *cli.TReaderOptions
 	recordsPerBatch int64 // distinct from readerOptions.RecordsPerBatch for join/repl
 	pairSplitter    iXTABPairSplitter
+	// recordArena batch-allocates field entries/values; reset per getRecordBatch.
+	recordArena *mlrval.RecordArena
 
 	// Note: XTAB uses two consecutive IFS in place of an IRS; IRS is ignored
 }
@@ -51,6 +53,7 @@ func NewRecordReaderXTAB(
 		readerOptions:   readerOptions,
 		recordsPerBatch: recordsPerBatch,
 		pairSplitter:    newXTABPairSplitter(readerOptions),
+		recordArena:     mlrval.NewRecordArena(64),
 	}, nil
 }
 
@@ -245,6 +248,8 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 		return recordsAndContexts, true
 	}
 
+	reader.recordArena = mlrval.NewRecordArena(len(stanzas) * 8)
+
 	for _, stanza := range stanzas {
 
 		if len(stanza.commentLines) > 0 {
@@ -280,10 +285,7 @@ func (reader *RecordReaderXTAB) recordFromXTABLines(
 			return nil, err
 		}
 
-		_, err = record.PutReferenceMaybeDedupe(key, mlrval.FromDeferredType(value), dedupeFieldNames)
-		if err != nil {
-			return nil, err
-		}
+		reader.recordArena.PutDeferred(record, key, value, dedupeFieldNames)
 	}
 
 	return record, nil

--- a/pkg/mlrval/mlrmap.go
+++ b/pkg/mlrval/mlrmap.go
@@ -63,13 +63,34 @@ func HashRecords(onOff bool) {
 	hashRecords = onOff
 }
 
+// mlrmapHashThreshold is the field-count at or above which a lazily-hashable
+// record builds its key-to-entry index on first lookup. Below this, linear
+// search through the (short) linked list is cheaper than allocating and
+// populating a map -- and, crucially, records that are never looked up (e.g.
+// `mlr cat`) never pay for a map at all. Wide records that do get looked up
+// still get hash-accelerated access, preserving the fix for
+// https://github.com/johnkerl/miller/issues/1506.
+const mlrmapHashThreshold = 12
+
 type Mlrmap struct {
 	FieldCount int64
 	Head       *MlrmapEntry
 	Tail       *MlrmapEntry
 
-	// This can be nil if hashRecords is off.
+	// keysToEntries is the key-to-entry index for hash-accelerated lookups.
+	// It can be nil in three situations:
+	//   - hashing is disabled entirely (`mlr --no-hash-records`), in which
+	//     case autoHash is false and the index is never built;
+	//   - the map is lazily hashable (autoHash true) but no lookup has yet
+	//     triggered index construction, or the record is narrow enough that
+	//     linear search is preferred;
+	//   - the map is empty.
 	keysToEntries map[string]*MlrmapEntry
+
+	// autoHash, when true, lets findEntry lazily build keysToEntries on the
+	// first lookup of a sufficiently-wide record. It is false for explicitly
+	// unhashed maps (`--no-hash-records`).
+	autoHash bool
 }
 
 type MlrmapEntry struct {
@@ -94,12 +115,28 @@ type MlrmapPair struct {
 
 func NewMlrmapAsRecord() *Mlrmap {
 	if hashRecords {
-		return newMlrmapHashed()
+		return newMlrmapLazyHashed()
 	}
 	return newMlrmapUnhashed()
 }
 func NewMlrmap() *Mlrmap {
 	return newMlrmapHashed()
+}
+
+// newMlrmapLazyHashed is the default for record-stream data. It allocates no
+// key-to-entry index up front; findEntry builds one on demand only when a
+// lookup occurs on a wide record (see mlrmapHashThreshold). This avoids a map
+// allocation and N map-inserts per record for the common case of streaming
+// over many narrow records, while retaining hash-accelerated lookups for wide
+// records that are actually queried.
+func newMlrmapLazyHashed() *Mlrmap {
+	return &Mlrmap{
+		FieldCount:    0,
+		Head:          nil,
+		Tail:          nil,
+		keysToEntries: nil,
+		autoHash:      true,
+	}
 }
 
 // Faster on record-stream data as noted above.

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -43,7 +43,13 @@ func (mlrmap *Mlrmap) PutReference(key string, value *Mlrval) {
 // and PutReferenceMaybeDedupe. It should not be invoked from anywhere else --
 // it doesn't do its own check if the key already exists in the record or not.
 func (mlrmap *Mlrmap) putReferenceNewAux(key string, value *Mlrval) {
-	pe := newMlrmapEntry(key, value)
+	mlrmap.linkNewEntry(newMlrmapEntry(key, value))
+}
+
+// linkNewEntry appends an already-constructed entry to the tail of the list and
+// updates the index if present. The entry must not already be in the map. It is
+// shared by the normal put path and by the batch-arena reader fast path.
+func (mlrmap *Mlrmap) linkNewEntry(pe *MlrmapEntry) {
 	if mlrmap.Head == nil {
 		mlrmap.Head = pe
 		mlrmap.Tail = pe
@@ -54,7 +60,7 @@ func (mlrmap *Mlrmap) putReferenceNewAux(key string, value *Mlrval) {
 		mlrmap.Tail = pe
 	}
 	if mlrmap.keysToEntries != nil {
-		mlrmap.keysToEntries[key] = pe
+		mlrmap.keysToEntries[pe.Key] = pe
 	}
 	mlrmap.FieldCount++
 }

--- a/pkg/mlrval/mlrmap_accessors.go
+++ b/pkg/mlrval/mlrmap_accessors.go
@@ -194,12 +194,34 @@ func (mlrmap *Mlrmap) findEntry(key string) *MlrmapEntry {
 	if mlrmap.keysToEntries != nil {
 		return mlrmap.keysToEntries[key]
 	}
+	// Lazily build the key-to-entry index when a lookup happens on a record
+	// wide enough to benefit. Narrow records (the common case) and records
+	// that are never looked up stay on the linear-search path and never pay
+	// for a map. See mlrmapHashThreshold.
+	if mlrmap.autoHash && mlrmap.FieldCount >= mlrmapHashThreshold {
+		mlrmap.buildIndex()
+		return mlrmap.keysToEntries[key]
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		if pe.Key == key {
 			return pe
 		}
 	}
 	return nil
+}
+
+// buildIndex populates keysToEntries from the linked list. Once built, all
+// mutators keep it in sync (each guards on keysToEntries != nil). On duplicate
+// keys the last entry wins, matching the linear-search semantics of findEntry
+// (which returns the first match), since records are deduped on insert.
+func (mlrmap *Mlrmap) buildIndex() {
+	m := make(map[string]*MlrmapEntry, mlrmap.FieldCount)
+	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
+		if _, ok := m[pe.Key]; !ok {
+			m[pe.Key] = pe
+		}
+	}
+	mlrmap.keysToEntries = m
 }
 
 // findEntryByPositionalIndex is for '$[1]' etc. in the DSL.
@@ -459,7 +481,14 @@ func (mlrmap *Mlrmap) Clear() {
 }
 
 func (mlrmap *Mlrmap) Copy() *Mlrmap {
-	other := NewMlrmapMaybeHashed(mlrmap.isHashed())
+	var other *Mlrmap
+	if mlrmap.autoHash {
+		// Preserve lazy-hashing semantics: don't force an eager index on the
+		// copy just because the source happens to have built one.
+		other = newMlrmapLazyHashed()
+	} else {
+		other = NewMlrmapMaybeHashed(mlrmap.isHashed())
+	}
 	for pe := mlrmap.Head; pe != nil; pe = pe.Next {
 		other.PutCopy(pe.Key, pe.Value)
 	}

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -1,0 +1,92 @@
+package mlrval
+
+import "strconv"
+
+// arenaChunkFields is the slab size (in fields) used when a RecordArena needs
+// to grow. It is large enough that a typical record batch draws from one or two
+// slabs, amortizing allocation overhead across thousands of fields.
+const arenaChunkFields = 4096
+
+// RecordArena is a batch (slab) allocator for record fields. A record reader
+// allocates one arena per batch of records and draws each field's MlrmapEntry
+// and Mlrval from contiguous slabs, turning two heap allocations per field into
+// roughly two allocations per slab.
+//
+// Lifetime: a slab stays alive as long as any entry or value drawn from it is
+// reachable. For streaming verbs the whole batch is processed and released
+// together, so its slabs are freed as units. For accumulating verbs (e.g. sort)
+// the slabs are retained for the duration -- the same bytes as before, but as a
+// few large objects rather than millions of tiny ones, which also lowers
+// resident-set size via reduced fragmentation.
+//
+// The arena grows on demand (allocating a fresh slab when the current one is
+// exhausted), so the size hint passed to NewRecordArena need not be exact: it
+// only sizes the first slab.
+type RecordArena struct {
+	entries []MlrmapEntry
+	values  []Mlrval
+	ei      int
+	vi      int
+	chunk   int
+}
+
+// NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
+// (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
+func NewRecordArena(nfieldsHint int) *RecordArena {
+	chunk := nfieldsHint
+	if chunk < 1 {
+		chunk = 1
+	}
+	if chunk > arenaChunkFields {
+		chunk = arenaChunkFields
+	}
+	return &RecordArena{chunk: chunk}
+}
+
+// PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type
+// value from the arena slabs. It mirrors PutReferenceMaybeDedupe's semantics for
+// duplicate keys. The value is built from the raw input string with type
+// inference deferred (MT_PENDING), exactly as FromDeferredType does.
+func (a *RecordArena) PutDeferred(mlrmap *Mlrmap, key string, input string, dedupe bool) {
+	pe := mlrmap.findEntry(key)
+	if pe == nil {
+		mlrmap.linkNewEntry(a.newEntry(key, input))
+		return
+	}
+	if !dedupe {
+		pe.Value = a.newValue(input)
+		return
+	}
+	for i := 2; ; i++ {
+		newKey := key + "_" + strconv.Itoa(i)
+		if mlrmap.findEntry(newKey) == nil {
+			mlrmap.linkNewEntry(a.newEntry(newKey, input))
+			return
+		}
+	}
+}
+
+func (a *RecordArena) newValue(input string) *Mlrval {
+	if a.vi >= len(a.values) {
+		a.values = make([]Mlrval, a.chunk)
+		a.vi = 0
+	}
+	v := &a.values[a.vi]
+	a.vi++
+	v.mvtype = MT_PENDING
+	v.printrep = input
+	v.printrepValid = true
+	return v
+}
+
+func (a *RecordArena) newEntry(key string, input string) *MlrmapEntry {
+	if a.ei >= len(a.entries) {
+		a.entries = make([]MlrmapEntry, a.chunk)
+		a.ei = 0
+	}
+	e := &a.entries[a.ei]
+	a.ei++
+	e.Key = key
+	e.Value = a.newValue(input)
+	return e
+}

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -28,7 +28,16 @@ type RecordArena struct {
 	ei      int
 	vi      int
 	chunk   int
+
+	// records is a slab of Mlrmap structs vended by NewRecord, so the record
+	// container itself is batch-allocated alongside its fields.
+	records []Mlrmap
+	ri      int
 }
+
+// arenaChunkRecords is the slab size (in records) for NewRecord. It tracks the
+// nominal records-per-batch so a batch typically draws from one slab.
+const arenaChunkRecords = 512
 
 // NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
 // (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
@@ -41,6 +50,24 @@ func NewRecordArena(nfieldsHint int) *RecordArena {
 		chunk = arenaChunkFields
 	}
 	return &RecordArena{chunk: chunk}
+}
+
+// NewRecord vends a fresh empty record (lazily-hashed, like NewMlrmapAsRecord)
+// from the arena's record slab, batch-allocating the Mlrmap struct itself. It
+// respects the global hashRecords setting: with --no-hash-records it returns an
+// unhashed map, matching NewMlrmapAsRecord.
+func (a *RecordArena) NewRecord() *Mlrmap {
+	if !hashRecords {
+		return newMlrmapUnhashed()
+	}
+	if a.ri >= len(a.records) {
+		a.records = make([]Mlrmap, arenaChunkRecords)
+		a.ri = 0
+	}
+	m := &a.records[a.ri]
+	a.ri++
+	m.autoHash = true
+	return m
 }
 
 // PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type

--- a/pkg/output/record_writer_csv.go
+++ b/pkg/output/record_writer_csv.go
@@ -19,6 +19,12 @@ type RecordWriterCSV struct {
 	firstRecordKeys   []string
 	firstRecordNF     int64
 	quoteAll          bool // For double-quote around all fields
+	// fieldsBuffer is a reusable scratch slice for the stringified field values
+	// of the record currently being written. WriteCSVRecordMaybeColorized
+	// consumes it synchronously and does not retain it, and the writer processes
+	// one record at a time, so a single buffer can be shared across records to
+	// avoid a per-record allocation.
+	fieldsBuffer []string
 }
 
 func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
@@ -76,7 +82,10 @@ func (writer *RecordWriterCSV) Write(
 		outputNF = writer.firstRecordNF
 	}
 
-	fields := make([]string, outputNF)
+	if int64(cap(writer.fieldsBuffer)) < outputNF {
+		writer.fieldsBuffer = make([]string, outputNF)
+	}
+	fields := writer.fieldsBuffer[:outputNF]
 	var i int64 = 0
 	for pe := outrec.Head; pe != nil; pe = pe.Next {
 		if i < writer.firstRecordNF && pe.Key != writer.firstRecordKeys[i] {

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -179,6 +179,12 @@ const stackFrameSetInitCap = 6
 
 type StackFrameSet struct {
 	stackFrames []*StackFrame
+	// pool retains popped frames for reuse. Push/pop is strictly LIFO and a
+	// StackFrameSet is reused across all records (it lives on the persistent
+	// runtime.State), so without pooling each record's block entry/exit would
+	// allocate and discard a StackFrame (a slice + a map). Pooling makes
+	// per-record block execution allocation-free after the first record.
+	pool []*StackFrame
 }
 
 func newStackFrameSet() *StackFrameSet {
@@ -190,11 +196,22 @@ func newStackFrameSet() *StackFrameSet {
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {
-	frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	n := len(frameset.pool)
+	if n > 0 {
+		frame := frameset.pool[n-1]
+		frameset.pool = frameset.pool[:n-1]
+		frame.clear()
+		frameset.stackFrames = append(frameset.stackFrames, frame)
+	} else {
+		frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	}
 }
 
 func (frameset *StackFrameSet) popStackFrame() {
-	frameset.stackFrames = frameset.stackFrames[0 : len(frameset.stackFrames)-1]
+	n := len(frameset.stackFrames)
+	frame := frameset.stackFrames[n-1]
+	frameset.stackFrames = frameset.stackFrames[0 : n-1]
+	frameset.pool = append(frameset.pool, frame)
 }
 
 // Returns nil on no-such
@@ -322,6 +339,17 @@ func newStackFrame() *StackFrame {
 		vars:           vars,
 		namesToOffsets: namesToOffsets,
 	}
+}
+
+// clear resets a frame for reuse from the pool, retaining its backing slice and
+// map allocations. The vars elements are nilled so reuse does not pin the
+// previous scope's variable values.
+func (frame *StackFrame) clear() {
+	for i := range frame.vars {
+		frame.vars[i] = nil
+	}
+	frame.vars = frame.vars[:0]
+	clear(frame.namesToOffsets)
 }
 
 // Returns nil on no such


### PR DESCRIPTION
**Negative result — open-and-close, do not merge.** Stacked on #2086.

Continues the allocation-perf work. After stack-frame pooling (#2086), the #1 remaining `put` allocator is `FromFloat` (~6.8M objects for `put -f chain-1.mlr`) — interior arithmetic temporaries. The proposed fix was node-owned result slots + in-place bif variants.

**Before building it, I measured the ceiling** by hacking `FromFloat`/`FromInt` to reuse globals (allocation-free; garbage output but representative timing since chain-1 has no value-dependent branching):

| workload | baseline (post #2086) | FromFloat+FromInt allocation-free |
|---|---|---|
| put chain-1 | 0.71s | **0.64s (~10%)** |
| put chain-4 | 0.86s | ~0.79s (~8%) |

So eliminating **every** DSL numeric temporary — the whole point of the refactor — buys ~10% on the put-heavy workload and ~0 on cat/sort. `put` is ~27% I/O-bound and the allocation cost overlaps GC on idle cores, so `FromFloat`'s huge *count* isn't the wall-clock gate.

**Cost/risk of the real refactor:** change `bifs.BinaryFunc`/`UnaryFunc` signatures across hundreds of disposition-matrix cells, **plus** an aliasing audit — scalar retention points copy (field/oosvar/local verified), but indexed/collection stores (`Oosvars.PutIndexed`) appear to store by reference, relying on the current always-fresh invariant; breaking it = silent cross-record corruption.

**Verdict:** not worth ~10% for that surface area and corruption risk. Closing. The clean DSL win (frame pooling, #2086) stands. See the committed `EXPERIMENT-dsl-fromfloat-ceiling.md` for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
