### PR TITLE
update ubuntu/python versions in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
https://app.readthedocs.org/projects/miller/builds/33183452/ failing with

> Config file validation error Config validation error in build.os. Expected one of (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got type str (ubuntu-20.04). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)
