### PR TITLE
docs: add "Allocation/GC optimizations: June 2026" performance section

### DIFF
--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -63,6 +63,41 @@ Notes:
 * Even single-verb processing with `put` and `stats1` was significantly faster on both platforms.
 * Longer then-chains benefit even more from Miller 6's [multicore approach](cpu.md).
 
+## Allocation/GC optimizations: June 2026
+
+A series of changes in mid-2026 cut per-record and per-field memory allocation throughout Miller's read, write, and DSL paths. On these workloads the dominant controllable cost in the Go implementation is the sheer volume of heap allocations (and the garbage-collection work that follows), rather than GC tuning per se -- so the work focused on reducing allocation *count*: lazy per-record hashing, batch/slab allocation of record fields and per-record objects, reuse of writer buffers, and stack-frame pooling plus copy-elision in the DSL interpreter.
+
+The table below compares wall-clock time before and after these changes, using the same million-record files as above (CSV unless noted), as the best of five runs on an Apple M1 laptop. The `put` rows use a two-statement script (`chain-1`), a four-deep then-chain of it (`chain-4`), a local-variable expression, and user-defined-function-heavy scripts.
+
+| Workload | Before | After | Change |
+| --- | --- | --- | --- |
+| `cat` (CSV) | 0.62s | 0.22s | -65% |
+| `cat` (DKVP) | 0.90s | 0.44s | -51% |
+| `cat` (NIDX) | 2.02s | 1.56s | -23% |
+| `tac` (CSV) | 1.00s | 0.44s | -56% |
+| `sort -nf` (CSV) | 3.31s | 2.00s | -40% |
+| `stats1` (CSV) | 0.64s | 0.54s | -16% |
+| `put` chain-1 | 1.06s | 0.71s | -33% |
+| `put` chain-4 | 1.24s | 0.93s | -25% |
+| `put` local-variable | 0.71s | 0.51s | -28% |
+| `put` UDF-heavy | 2.81s | 1.71s | -39% |
+| `put` map-returning UDF | 2.72s | 1.92s | -29% |
+
+Peak resident set size (RSS) for representative workloads:
+
+| Workload | Before | After | Change |
+| --- | --- | --- | --- |
+| `cat` (CSV) | 379MB | 180MB | -53% |
+| `sort -nf` (CSV) | 1389MB | 1306MB | -6% |
+| `put` chain-1 | 414MB | 411MB | ~0% |
+
+Notes:
+
+* Streaming I/O verbs such as `cat` and `tac` improved the most; `mlr --csv cat` is now essentially I/O-bound (most of its time is spent in read/write system calls), so its memory use also dropped sharply.
+* `sort` got substantially faster in time but barely changed in memory: it intrinsically holds all records in memory at once, so the speedup comes from cheaper record construction, not from fewer live records.
+* DSL (`put`) speedups combine lazy record hashing with interpreter-level allocation reductions (stack-frame and frame-set pooling, eliding redundant value copies). Function-heavy scripts benefit most, since each call previously allocated and copied the most.
+* As always, results vary by platform, file format, and multi-core use.
+
 ## Decompression options
 
 This is some data from [https://community.opencellid.org](https://community.opencellid.org): approximately 40

--- a/docs/src/performance.md.in
+++ b/docs/src/performance.md.in
@@ -47,6 +47,41 @@ Notes:
 * Even single-verb processing with `put` and `stats1` was significantly faster on both platforms.
 * Longer then-chains benefit even more from Miller 6's [multicore approach](cpu.md).
 
+## Allocation/GC optimizations: June 2026
+
+A series of changes in mid-2026 cut per-record and per-field memory allocation throughout Miller's read, write, and DSL paths. On these workloads the dominant controllable cost in the Go implementation is the sheer volume of heap allocations (and the garbage-collection work that follows), rather than GC tuning per se -- so the work focused on reducing allocation *count*: lazy per-record hashing, batch/slab allocation of record fields and per-record objects, reuse of writer buffers, and stack-frame pooling plus copy-elision in the DSL interpreter.
+
+The table below compares wall-clock time before and after these changes, using the same million-record files as above (CSV unless noted), as the best of five runs on an Apple M1 laptop. The `put` rows use a two-statement script (`chain-1`), a four-deep then-chain of it (`chain-4`), a local-variable expression, and user-defined-function-heavy scripts.
+
+| Workload | Before | After | Change |
+| --- | --- | --- | --- |
+| `cat` (CSV) | 0.62s | 0.22s | -65% |
+| `cat` (DKVP) | 0.90s | 0.44s | -51% |
+| `cat` (NIDX) | 2.02s | 1.56s | -23% |
+| `tac` (CSV) | 1.00s | 0.44s | -56% |
+| `sort -nf` (CSV) | 3.31s | 2.00s | -40% |
+| `stats1` (CSV) | 0.64s | 0.54s | -16% |
+| `put` chain-1 | 1.06s | 0.71s | -33% |
+| `put` chain-4 | 1.24s | 0.93s | -25% |
+| `put` local-variable | 0.71s | 0.51s | -28% |
+| `put` UDF-heavy | 2.81s | 1.71s | -39% |
+| `put` map-returning UDF | 2.72s | 1.92s | -29% |
+
+Peak resident set size (RSS) for representative workloads:
+
+| Workload | Before | After | Change |
+| --- | --- | --- | --- |
+| `cat` (CSV) | 379MB | 180MB | -53% |
+| `sort -nf` (CSV) | 1389MB | 1306MB | -6% |
+| `put` chain-1 | 414MB | 411MB | ~0% |
+
+Notes:
+
+* Streaming I/O verbs such as `cat` and `tac` improved the most; `mlr --csv cat` is now essentially I/O-bound (most of its time is spent in read/write system calls), so its memory use also dropped sharply.
+* `sort` got substantially faster in time but barely changed in memory: it intrinsically holds all records in memory at once, so the speedup comes from cheaper record construction, not from fewer live records.
+* DSL (`put`) speedups combine lazy record hashing with interpreter-level allocation reductions (stack-frame and frame-set pooling, eliding redundant value copies). Function-heavy scripts benefit most, since each call previously allocated and copied the most.
+* As always, results vary by platform, file format, and multi-core use.
+
 ## Decompression options
 
 This is some data from [https://community.opencellid.org](https://community.opencellid.org): approximately 40

--- a/pkg/dsl/cst/udf.go
+++ b/pkg/dsl/cst/udf.go
@@ -304,7 +304,12 @@ func (site *UDFCallsite) EvaluateWithArguments(
 		"function "+udf.signature.funcOrSubrName+" return value",
 	)
 
-	return blockExitPayload.blockReturnValue.Copy()
+	// blockReturnValue is already an independent deep copy: ReturnNode.Execute
+	// does returnValue.Copy() when building the payload, precisely so the value
+	// survives the callee frame being popped (and, with frame pooling, reused).
+	// A second copy here is redundant -- the caller copies again if it stores
+	// the value (field/oosvar/local assignment all PutCopy/Copy).
+	return blockExitPayload.blockReturnValue
 }
 
 // UDFManager tracks named UDFs like 'func f(a, b) { return b - a }'

--- a/pkg/input/record_reader_csv.go
+++ b/pkg/input/record_reader_csv.go
@@ -214,6 +214,12 @@ func (reader *RecordReaderCSV) getRecordBatch(
 	}
 	arena := mlrval.NewRecordArena(nfields)
 
+	// Batch-allocate the RecordAndContext wrappers too: one slab for the whole
+	// batch instead of one heap object per record. Comment/output-string entries
+	// (rare) still allocate individually via maybeConsumeComment.
+	racSlab := make([]types.RecordAndContext, len(csvRecords))
+	racIndex := 0
+
 	for _, csvRecord := range csvRecords {
 
 		if reader.needHeader {
@@ -242,7 +248,7 @@ func (reader *RecordReaderCSV) getRecordBatch(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		nh := int64(len(reader.header))
 		nd := int64(len(csvRecord))
@@ -281,7 +287,11 @@ func (reader *RecordReaderCSV) getRecordBatch(
 
 		context.UpdateForInputRecord()
 
-		recordsAndContexts = append(recordsAndContexts, types.NewRecordAndContext(record, context))
+		rac := &racSlab[racIndex]
+		racIndex++
+		rac.Record = record
+		rac.Context = *context
+		recordsAndContexts = append(recordsAndContexts, rac)
 	}
 
 	return recordsAndContexts, false

--- a/pkg/input/record_reader_csvlite.go
+++ b/pkg/input/record_reader_csvlite.go
@@ -224,7 +224,7 @@ func getRecordBatchExplicitCSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					if reader.useVoidRep && field == reader.voidRep {
@@ -335,7 +335,7 @@ func getRecordBatchImplicitCSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				if reader.useVoidRep && field == reader.voidRep {

--- a/pkg/input/record_reader_dkvp_nidx.go
+++ b/pkg/input/record_reader_dkvp_nidx.go
@@ -170,7 +170,7 @@ func (reader *RecordReaderDKVPNIDX) getRecordBatch(
 }
 
 func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	pairs := reader.fieldSplitter.Split(line)
@@ -212,7 +212,7 @@ func recordFromDKVPLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrm
 }
 
 func recordFromNIDXLine(reader *RecordReaderDKVPNIDX, line string) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 
 	values := reader.fieldSplitter.Split(line)
 

--- a/pkg/input/record_reader_dkvpx.go
+++ b/pkg/input/record_reader_dkvpx.go
@@ -171,7 +171,7 @@ func (reader *RecordReaderDKVPX) getRecordBatch(
 	arena := mlrval.NewRecordArena(nfields)
 
 	for _, omap := range dkvpxRecords {
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 
 		for pe := omap.Head; pe != nil; pe = pe.Next {
 			arena.PutDeferred(record, pe.Key, pe.Value, dedupeFieldNames)

--- a/pkg/input/record_reader_pprint.go
+++ b/pkg/input/record_reader_pprint.go
@@ -239,7 +239,7 @@ func (reader *RecordReaderPprintFixedSplit) getRecords(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -472,7 +472,7 @@ func getRecordBatchExplicitPprintHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)
@@ -596,7 +596,7 @@ func getRecordBatchImplicitPprintHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				arena.PutDeferred(record, reader.headerStrings[i], field, dedupeFieldNames)

--- a/pkg/input/record_reader_tsv.go
+++ b/pkg/input/record_reader_tsv.go
@@ -193,7 +193,7 @@ func getRecordBatchExplicitTSVHeader(
 				return
 			}
 
-			record := mlrval.NewMlrmapAsRecord()
+			record := arena.NewRecord()
 			if !reader.readerOptions.AllowRaggedCSVInput {
 				for i, field := range fields {
 					field = lib.TSVDecodeField(field)
@@ -300,7 +300,7 @@ func getRecordBatchImplicitTSVHeader(
 			}
 		}
 
-		record := mlrval.NewMlrmapAsRecord()
+		record := arena.NewRecord()
 		if !reader.readerOptions.AllowRaggedCSVInput {
 			for i, field := range fields {
 				field = lib.TSVDecodeField(field)

--- a/pkg/input/record_reader_xtab.go
+++ b/pkg/input/record_reader_xtab.go
@@ -275,7 +275,7 @@ func (reader *RecordReaderXTAB) getRecordBatch(
 func (reader *RecordReaderXTAB) recordFromXTABLines(
 	stanza []string,
 ) (*mlrval.Mlrmap, error) {
-	record := mlrval.NewMlrmapAsRecord()
+	record := reader.recordArena.NewRecord()
 	dedupeFieldNames := reader.readerOptions.DedupeFieldNames
 
 	for _, line := range stanza {

--- a/pkg/mlrval/record_arena.go
+++ b/pkg/mlrval/record_arena.go
@@ -28,7 +28,16 @@ type RecordArena struct {
 	ei      int
 	vi      int
 	chunk   int
+
+	// records is a slab of Mlrmap structs vended by NewRecord, so the record
+	// container itself is batch-allocated alongside its fields.
+	records []Mlrmap
+	ri      int
 }
+
+// arenaChunkRecords is the slab size (in records) for NewRecord. It tracks the
+// nominal records-per-batch so a batch typically draws from one slab.
+const arenaChunkRecords = 512
 
 // NewRecordArena returns an arena whose first slabs are sized to nfieldsHint
 // (clamped to a sane range). Subsequent slabs, if needed, use arenaChunkFields.
@@ -41,6 +50,24 @@ func NewRecordArena(nfieldsHint int) *RecordArena {
 		chunk = arenaChunkFields
 	}
 	return &RecordArena{chunk: chunk}
+}
+
+// NewRecord vends a fresh empty record (lazily-hashed, like NewMlrmapAsRecord)
+// from the arena's record slab, batch-allocating the Mlrmap struct itself. It
+// respects the global hashRecords setting: with --no-hash-records it returns an
+// unhashed map, matching NewMlrmapAsRecord.
+func (a *RecordArena) NewRecord() *Mlrmap {
+	if !hashRecords {
+		return newMlrmapUnhashed()
+	}
+	if a.ri >= len(a.records) {
+		a.records = make([]Mlrmap, arenaChunkRecords)
+		a.ri = 0
+	}
+	m := &a.records[a.ri]
+	a.ri++
+	m.autoHash = true
+	return m
 }
 
 // PutDeferred appends a field to mlrmap, drawing the entry and its deferred-type

--- a/pkg/output/record_writer_csv.go
+++ b/pkg/output/record_writer_csv.go
@@ -19,6 +19,12 @@ type RecordWriterCSV struct {
 	firstRecordKeys   []string
 	firstRecordNF     int64
 	quoteAll          bool // For double-quote around all fields
+	// fieldsBuffer is a reusable scratch slice for the stringified field values
+	// of the record currently being written. WriteCSVRecordMaybeColorized
+	// consumes it synchronously and does not retain it, and the writer processes
+	// one record at a time, so a single buffer can be shared across records to
+	// avoid a per-record allocation.
+	fieldsBuffer []string
 }
 
 func NewRecordWriterCSV(writerOptions *cli.TWriterOptions) (*RecordWriterCSV, error) {
@@ -76,7 +82,10 @@ func (writer *RecordWriterCSV) Write(
 		outputNF = writer.firstRecordNF
 	}
 
-	fields := make([]string, outputNF)
+	if int64(cap(writer.fieldsBuffer)) < outputNF {
+		writer.fieldsBuffer = make([]string, outputNF)
+	}
+	fields := writer.fieldsBuffer[:outputNF]
 	var i int64 = 0
 	for pe := outrec.Head; pe != nil; pe = pe.Next {
 		if i < writer.firstRecordNF && pe.Key != writer.firstRecordKeys[i] {

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -179,6 +179,12 @@ const stackFrameSetInitCap = 6
 
 type StackFrameSet struct {
 	stackFrames []*StackFrame
+	// pool retains popped frames for reuse. Push/pop is strictly LIFO and a
+	// StackFrameSet is reused across all records (it lives on the persistent
+	// runtime.State), so without pooling each record's block entry/exit would
+	// allocate and discard a StackFrame (a slice + a map). Pooling makes
+	// per-record block execution allocation-free after the first record.
+	pool []*StackFrame
 }
 
 func newStackFrameSet() *StackFrameSet {
@@ -190,11 +196,22 @@ func newStackFrameSet() *StackFrameSet {
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {
-	frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	n := len(frameset.pool)
+	if n > 0 {
+		frame := frameset.pool[n-1]
+		frameset.pool = frameset.pool[:n-1]
+		frame.clear()
+		frameset.stackFrames = append(frameset.stackFrames, frame)
+	} else {
+		frameset.stackFrames = append(frameset.stackFrames, newStackFrame())
+	}
 }
 
 func (frameset *StackFrameSet) popStackFrame() {
-	frameset.stackFrames = frameset.stackFrames[0 : len(frameset.stackFrames)-1]
+	n := len(frameset.stackFrames)
+	frame := frameset.stackFrames[n-1]
+	frameset.stackFrames = frameset.stackFrames[0 : n-1]
+	frameset.pool = append(frameset.pool, frame)
 }
 
 // Returns nil on no-such
@@ -322,6 +339,17 @@ func newStackFrame() *StackFrame {
 		vars:           vars,
 		namesToOffsets: namesToOffsets,
 	}
+}
+
+// clear resets a frame for reuse from the pool, retaining its backing slice and
+// map allocations. The vars elements are nilled so reuse does not pin the
+// previous scope's variable values.
+func (frame *StackFrame) clear() {
+	for i := range frame.vars {
+		frame.vars[i] = nil
+	}
+	frame.vars = frame.vars[:0]
+	clear(frame.namesToOffsets)
 }
 
 // Returns nil on no such

--- a/pkg/runtime/stack.go
+++ b/pkg/runtime/stack.go
@@ -62,19 +62,26 @@ func (sv *StackVariable) GetName() string {
 // STACK METHODS
 
 type Stack struct {
-	// list of *StackFrameSet
+	// Save/restore stack of framesets, one pushed per user-defined
+	// function/subroutine call. The CURRENT frameset is the tail element
+	// (stackFrameSets[len-1]); pushing appends and popping truncates, so neither
+	// allocates a new slice once capacity is established. (Order among the saved
+	// sets is irrelevant: all get/set go through the cached head.)
 	stackFrameSets []*StackFrameSet
 
-	// Invariant: equal to the head of the stackFrameSets list. This is cached
+	// Invariant: equal to the tail of the stackFrameSets list. This is cached
 	// since all sets/gets in between frameset-push and frameset-pop will all
 	// and only be operating on the head.
 	head *StackFrameSet
+
+	// pool retains popped framesets for reuse, so repeated function calls do not
+	// each allocate a fresh StackFrameSet (and its initial StackFrame).
+	pool []*StackFrameSet
 }
 
 func NewStack() *Stack {
-	stackFrameSets := make([]*StackFrameSet, 1)
 	head := newStackFrameSet()
-	stackFrameSets[0] = head
+	stackFrameSets := []*StackFrameSet{head}
 	return &Stack{
 		stackFrameSets: stackFrameSets,
 		head:           head,
@@ -83,14 +90,26 @@ func NewStack() *Stack {
 
 // For when a user-defined function/subroutine is being entered
 func (stack *Stack) PushStackFrameSet() {
-	stack.head = newStackFrameSet()
-	stack.stackFrameSets = append([]*StackFrameSet{stack.head}, stack.stackFrameSets...)
+	var frameset *StackFrameSet
+	n := len(stack.pool)
+	if n > 0 {
+		frameset = stack.pool[n-1]
+		stack.pool = stack.pool[:n-1]
+		frameset.reset()
+	} else {
+		frameset = newStackFrameSet()
+	}
+	stack.stackFrameSets = append(stack.stackFrameSets, frameset)
+	stack.head = frameset
 }
 
 // For when a user-defined function/subroutine is being exited
 func (stack *Stack) PopStackFrameSet() {
-	stack.stackFrameSets = stack.stackFrameSets[1:]
-	stack.head = stack.stackFrameSets[0]
+	n := len(stack.stackFrameSets)
+	popped := stack.stackFrameSets[n-1]
+	stack.stackFrameSets = stack.stackFrameSets[0 : n-1]
+	stack.pool = append(stack.pool, popped)
+	stack.head = stack.stackFrameSets[len(stack.stackFrameSets)-1]
 }
 
 // All of these are simply delegations to the head frameset
@@ -193,6 +212,17 @@ func newStackFrameSet() *StackFrameSet {
 	return &StackFrameSet{
 		stackFrames: stackFrames,
 	}
+}
+
+// reset returns a pooled frameset to its freshly-constructed state: exactly one
+// (cleared) base frame. Any extra frames are kept in the per-frameset frame
+// pool for reuse. At a balanced PopStackFrameSet the set is already at depth 1,
+// so this is normally just a clear of the base frame.
+func (frameset *StackFrameSet) reset() {
+	for len(frameset.stackFrames) > 1 {
+		frameset.popStackFrame()
+	}
+	frameset.stackFrames[0].clear()
 }
 
 func (frameset *StackFrameSet) pushStackFrame() {

--- a/pkg/types/mlrval_typing.go
+++ b/pkg/types/mlrval_typing.go
@@ -46,6 +46,22 @@ type TypeGatedMlrvalVariable struct {
 	value               *mlrval.Mlrval
 }
 
+// copyForBind returns the value to store when binding a local variable or
+// function parameter. Scalars are stored by reference (no copy, no allocation):
+// assignment everywhere replaces pointers rather than mutating Mlrvals in place
+// (Mlrmap.PutCopy reassigns pe.Value; Assign reassigns tvar.value), and the
+// only in-place mutation a scalar undergoes is idempotent type-inference
+// caching -- so an aliased scalar can never be observed to change underneath
+// its source. Maps and arrays, however, ARE mutated in place by indexed
+// assignment (m[k]=v), so they must be deep-copied to keep the binding
+// independent of its source.
+func copyForBind(value *mlrval.Mlrval) *mlrval.Mlrval {
+	if value.IsArrayOrMap() {
+		return value.Copy()
+	}
+	return value
+}
+
 func NewTypeGatedMlrvalVariable(
 	name string, // e.g. "x"
 	typeName string, // e.g. "num"
@@ -63,7 +79,7 @@ func NewTypeGatedMlrvalVariable(
 
 	return &TypeGatedMlrvalVariable{
 		typeGatedMlrvalName,
-		value.Copy(),
+		copyForBind(value),
 	}, nil
 }
 
@@ -77,8 +93,7 @@ func (tvar *TypeGatedMlrvalVariable) Assign(value *mlrval.Mlrval) error {
 		return err
 	}
 
-	// TODO: revisit copy-reduction
-	tvar.value = value.Copy()
+	tvar.value = copyForBind(value)
 	return nil
 }
 


### PR DESCRIPTION
Context: #2084

**Stacked on #2090.** Docs-only — open-and-merge.

Adds a new section, **"Allocation/GC optimizations: June 2026"**, to the performance page (`docs/src/performance.md.in` and the generated `docs/src/performance.md` — the page has no live-code `GENMD` blocks, so both are updated identically).

It records the main→full-stack deltas from this allocation-reduction series (#2081, #2082, #2083, #2086, #2088, #2089, #2090), measured fresh as best-of-five on an M1 laptop over the same million-record files used elsewhere on the page:

- a **wall-clock before/after table** (cat/tac/sort/stats1 + put chain-1/chain-4/local-var/UDF-heavy/map-returning-UDF), −16% to −65%;
- a **peak-RSS table** (cat CSV 379→180MB);
- notes on why streaming I/O verbs and DSL/UDF workloads gain most, and why `sort`'s time drops while its memory doesn't (it holds all records live).

No graphs — just the rendered markdown tables, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
