### PR TITLE
Switch to `--as-json`

### DIFF
--- a/pkg/cli/flag_json.go
+++ b/pkg/cli/flag_json.go
@@ -1,5 +1,5 @@
 // Machine-readable (JSON) accessors over the command-line flag table, for
-// `mlr help --json` and similar tooling. Unlike verb options (which are
+// `mlr help --as-json` and similar tooling. Unlike verb options (which are
 // prose-only), the flag table is already fully structured since it drives the
 // actual command-line parser -- so this is a thin serialization layer.
 

--- a/pkg/dsl/cst/builtin_function_manager_json.go
+++ b/pkg/dsl/cst/builtin_function_manager_json.go
@@ -1,6 +1,6 @@
 // Machine-readable (JSON) accessors over the built-in-function catalog. These
 // mirror the human-readable listings elsewhere in this file's neighbors (e.g.
-// ListBuiltinFunctionUsages) but return structured data for `mlr help --json`
+// ListBuiltinFunctionUsages) but return structured data for `mlr help --as-json`
 // and any other tooling -- AI agents in particular -- which needs to model
 // Miller's function surface without scraping prose.
 

--- a/pkg/dsl/cst/keyword_usage_json.go
+++ b/pkg/dsl/cst/keyword_usage_json.go
@@ -1,5 +1,5 @@
 // Machine-readable (JSON) accessors over the keyword catalog, for
-// `mlr help --json` and similar tooling. The per-keyword usage functions print
+// `mlr help --as-json` and similar tooling. The per-keyword usage functions print
 // their bodies directly to stdout (they predate any structured-help need), so
 // here we capture that output by temporarily redirecting os.Stdout.
 

