### PR TITLE
Drop redundant deep-copy of UDF return values (~3-16% perf on UDFs in `mlr put`)

### DIFF
--- a/pkg/dsl/cst/udf.go
+++ b/pkg/dsl/cst/udf.go
@@ -304,7 +304,12 @@ func (site *UDFCallsite) EvaluateWithArguments(
 		"function "+udf.signature.funcOrSubrName+" return value",
 	)
 
-	return blockExitPayload.blockReturnValue.Copy()
+	// blockReturnValue is already an independent deep copy: ReturnNode.Execute
+	// does returnValue.Copy() when building the payload, precisely so the value
+	// survives the callee frame being popped (and, with frame pooling, reused).
+	// A second copy here is redundant -- the caller copies again if it stores
+	// the value (field/oosvar/local assignment all PutCopy/Copy).
+	return blockExitPayload.blockReturnValue
 }
 
 // UDFManager tracks named UDFs like 'func f(a, b) { return b - a }'

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -214,6 +214,12 @@ func (reader *RecordReaderCSV) getRecordBatch(
 	}
 	arena := mlrval.NewRecordArena(nfields)
 
+	// Batch-allocate the RecordAndContext wrappers too: one slab for the whole
+	// batch instead of one heap object per record. Comment/output-string entries
+	// (rare) still allocate individually via maybeConsumeComment.
+	racSlab := make([]types.RecordAndContext, len(csvRecords))
+	racIndex := 0
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,7 +248,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		nh := int64(len(reader.header))
 		nd := int64(len(csvRecord))
