### PR TITLE
Fix exponential memory use when chaining seqgen (#2072)

### DIFF
--- a/pkg/transformers/seqgen.go
+++ b/pkg/transformers/seqgen.go
@@ -183,6 +183,11 @@ func (tr *TransformerSeqgen) Transform(
 	inputDownstreamDoneChannel <-chan bool,
 	outputDownstreamDoneChannel chan<- bool,
 ) {
+	if !inrecAndContext.EndOfStream {
+		// Discard upstream records; generate output only when upstream is done.
+		return
+	}
+
 	counter := tr.start
 	context := types.NewNilContext()
 	context.UpdateForStartOfFile("seqgen")


### PR DESCRIPTION
## Summary

- `seqgen.Transform` was called once per upstream record AND once for the end-of-stream marker, generating the full sequence each time
- Chaining two `seqgen --stop N` produced O(N²) records in memory — ~14 GB for N=5000 — even though only N records are ever written
- Fix: discard non-EOS input immediately; generate the sequence only when the upstream EOS arrives, matching the documented "discards the input record stream" semantics

## Root cause

In `runSingleTransformerBatch`, `Transform()` is invoked for every record in the incoming batch. For a chained `seqgen`, the upstream seqgen delivers a batch of [rec₁, rec₂, …, recₙ, EOS]. The downstream seqgen called its generation loop for each of those N+1 items, accumulating (N+1)² records in `outputRecordsAndContexts` before the writer ever saw anything. Only the first N records (before the first embedded EOS) were output.

## Fix

Added an early return at the top of `Transform()` for non-EOS input:

```go
if !inrecAndContext.EndOfStream {
    return  // discard upstream records; generate output only when upstream is done
}
```

This is a no-op for the first-in-chain case (the reader sends a single EOS when `NoInput=true`), and fixes the N² blowup for all subsequent positions in the chain.

## Test plan

- [x] `mlr seqgen -f one --stop 5000 then seqgen -f two --stop 5000 | wc -l` → 5000 (was ~14 GB RSS, now fast and small)
- [x] Triple-chained seqgen works correctly
- [x] `seqgen then head` downstream-done signaling still works
- [x] `make unit-test` — all pass
- [x] `make regression-test` — 4669/4669 cases pass

**Before**

```
time mlr-6.17.0 seqgen -f one --stop 5000 then seqgen -f two --stop 5000 | wc -l

real    0m7.964s
user    0m7.149s
sys     0m3.630s
```

**After**

```
time ./mlr seqgen -f one --stop 5000 then seqgen -f two --stop 5000 | wc -l

real    0m0.360s
user    0m0.025s
sys     0m0.020s
```

Fixes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)