--- a/pkg/terminals/help/entry.go
+++ b/pkg/terminals/help/entry.go
@@ -232,10 +232,11 @@ func GetTerminalFlagNames() []string {
 func HelpMain(args []string) int {
 	args = args[1:]
 
-	// Machine-readable help: `mlr help --json [topic [names...]]`. The --json
-	// token may appear anywhere; if present we emit structured JSON and the
-	// plain-text handlers below are bypassed.
-	if jsonMode, rest := extractJSONFlag(args); jsonMode {
+	// Machine-readable help: `mlr help --as-json [topic [names...]]`. The
+	// --as-json token (or a truthy MLR_HELP_JSON env var) may appear anywhere;
+	// if either is set we emit structured JSON and the plain-text handlers
+	// below are bypassed.
+	if jsonMode, rest := wantJSONOutput(args); jsonMode {
 		return helpJSON(rest)
 	}
 

--- a/pkg/terminals/help/entry_json.go
+++ b/pkg/terminals/help/entry_json.go
@@ -1,16 +1,21 @@
-// Machine-readable (JSON) help, for `mlr help --json` and friends.
+// Machine-readable (JSON) help, for `mlr help --as-json` and friends.
 //
 // This assembles the structured catalogs exposed by the verb, function, flag,
 // and keyword registries into a single document, so AI agents and other tooling
 // can model Miller's surface without scraping the human-readable prose. The
-// plain (non-`--json`) help behavior is unchanged; `--json` only switches the
-// rendering.
+// plain (non-`--as-json`) help behavior is unchanged; `--as-json` only switches
+// the rendering.
+//
+// Two equivalent ways to opt in:
+//   - Per-call flag `--as-json` anywhere on a `mlr help ...` command line.
+//   - Env var MLR_HELP_JSON set to a truthy value (1, true, yes).
 
 package help
 
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/johnkerl/miller/v6/pkg/cli"
 	"github.com/johnkerl/miller/v6/pkg/dsl/cst"
@@ -18,30 +23,58 @@ import (
 	"github.com/johnkerl/miller/v6/pkg/version"
 )
 
-// CatalogForJSON is the top-level document emitted by `mlr help --json` with no
-// further topic: the entire help catalog in one machine-readable object.
+// catalogSchemaVersion is bumped whenever the shape of the JSON catalog
+// changes. Agents and tools can use this (together with mlr_version) as a
+// cache key: re-fetch only when either value changes.
+const catalogSchemaVersion = 1
+
+// CatalogForJSON is the top-level document emitted by `mlr help --as-json`
+// with no further topic: the entire help catalog in one machine-readable
+// object.
 type CatalogForJSON struct {
-	MlrVersion string                          `json:"mlr_version"`
-	Verbs      []*transformers.VerbInfoForJSON `json:"verbs"`
-	Functions  []*cst.FunctionInfoForJSON      `json:"functions"`
-	Flags      []*cli.FlagInfoForJSON          `json:"flags"`
-	Keywords   []*cst.KeywordInfoForJSON       `json:"keywords"`
+	MlrVersion           string                          `json:"mlr_version"`
+	CatalogSchemaVersion int                             `json:"catalog_schema_version"`
+	Verbs                []*transformers.VerbInfoForJSON `json:"verbs"`
+	Functions            []*cst.FunctionInfoForJSON      `json:"functions"`
+	Flags                []*cli.FlagInfoForJSON          `json:"flags"`
+	Keywords             []*cst.KeywordInfoForJSON       `json:"keywords"`
 }
 
-// extractJSONFlag removes any "--json" token from args, returning whether one
-// was present along with the remaining args. The flag may appear anywhere
-// (e.g. `mlr help --json` or `mlr help verb cat --json`).
-func extractJSONFlag(args []string) (bool, []string) {
-	jsonMode := false
+// wantJSONOutput returns true when the caller has opted in to JSON output via
+// either the --as-json flag or a truthy MLR_HELP_JSON env var.
+func wantJSONOutput(args []string) (bool, []string) {
+	if isTruthyEnv(os.Getenv("MLR_HELP_JSON")) {
+		// Env var wins; still strip any --as-json tokens so dispatch is clean.
+		_, rest := extractAsJSONFlag(args)
+		return true, rest
+	}
+	return extractAsJSONFlag(args)
+}
+
+// isTruthyEnv returns true for non-empty strings commonly used as boolean
+// env-var truthy values: "1", "true", "yes" (case-insensitive).
+func isTruthyEnv(v string) bool {
+	switch v {
+	case "1", "true", "True", "TRUE", "yes", "Yes", "YES":
+		return true
+	}
+	return false
+}
+
+// extractAsJSONFlag removes any "--as-json" token from args, returning whether
+// one was present along with the remaining args. The flag may appear anywhere
+// (e.g. `mlr help --as-json` or `mlr help verb cat --as-json`).
+func extractAsJSONFlag(args []string) (bool, []string) {
+	found := false
 	kept := make([]string, 0, len(args))
 	for _, arg := range args {
-		if arg == "--json" {
-			jsonMode = true
+		if arg == "--as-json" {
+			found = true
 		} else {
 			kept = append(kept, arg)
 		}
 	}
-	return jsonMode, kept
+	return found, kept
 }
 
 // printAsJSON marshals v as indented JSON to stdout. Returns a process exit
@@ -56,9 +89,10 @@ func printAsJSON(v any) int {
 	return 0
 }
 
-// helpJSON dispatches `mlr help --json [topic [names...]]`. With no topic it
-// emits the full catalog; with a topic (verb/function/flag/keyword) it emits
-// just those entries -- all of them if no names are given, or the named ones.
+// helpJSON dispatches `mlr help --as-json [topic [names...]]`. With no topic
+// it emits the full catalog; with a topic (verb/function/flag/keyword) it
+// emits just those entries -- all of them if no names are given, or the named
+// ones.
 func helpJSON(args []string) int {
 	if len(args) == 0 {
 		return printAsJSON(buildFullCatalog())
@@ -77,7 +111,7 @@ func helpJSON(args []string) int {
 	case "keyword", "keywords":
 		return printAsJSON(collectKeywords(names))
 	default:
-		fmt.Printf("mlr help --json: unsupported topic \"%s\".\n", topic)
+		fmt.Printf("mlr help --as-json: unsupported topic \"%s\".\n", topic)
 		fmt.Printf("Supported: (no topic) for the full catalog, or one of: verb, function, flag, keyword.\n")
 		return 1
 	}
@@ -85,11 +119,12 @@ func helpJSON(args []string) int {
 
 func buildFullCatalog() *CatalogForJSON {
 	return &CatalogForJSON{
-		MlrVersion: version.STRING,
-		Verbs:      transformers.GetVerbInfosForJSON(),
-		Functions:  cst.BuiltinFunctionManagerInstance.GetFunctionInfosForJSON(),
-		Flags:      cli.FLAG_TABLE.GetFlagInfosForJSON(),
-		Keywords:   cst.GetKeywordInfosForJSON(),
+		MlrVersion:           version.STRING,
+		CatalogSchemaVersion: catalogSchemaVersion,
+		Verbs:                transformers.GetVerbInfosForJSON(),
+		Functions:            cst.BuiltinFunctionManagerInstance.GetFunctionInfosForJSON(),
+		Flags:                cli.FLAG_TABLE.GetFlagInfosForJSON(),
+		Keywords:             cst.GetKeywordInfosForJSON(),
 	}
 }
 

--- a/pkg/terminals/help/entry_json_test.go
+++ b/pkg/terminals/help/entry_json_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestFullCatalogIsValidJSON guards the `mlr help --json` contract: the
+// TestFullCatalogIsValidJSON guards the `mlr help --as-json` contract: the
 // assembled catalog must round-trip through encoding/json and carry a non-empty
 // entry in each of the four sections.
 func TestFullCatalogIsValidJSON(t *testing.T) {
@@ -23,6 +23,9 @@ func TestFullCatalogIsValidJSON(t *testing.T) {
 
 	if catalog.MlrVersion == "" {
 		t.Error("catalog mlr_version is empty")
+	}
+	if catalog.CatalogSchemaVersion == 0 {
+		t.Error("catalog catalog_schema_version is zero")
 	}
 	if len(catalog.Verbs) == 0 {
 		t.Error("catalog has no verbs")

--- a/pkg/transformers/aaa_transformer_json.go
+++ b/pkg/transformers/aaa_transformer_json.go
@@ -1,5 +1,5 @@
 // Machine-readable (JSON) accessors over the verb (transformer) catalog, for
-// `mlr help --json` and similar tooling.
+// `mlr help --as-json` and similar tooling.
 //
 // Tier-1 caveat: unlike functions and flags, verb options are not held in any
 // structured form -- each verb hand-writes a UsageFunc that prints prose. So


### PR DESCRIPTION
Follow-on to PR #2099 for issue #2098 -- commits I intended to include as the final commit of #2099.

This adheres to [./plans/plan-2098-llm.md](https://github.com/johnkerl/miller/blob/main/plans/plan-2098-llm.md).