@@ -281,7 +287,11 @@ func (reader *RecordReaderCSV) getRecordBatch(
 
 		context.UpdateForInputRecord()
 
-		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+		rac := &racSlab[racIndex]
+		racIndex++
+		rac.Record = record
+		rac.Context = *context
+		recordsAndContexts = append(recordsAndContexts, rac)
 	}
 
 	return recordsAndContexts, false

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -224,7 +224,7 @@ func getRecordBatchExplicitCSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					if reader.useVoidRep && field == reader.voidRep {
@@ -335,7 +335,7 @@ func getRecordBatchImplicitCSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				if reader.useVoidRep && field == reader.voidRep {

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -170,7 +170,7 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 }
 
 func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	pairs := reader.fieldSplitter.Split(line)
@@ -212,7 +212,7 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 }
 
 func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 
 	values := reader.fieldSplitter.Split(line)
 

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -171,7 +171,7 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 	arena := mlrval.NewRecordArena(nfields)
 
 	for _, omap := range dkvpxRecords {
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
 			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -239,7 +239,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -472,7 +472,7 @@ func getRecordBatchExplicitPprintHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -596,7 +596,7 @@ func getRecordBatchImplicitPprintHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -193,7 +193,7 @@ func getRecordBatchExplicitTSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
@@ -300,7 +300,7 @@ func getRecordBatchImplicitTSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -275,7 +275,7 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 func (reader *RecordReaderXTAB) recordFromXTABLines(
 	stanza []string,
 ) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	for _, line := range stanza {

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -28,7 +28,16 @@ type RecordArena struct {
 	ei      int
 	vi      int
 	chunk   int
+
+	// records is a slab of Mlrmap structs vended by NewRecord, so the record
+	// container itself is batch-allocated alongside its fields.
+	records []Mlrmap
+	ri      int
 }
+
+// arenaChunkRecords is the slab size (in records) for NewRecord. It tracks the
+// nominal records-per-batch so a batch typically draws from one slab.
+const arenaChunkRecords = 512
 
 // NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
 // (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
@@ -41,6 +50,24 @@ func NewRecordArena(nfieldsHint int) *RecordArena {
 		chunk = arenaChunkFields
 	}
 	return &RecordArena{chunk: chunk}
+}
+
+// NewRecord vends a fresh empty record (lazily-hashed, like NewMlrmapAsRecord)
+// from the arena's record slab, batch-allocating the Mlrmap struct itself. It
+// respects the global hashRecords setting: with --no-hash-records it returns an
+// unhashed map, matching NewMlrmapAsRecord.
+func (a *RecordArena) NewRecord() *Mlrmap {
+	if !hashRecords {
+		return newMlrmapUnhashed()
+	}
+	if a.ri >= len(a.records) {
+		a.records = make([]Mlrmap, arenaChunkRecords)
+		a.ri = 0
+	}
+	m := &a.records[a.ri]
+	a.ri++
+	m.autoHash = true
+	return m
 }
 
 // PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type

--- a/pkg/output/record_writer_csv.go
+++ b/pkg/output/record_writer_csv.go
@@ -19,6 +19,12 @@ type RecordWriterCSV struct {
 	firstRecordKeys   []string
 	firstRecordNF     int64
 	quoteAll          bool // For double-quote around all fields
+	// fieldsBuffer is a reusable scratch slice for the stringified field values
+	// of the record currently being written. WriteCSVRecordMaybeColorized
+	// consumes it synchronously and does not retain it, and the writer processes
+	// one record at a time, so a single buffer can be shared across records to
+	// avoid a per-record allocation.
+	fieldsBuffer []string
 }
 
 func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
@@ -76,7 +82,10 @@ func (writer *RecordWriterCSV) Write(
 		outputNF = writer.firstRecordNF
 	}
 
-	fields := make([]string, outputNF)
+	if int64(cap(writer.fieldsBuffer)) < outputNF {
+		writer.fieldsBuffer = make([]string, outputNF)
+	}
+	fields := writer.fieldsBuffer[:outputNF]
 	var i int64 = 0
 	for pe := outrec.Head; pe != nil; pe = pe.Next {
 		if i < writer.firstRecordNF && pe.Key != writer.firstRecordKeys[i] {

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -179,6 +179,12 @@ const stackFrameSetInitCap = 6
 
 type StackFrameSet struct {
 	stackFrames []*StackFrame
+	// pool retains popped frames for reuse. Push/pop is strictly LIFO and a
+	// StackFrameSet is reused across all records (it lives on the persistent
+	// runtime.State), so without pooling each record's block entry/exit would
+	// allocate and discard a StackFrame (a slice + a map). Pooling makes
+	// per-record block execution allocation-free after the first record.
+	pool []*StackFrame
 }
 
 func newStackFrameSet() *StackFrameSet {
@@ -190,11 +196,22 @@ func newStackFrameSet() *StackFrameSet {
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {
-	frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	n := len(frameset.pool)
+	if n > 0 {
+		frame := frameset.pool[n-1]
+		frameset.pool = frameset.pool[:n-1]
+		frame.clear()
+		frameset.stackFrames = append(frameset.stackFrames, frame)
+	} else {
+		frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	}
 }
 
 func (frameset *StackFrameSet) popStackFrame() {
-	frameset.stackFrames = frameset.stackFrames[0 : len(frameset.stackFrames)-1]
+	n := len(frameset.stackFrames)
+	frame := frameset.stackFrames[n-1]
+	frameset.stackFrames = frameset.stackFrames[0 : n-1]
+	frameset.pool = append(frameset.pool, frame)
 }
 
 // Returns nil on no-such
@@ -322,6 +339,17 @@ func newStackFrame() *StackFrame {
 		vars:           vars,
 		namesToOffsets: namesToOffsets,
 	}
+}
+
+// clear resets a frame for reuse from the pool, retaining its backing slice and
+// map allocations. The vars elements are nilled so reuse does not pin the
+// previous scope's variable values.
+func (frame *StackFrame) clear() {
+	for i := range frame.vars {
+		frame.vars[i] = nil
+	}
+	frame.vars = frame.vars[:0]
+	clear(frame.namesToOffsets)
 }
 
 // Returns nil on no such

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -62,19 +62,26 @@ func (sv *StackVariable) GetName() string {
 // STACK METHODS
 
 type Stack struct {
-	// list of *StackFrameSet
+	// Save/restore stack of framesets, one pushed per user-defined
+	// function/subroutine call. The CURRENT frameset is the tail element
+	// (stackFrameSets[len-1]); pushing appends and popping truncates, so neither
+	// allocates a new slice once capacity is established. (Order among the saved
+	// sets is irrelevant: all get/set go through the cached head.)
 	stackFrameSets []*StackFrameSet
 
-	// Invariant: equal to the head of the stackFrameSets list. This is cached
+	// Invariant: equal to the tail of the stackFrameSets list. This is cached
 	// since all sets/gets in between frameset-push and frameset-pop will all
 	// and only be operating on the head.
 	head *StackFrameSet
+
+	// pool retains popped framesets for reuse, so repeated function calls do not
+	// each allocate a fresh StackFrameSet (and its initial StackFrame).
+	pool []*StackFrameSet
 }
 
 func NewStack() *Stack {
-	stackFrameSets := make([]*StackFrameSet, 1)
 	head := newStackFrameSet()
-	stackFrameSets[0] = head
+	stackFrameSets := []*StackFrameSet{head}
 	return &Stack{
 		stackFrameSets: stackFrameSets,
 		head:           head,
@@ -83,14 +90,26 @@ func NewStack() *Stack {
 
 // For when a user-defined function/subroutine is being entered
 func (stack *Stack) PushStackFrameSet() {
-	stack.head = newStackFrameSet()
-	stack.stackFrameSets = append([]*StackFrameSet{stack.head}, stack.stackFrameSets...)
+	var frameset *StackFrameSet
+	n := len(stack.pool)
+	if n > 0 {
+		frameset = stack.pool[n-1]
+		stack.pool = stack.pool[:n-1]
+		frameset.reset()
+	} else {
+		frameset = newStackFrameSet()
+	}
+	stack.stackFrameSets = append(stack.stackFrameSets, frameset)
+	stack.head = frameset
 }
 
 // For when a user-defined function/subroutine is being exited
 func (stack *Stack) PopStackFrameSet() {
-	stack.stackFrameSets = stack.stackFrameSets[1:]
-	stack.head = stack.stackFrameSets[0]
+	n := len(stack.stackFrameSets)
+	popped := stack.stackFrameSets[n-1]
+	stack.stackFrameSets = stack.stackFrameSets[0 : n-1]
+	stack.pool = append(stack.pool, popped)
+	stack.head = stack.stackFrameSets[len(stack.stackFrameSets)-1]
 }
 
 // All of these are simply delegations to the head frameset
@@ -193,6 +212,17 @@ func newStackFrameSet() *StackFrameSet {
 	return &StackFrameSet{
 		stackFrames: stackFrames,
 	}
+}
+
+// reset returns a pooled frameset to its freshly-constructed state: exactly one
+// (cleared) base frame. Any extra frames are kept in the per-frameset frame
+// pool for reuse. At a balanced PopStackFrameSet the set is already at depth 1,
+// so this is normally just a clear of the base frame.
+func (frameset *StackFrameSet) reset() {
+	for len(frameset.stackFrames) > 1 {
+		frameset.popStackFrame()
+	}
+	frameset.stackFrames[0].clear()
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {


### PR DESCRIPTION
**Stacked on #2088.** A win — open-and-merge.

## What

A UDF return value was deep-copied **twice** on the way out:
1. `ReturnNode.Execute` — `returnValue.Copy()` when building the block-exit payload.
2. `UDFCallsite.EvaluateWithArguments` — `blockReturnValue.Copy()` at the end.

The `ReturnNode` copy is the necessary one: it detaches the value from the callee's frame so it survives the frame being popped (and, since #2088, pooled/reused). By the time `EvaluateWithArguments` returns, `blockReturnValue` is therefore *already* an independent deep copy — so the second copy is pure waste. Callers that retain the result copy again anyway (field/oosvar/local assignment all `PutCopy`/`Copy`). The implicit-absent and error return paths don't touch `blockReturnValue`, so only the `BLOCK_EXIT_RETURN_VALUE` path is affected.

One-line fix: return `blockReturnValue` directly.

## Impact

`big.csv`, 1M rows, best of 5:

| workload | before | after |
|---|---|---|
| put, 2 nested scalar-returning calls/record | 1.89s | 1.83s (~3%) |
| put, map-returning func per record | 2.34s | **1.97s (~16%)** |

The win scales with return-value size, since the avoided copy is deep. Every UDF and higher-order-function callsite (`apply`/`reduce`/`sort`/`select`/`fold`/…) goes through this path.

## Verification

- `go test ./pkg/...` ✅ and full `regression_test.go` suite ✅
- Hand-checked: recursion (`fact(10)`), HOFs (apply/reduce/sort/select), and — the key safety test — **returned-map isolation**: mutating a map returned from `f()` does not affect a subsequent `f()` call (`{"a":1,"b":2}` stays clean). That confirms `ReturnNode`'s deep copy alone preserves independence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
