### PR TITLE
Convert if/else-if chains to typed switch (staticcheck QF1003)

### DIFF
--- a/pkg/auxents/hex.go
+++ b/pkg/auxents/hex.go
@@ -40,10 +40,11 @@ func hexMain(args []string) int {
 	verb := args[1]
 	args = args[2:]
 	if len(args) >= 1 {
-		if args[0] == "-r" {
+		switch args[0] {
+		case "-r":
 			doRaw = true
 			args = args[1:]
-		} else if args[0] == "-h" || args[0] == "--help" {
+		case "-h", "--help":
 			hexUsage(verb, os.Stdout, 0)
 		}
 	}

--- a/pkg/auxents/lecat.go
+++ b/pkg/auxents/lecat.go
@@ -67,7 +67,8 @@ func lecatFile(istream *os.File, doColor bool) {
 		if err == io.EOF {
 			break
 		}
-		if c == '\r' {
+		switch c {
+		case '\r':
 			if doColor {
 				fmt.Printf("\033[31;01m") // xterm red
 			}
@@ -75,7 +76,7 @@ func lecatFile(istream *os.File, doColor bool) {
 			if doColor {
 				fmt.Printf("\033[0m")
 			}
-		} else if c == '\n' {
+		case '\n':
 			if doColor {
 				fmt.Printf("\033[32;01m") // xterm green
 			}
@@ -83,7 +84,7 @@ func lecatFile(istream *os.File, doColor bool) {
 			if doColor {
 				fmt.Printf("\033[0m")
 			}
-		} else {
+		default:
 			fmt.Printf("%c", c)
 		}
 	}

--- a/pkg/auxents/termcvt.go
+++ b/pkg/auxents/termcvt.go
@@ -43,29 +43,30 @@ func termcvtMain(args []string) int {
 		}
 		args = args[1:]
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			termcvtUsage(verb, os.Stdout, 0)
-		} else if opt == "-I" {
+		case "-I":
 			doInPlace = true
-		} else if opt == "--cr2crlf" {
+		case "--cr2crlf":
 			inputTerminator = "\r"
 			outputTerminator = "\r\n"
-		} else if opt == "--lf2crlf" {
+		case "--lf2crlf":
 			inputTerminator = "\n"
 			outputTerminator = "\r\n"
-		} else if opt == "--crlf2cr" {
+		case "--crlf2cr":
 			inputTerminator = "\r\n"
 			outputTerminator = "\r"
-		} else if opt == "--lf2cr" {
+		case "--lf2cr":
 			inputTerminator = "\n"
 			outputTerminator = "\r"
-		} else if opt == "--crlf2lf" {
+		case "--crlf2lf":
 			inputTerminator = "\r\n"
 			outputTerminator = "\n"
-		} else if opt == "--cr2lf" {
+		case "--cr2lf":
 			inputTerminator = "\r"
 			outputTerminator = "\n"
-		} else {
+		default:
 			termcvtUsage(verb, os.Stderr, 1)
 		}
 	}

--- a/pkg/bifs/stats.go
+++ b/pkg/bifs/stats.go
@@ -561,7 +561,8 @@ func bif_percentiles_with_options_aux(
 			return type_error_named_argument(funcname, "map", "options", options)
 		}
 		for pe := om.Head; pe != nil; pe = pe.Next {
-			if pe.Key == "array_is_sorted" || pe.Key == "ais" {
+			switch pe.Key {
+			case "array_is_sorted", "ais":
 				if mlrval.Equals(pe.Value, mlrval.TRUE) {
 					arrayIsSorted = true
 				} else if mlrval.Equals(pe.Value, mlrval.FALSE) {
@@ -569,7 +570,7 @@ func bif_percentiles_with_options_aux(
 				} else {
 					return type_error_named_argument(funcname, "boolean", pe.Key, pe.Value)
 				}
-			} else if pe.Key == "interpolate_linearly" || pe.Key == "il" {
+			case "interpolate_linearly", "il":
 				if mlrval.Equals(pe.Value, mlrval.TRUE) {
 					interpolateLinearly = true
 				} else if mlrval.Equals(pe.Value, mlrval.FALSE) {
@@ -577,7 +578,7 @@ func bif_percentiles_with_options_aux(
 				} else {
 					return type_error_named_argument(funcname, "boolean", pe.Key, pe.Value)
 				}
-			} else if pe.Key == "output_array_not_map" || pe.Key == "oa" {
+			case "output_array_not_map", "oa":
 				if mlrval.Equals(pe.Value, mlrval.TRUE) {
 					outputArrayNotMap = true
 				} else if mlrval.Equals(pe.Value, mlrval.FALSE) {

--- a/pkg/climain/mlrcli_shebang.go
+++ b/pkg/climain/mlrcli_shebang.go
@@ -31,11 +31,12 @@ func maybeInterpolateDashS(args []string) ([]string, error) {
 	if len(args) < 2 {
 		return args, nil
 	}
-	if args[1] == "-s" {
+	switch args[1] {
+	case "-s":
 		stripComments = true
-	} else if args[1] == "--s-no-comment-strip" {
+	case "--s-no-comment-strip":
 		stripComments = false
-	} else { // Normal case
+	default: // Normal case
 		return args, nil
 	}
 	if len(args) < 3 {

--- a/pkg/dsl/cst/dump.go
+++ b/pkg/dsl/cst/dump.go
@@ -130,11 +130,12 @@ func (root *RootNode) buildDumpxStatementNode(
 
 	if redirectorNode.Type == asts.NodeType(NodeTypeNoOp) {
 		// No > >> or | was provided.
-		if defaultOutputStream == os.Stdout {
+		switch defaultOutputStream {
+		case os.Stdout:
 			retval.dumpToRedirectFunc = retval.dumpToStdout
-		} else if defaultOutputStream == os.Stderr {
+		case os.Stderr:
 			retval.dumpToRedirectFunc = retval.dumpToStderr
-		} else {
+		default:
 			lib.InternalCodingErrorIf(true)
 		}
 	} else {

--- a/pkg/dsl/cst/if.go
+++ b/pkg/dsl/cst/if.go
@@ -77,7 +77,8 @@ func (root *RootNode) BuildIfChainNode(astNode *asts.ASTNode) (*IfChainNode, err
 	for _, astChild := range astChildren {
 		lib.InternalCodingErrorIf(astChild.Type != asts.NodeType(NodeTypeIfItem))
 		token := tokenLit(astChild) // "if", "elif", "else"
-		if token == "if" || token == "elif" {
+		switch token {
+		case "if", "elif":
 			lib.InternalCodingErrorIf(len(astChild.Children) != 2)
 			conditionNode, err := root.BuildEvaluableNode(astChild.Children[0])
 			if err != nil {
@@ -94,9 +95,9 @@ func (root *RootNode) BuildIfChainNode(astNode *asts.ASTNode) (*IfChainNode, err
 			}
 			ifItems = append(ifItems, ifItem)
 
-		} else if token == "else" {
+		case "else":
 			lib.InternalCodingErrorIf(len(astChild.Children) != 1)
-			var conditionNode IEvaluable = nil
+			var conditionNode IEvaluable
 			statementBlockNode, err := root.BuildStatementBlockNode(astChild.Children[0])
 			if err != nil {
 				return nil, err
@@ -107,7 +108,7 @@ func (root *RootNode) BuildIfChainNode(astNode *asts.ASTNode) (*IfChainNode, err
 			}
 			ifItems = append(ifItems, ifItem)
 
-		} else {
+		default:
 			lib.InternalCodingErrorIf(true)
 		}
 	}

--- a/pkg/dsl/cst/print.go
+++ b/pkg/dsl/cst/print.go
@@ -272,11 +272,12 @@ func (root *RootNode) buildPrintxStatementNode(
 
 	if redirectorNode.Type == asts.NodeType(NodeTypeNoOp) {
 		// No > >> or | was provided.
-		if defaultOutputStream == os.Stdout {
+		switch defaultOutputStream {
+		case os.Stdout:
 			retval.printToRedirectFunc = retval.printToStdout
-		} else if defaultOutputStream == os.Stderr {
+		case os.Stderr:
 			retval.printToRedirectFunc = retval.printToStderr
-		} else {
+		default:
 			lib.InternalCodingErrorIf(true)
 		}
 	} else {

--- a/pkg/lib/file_readers.go
+++ b/pkg/lib/file_readers.go
@@ -128,15 +128,16 @@ func escapeFileNameForPopen(filename string) string {
 	var buffer bytes.Buffer
 	foundQuoteOrSpace := false
 	for _, c := range filename {
-		if c == '\'' || c == '"' {
+		switch c {
+		case '\'', '"':
 			buffer.WriteRune('\'')
 			buffer.WriteRune(c)
 			buffer.WriteRune('\'')
 			foundQuoteOrSpace = true
-		} else if c == ' ' {
+		case ' ':
 			buffer.WriteRune(c)
 			foundQuoteOrSpace = true
-		} else {
+		default:
 			buffer.WriteRune(c)
 		}
 	}

--- a/pkg/lib/tsv_codec.go
+++ b/pkg/lib/tsv_codec.go
@@ -19,19 +19,20 @@ func TSVDecodeField(input string) string {
 		c := input[i]
 		if c == '\\' && i < n-1 {
 			d := input[i+1]
-			if d == '\\' {
+			switch d {
+			case '\\':
 				buffer.WriteByte('\\')
 				i += 2
-			} else if d == 'n' {
+			case 'n':
 				buffer.WriteByte('\n')
 				i += 2
-			} else if d == 'r' {
+			case 'r':
 				buffer.WriteByte('\r')
 				i += 2
-			} else if d == 't' {
+			case 't':
 				buffer.WriteByte('\t')
 				i += 2
-			} else {
+			default:
 				buffer.WriteByte(c)
 				i++
 			}
@@ -47,19 +48,20 @@ func TSVDecodeField(input string) string {
 func TSVEncodeField(input string) string {
 	var buffer bytes.Buffer
 	for _, r := range input {
-		if r == '\\' {
+		switch r {
+		case '\\':
 			buffer.WriteByte('\\')
 			buffer.WriteByte('\\')
-		} else if r == '\n' {
+		case '\n':
 			buffer.WriteByte('\\')
 			buffer.WriteByte('n')
-		} else if r == '\r' {
+		case '\r':
 			buffer.WriteByte('\\')
 			buffer.WriteByte('r')
-		} else if r == '\t' {
+		case '\t':
 			buffer.WriteByte('\\')
 			buffer.WriteByte('t')
-		} else {
+		default:
 			buffer.WriteRune(r)
 		}
 	}

--- a/pkg/mlrval/mlrmap_json.go
+++ b/pkg/mlrval/mlrmap_json.go
@@ -44,9 +44,10 @@ func (mlrmap *Mlrmap) marshalJSONAux(
 	elementNestingDepth int,
 	outputIsStdout bool,
 ) (string, error) {
-	if jsonFormatting == JSON_MULTILINE {
+	switch jsonFormatting {
+	case JSON_MULTILINE:
 		return mlrmap.marshalJSONAuxMultiline(jsonFormatting, elementNestingDepth, outputIsStdout)
-	} else if jsonFormatting == JSON_SINGLE_LINE {
+	case JSON_SINGLE_LINE:
 		return mlrmap.marshalJSONAuxSingleLine(jsonFormatting, elementNestingDepth, outputIsStdout)
 	}
 	lib.InternalCodingErrorIf(true)

--- a/pkg/mlrval/mlrval_copy.go
+++ b/pkg/mlrval/mlrval_copy.go
@@ -3,9 +3,10 @@ package mlrval
 // TODO: comment about mvtype; deferrence; copying of deferrence.
 func (mv *Mlrval) Copy() *Mlrval {
 	other := *mv
-	if mv.mvtype == MT_MAP {
+	switch mv.mvtype {
+	case MT_MAP:
 		other.intf = mv.intf.(*Mlrmap).Copy()
-	} else if mv.mvtype == MT_ARRAY {
+	case MT_ARRAY:
 		other.intf = CopyMlrvalArray(mv.intf.([]*Mlrval))
 	}
 	return &other

--- a/pkg/mlrval/mlrval_infer.go
+++ b/pkg/mlrval/mlrval_infer.go
@@ -132,13 +132,14 @@ func inferHexInt(mv *Mlrval) *Mlrval {
 	var input string
 	var negate bool
 	// Skip known leading 0x or -0x prefix
-	if mv.printrep[0] == '-' {
+	switch mv.printrep[0] {
+	case '-':
 		input = mv.printrep[3:]
 		negate = true
-	} else if mv.printrep[0] == '+' {
+	case '+':
 		input = mv.printrep[3:]
 		negate = false
-	} else {
+	default:
 		input = mv.printrep[2:]
 		negate = false
 	}
@@ -196,13 +197,14 @@ func inferBaseInt(mv *Mlrval, base int) *Mlrval {
 	var input string
 	var negate bool
 	// Skip known leading 0x or -0x prefix
-	if mv.printrep[0] == '-' {
+	switch mv.printrep[0] {
+	case '-':
 		input = mv.printrep[3:]
 		negate = true
-	} else if mv.printrep[0] == '+' {
+	case '+':
 		input = mv.printrep[3:]
 		negate = false
-	} else {
+	default:
 		input = mv.printrep[2:]
 		negate = false
 	}

--- a/pkg/mlrval/mlrval_json.go
+++ b/pkg/mlrval/mlrval_json.go
@@ -169,15 +169,16 @@ func MlrvalDecodeFromJSON(decoder *json.Decoder) (
 		var expectedClosingDelimiter rune
 		var collectionType string
 
-		if delimiter == '[' {
+		switch delimiter {
+		case '[':
 			isArray = true
 			expectedClosingDelimiter = ']'
 			collectionType = "JSON array"
-		} else if delimiter == '{' {
+		case '{':
 			isArray = false
 			expectedClosingDelimiter = '}'
 			collectionType = "JSON object`"
-		} else {
+		default:
 			return nil, false, fmt.Errorf(
 				"JSON reader: Unhandled opening delimiter \"%s\"", string(delimiter),
 			)

--- a/pkg/mlrval/mlrval_new.go
+++ b/pkg/mlrval/mlrval_new.go
@@ -144,9 +144,10 @@ func FromInferredType(input string) *Mlrval {
 		printrepValid: true,
 	}
 	// TODO: comment re data files vs literals context -- this is for the latter
-	if input == "true" {
+	switch input {
+	case "true":
 		return TRUE
-	} else if input == "false" {
+	case "false":
 		return FALSE
 	}
 	packageLevelInferrer(mv)
@@ -280,9 +281,10 @@ func FromBool(input bool) *Mlrval {
 }
 
 func FromBoolString(input string) *Mlrval {
-	if input == "true" {
+	switch input {
+	case "true":
 		return TRUE
-	} else if input == "false" {
+	case "false":
 		return FALSE
 	}
 	lib.InternalCodingErrorIf(true)

--- a/pkg/terminals/help/entry.go
+++ b/pkg/terminals/help/entry.go
@@ -579,15 +579,16 @@ func helpTypeArithmeticInfoAux(extended bool) {
 			fmt.Printf("%-10s |", mlrvals[i].String())
 		}
 		for j := 0; j < n; j++ {
-			if i == -2 {
+			switch i {
+			case -2:
 				if mlrvals[j].IsVoid() {
 					fmt.Printf("%-10s", "(empty)")
 				} else {
 					fmt.Printf(" %-10s", mlrvals[j].String())
 				}
-			} else if i == -1 {
+			case -1:
 				fmt.Printf(" %-10s", "------")
-			} else {
+			default:
 				sum := bifs.BIF_plus_binary(mlrvals[i], mlrvals[j])
 				if sum.IsVoid() {
 					fmt.Printf(" %-10s", "(empty)")
@@ -631,15 +632,16 @@ func helpTypeArithmeticInfoAux(extended bool) {
 				fmt.Printf("%-10s |", mlrvals[i].String())
 			}
 			for j := 0; j < n; j++ {
-				if i == -2 {
+				switch i {
+				case -2:
 					if mlrvals[j].IsVoid() {
 						fmt.Printf("%-10s", "(empty)")
 					} else {
 						fmt.Printf(" %-10s", mlrvals[j].String())
 					}
-				} else if i == -1 {
+				case -1:
 					fmt.Printf(" %-10s", "------")
-				} else {
+				default:
 
 					inode := cst.BuildMlrvalLiteralNode(mlrvals[i])
 					jnode := cst.BuildMlrvalLiteralNode(mlrvals[j])

--- a/pkg/terminals/regtest/entry.go
+++ b/pkg/terminals/regtest/entry.go
@@ -53,17 +53,18 @@ func RegTestMain(args []string) int {
 		}
 		argi++
 
-		if arg == "-h" || arg == "--help" {
+		switch arg {
+		case "-h", "--help":
 			regTestUsage(verbName, os.Stdout, 0)
 
-		} else if arg == "-m" {
+		case "-m":
 			if argi >= argc {
 				regTestUsage(verbName, os.Stderr, 1)
 			}
 			exeName = args[argi]
 			argi++
 
-		} else if arg == "-s" {
+		case "-s":
 			if argi >= argc {
 				regTestUsage(verbName, os.Stderr, 1)
 			}
@@ -74,19 +75,19 @@ func RegTestMain(args []string) int {
 			firstNFailsToShow = temp
 			argi++
 
-		} else if arg == "-S" {
+		case "-S":
 			firstNFailsToShow = 1000000000
 
-		} else if arg == "-p" {
+		case "-p":
 			doPopulate = true
 
-		} else if arg == "-v" {
+		case "-v":
 			verbosityLevel++
 
-		} else if arg == "-j" {
+		case "-j":
 			plainMode = true
 
-		} else {
+		default:
 			regTestUsage(verbName, os.Stderr, 1)
 		}
 	}

--- a/pkg/terminals/repl/dsl.go
+++ b/pkg/terminals/repl/dsl.go
@@ -52,11 +52,12 @@ func (repl *Repl) handleDSLStringAux(
 		isReplImmediate,
 		doWarnings,
 		func(dslString string, astNode *asts.AST) {
-			if repl.astPrintMode == ASTPrintParex {
+			switch repl.astPrintMode {
+			case ASTPrintParex:
 				astNode.PrintParex()
-			} else if repl.astPrintMode == ASTPrintParexOneLine {
+			case ASTPrintParexOneLine:
 				astNode.PrintParexOneLine()
-			} else if repl.astPrintMode == ASTPrintIndent {
+			case ASTPrintIndent:
 				astNode.Print()
 			}
 		},

--- a/pkg/terminals/repl/verbs.go
+++ b/pkg/terminals/repl/verbs.go
@@ -463,11 +463,12 @@ func handleSkipOrProcessUntil(repl *Repl, dslString string, processingNotSkippin
 		true, // isReplImmediate
 		repl.doWarnings,
 		func(dslString string, astNode *asts.AST) {
-			if repl.astPrintMode == ASTPrintParex {
+			switch repl.astPrintMode {
+			case ASTPrintParex:
 				astNode.PrintParex()
-			} else if repl.astPrintMode == ASTPrintParexOneLine {
+			case ASTPrintParexOneLine:
 				astNode.PrintParexOneLine()
-			} else if repl.astPrintMode == ASTPrintIndent {
+			case ASTPrintIndent:
 				astNode.Print()
 			}
 		},
@@ -764,15 +765,16 @@ func handleASTPrint(repl *Repl, args []string) bool {
 		return false
 	}
 	style := args[0]
-	if style == "parex" {
+	switch style {
+	case "parex":
 		repl.astPrintMode = ASTPrintParex
-	} else if style == "parex1" {
+	case "parex1":
 		repl.astPrintMode = ASTPrintParexOneLine
-	} else if style == "indent" {
+	case "indent":
 		repl.astPrintMode = ASTPrintIndent
-	} else if style == "none" {
+	case "none":
 		repl.astPrintMode = ASTPrintNone
-	} else {
+	default:
 		fmt.Printf("Unrecognized style %s: see ':help :astprint'.\n", style)
 	}
 	return true

--- a/pkg/transformers/bar.go
+++ b/pkg/transformers/bar.go
@@ -82,52 +82,53 @@ func transformerBarParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerBarUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--lo" {
+		case "--lo":
 			lo, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-w" {
+		case "-w":
 			width, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "--hi" {
+		case "--hi":
 			hi, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-c" {
+		case "-c":
 			fillString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-x" {
+		case "-x":
 			oobString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-b" {
+		case "-b":
 			blankString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--auto" {
+		case "--auto":
 			doAuto = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/bootstrap.go
+++ b/pkg/transformers/bootstrap.go
@@ -61,17 +61,18 @@ func transformerBootstrapParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerBootstrapUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			nout, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/case.go
+++ b/pkg/transformers/case.go
@@ -75,32 +75,33 @@ func transformerCaseParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCaseUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-k" {
+		case "-k":
 			which = "keys_only"
 
-		} else if opt == "-v" {
+		case "-v":
 			which = "values_only"
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-u" {
+		case "-u":
 			style = e_UPPER_CASE
-		} else if opt == "-l" {
+		case "-l":
 			style = e_LOWER_CASE
-		} else if opt == "-s" {
+		case "-s":
 			style = e_SENTENCE_CASE
-		} else if opt == "-t" {
+		case "-t":
 			style = e_TITLE_CASE
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -133,11 +134,12 @@ func NewTransformerCase(
 ) (*TransformerCase, error) {
 	tr := &TransformerCase{}
 
-	if which == "keys_only" {
+	switch which {
+	case "keys_only":
 		tr.recordTransformerFunc = tr.transformKeysOnly
-	} else if which == "values_only" {
+	case "values_only":
 		tr.recordTransformerFunc = tr.transformValuesOnly
-	} else {
+	default:
 		tr.recordTransformerFunc = tr.transformKeysAndValues
 	}
 

--- a/pkg/transformers/cat.go
+++ b/pkg/transformers/cat.go
@@ -64,32 +64,33 @@ func transformerCatParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCatUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			counterFieldName = "n"
 
-		} else if opt == "-N" {
+		case "-N":
 			counterFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--filename" {
+		case "--filename":
 			doFileName = true
 
-		} else if opt == "--filenum" {
+		case "--filenum":
 			doFileNum = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/clean_whitespace.go
+++ b/pkg/transformers/clean_whitespace.go
@@ -63,18 +63,19 @@ func transformerCleanWhitespaceParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCleanWhitespaceUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-k" || opt == "--keys-only" {
+		case "-k", "--keys-only":
 			doKeys = true
 			doValues = false
-		} else if opt == "-v" || opt == "--values-only" {
+		case "-v", "--values-only":
 			doKeys = false
 			doValues = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verbNameCleanWhitespace, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/count.go
+++ b/pkg/transformers/count.go
@@ -62,26 +62,27 @@ func transformerCountParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCountUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-n" {
+		case "-n":
 			showCountsOnly = true
 
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/count_similar.go
+++ b/pkg/transformers/count_similar.go
@@ -59,23 +59,24 @@ func transformerCountSimilarParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCountSimilarUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-o" {
+		case "-o":
 			counterFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/cut.go
+++ b/pkg/transformers/cut.go
@@ -75,29 +75,27 @@ func transformerCutParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCutUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-o" {
+		case "-o":
 			doArgOrder = true
 
-		} else if opt == "-x" {
+		case "-x", "--complement":
 			doComplement = true
 
-		} else if opt == "--complement" {
-			doComplement = true
-
-		} else if opt == "-r" {
+		case "-r":
 			doRegexes = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/decimate.go
+++ b/pkg/transformers/decimate.go
@@ -60,11 +60,12 @@ func transformerDecimateParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerDecimateUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			decimateCount, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -73,19 +74,19 @@ func transformerDecimateParseCLI(
 				return nil, cli.VerbErrorf(verb, "-n must be positive")
 			}
 
-		} else if opt == "-b" {
+		case "-b":
 			atStart = true
 
-		} else if opt == "-e" {
+		case "-e":
 			atEnd = true
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/fill_down.go
+++ b/pkg/transformers/fill_down.go
@@ -66,26 +66,24 @@ func transformerFillDownParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerFillDownUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fillDownFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--all" {
+		case "--all":
 			doAll = true
 
-		} else if opt == "-a" {
+		case "-a", "--only-if-absent":
 			onlyIfAbsent = true
 
-		} else if opt == "--only-if-absent" {
-			onlyIfAbsent = true
-
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/fill_empty.go
+++ b/pkg/transformers/fill_empty.go
@@ -57,20 +57,21 @@ func transformerFillEmptyParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerFillEmptyUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-v" {
+		case "-v":
 			fillString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-S" {
+		case "-S":
 			inferType = false
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/flatten.go
+++ b/pkg/transformers/flatten.go
@@ -60,23 +60,24 @@ func transformerFlattenParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerFlattenUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-s" {
+		case "-s":
 			oFlatSep, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/format_values.go
+++ b/pkg/transformers/format_values.go
@@ -86,29 +86,30 @@ func transformerFormatValuesParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerFormatValuesUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-s" {
+		case "-s":
 			stringFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-i" {
+		case "-i":
 			intFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-f" {
+		case "-f":
 			floatFormat, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-n" {
+		case "-n":
 			coerceIntToFloat = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/fraction.go
+++ b/pkg/transformers/fraction.go
@@ -79,29 +79,30 @@ func transformerFractionParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerFractionUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fractionFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-p" {
+		case "-p":
 			doPercents = true
 
-		} else if opt == "-c" {
+		case "-c":
 			doCumu = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/gap.go
+++ b/pkg/transformers/gap.go
@@ -61,23 +61,24 @@ func transformerGapParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerGapUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			gapCount, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/grep.go
+++ b/pkg/transformers/grep.go
@@ -72,20 +72,21 @@ func transformerGrepParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerGrepUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-i" {
+		case "-i":
 			ignoreCase = true
 
-		} else if opt == "-v" {
+		case "-v":
 			invert = true
 
-		} else if opt == "-a" {
+		case "-a":
 			valuesOnly = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/having_fields.go
+++ b/pkg/transformers/having_fields.go
@@ -83,11 +83,12 @@ func transformerHavingFieldsParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerHavingFieldsUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "--at-least" {
+		case "--at-least":
 			havingFieldsCriterion = havingFieldsAtLeast
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -95,7 +96,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			regexString = ""
 
-		} else if opt == "--which-are" {
+		case "--which-are":
 			havingFieldsCriterion = havingFieldsWhichAre
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -103,7 +104,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			regexString = ""
 
-		} else if opt == "--at-most" {
+		case "--at-most":
 			havingFieldsCriterion = havingFieldsAtMost
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -111,7 +112,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			regexString = ""
 
-		} else if opt == "--all-matching" {
+		case "--all-matching":
 			havingFieldsCriterion = havingAllFieldsMatching
 			regexString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -119,7 +120,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			fieldNames = nil
 
-		} else if opt == "--any-matching" {
+		case "--any-matching":
 			havingFieldsCriterion = havingAnyFieldsMatching
 			regexString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -127,7 +128,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			fieldNames = nil
 
-		} else if opt == "--none-matching" {
+		case "--none-matching":
 			havingFieldsCriterion = havingNoFieldsMatching
 			regexString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -135,7 +136,7 @@ func transformerHavingFieldsParseCLI(
 			}
 			fieldNames = nil
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -187,13 +188,14 @@ func NewTransformerHavingFields(
 		tr.numFieldNames = int64(len(fieldNames))
 		tr.fieldNameSet = lib.StringListToSet(fieldNames)
 
-		if havingFieldsCriterion == havingFieldsAtLeast {
+		switch havingFieldsCriterion {
+		case havingFieldsAtLeast:
 			tr.recordTransformerFunc = tr.transformHavingFieldsAtLeast
-		} else if havingFieldsCriterion == havingFieldsWhichAre {
+		case havingFieldsWhichAre:
 			tr.recordTransformerFunc = tr.transformHavingFieldsWhichAre
-		} else if havingFieldsCriterion == havingFieldsAtMost {
+		case havingFieldsAtMost:
 			tr.recordTransformerFunc = tr.transformHavingFieldsAtMost
-		} else {
+		default:
 			lib.InternalCodingErrorIf(true)
 		}
 
@@ -214,13 +216,14 @@ func NewTransformerHavingFields(
 		}
 		tr.regex = regex
 
-		if havingFieldsCriterion == havingAllFieldsMatching {
+		switch havingFieldsCriterion {
+		case havingAllFieldsMatching:
 			tr.recordTransformerFunc = tr.transformHavingAllFieldsMatching
-		} else if havingFieldsCriterion == havingAnyFieldsMatching {
+		case havingAnyFieldsMatching:
 			tr.recordTransformerFunc = tr.transformHavingAnyFieldsMatching
-		} else if havingFieldsCriterion == havingNoFieldsMatching {
+		case havingNoFieldsMatching:
 			tr.recordTransformerFunc = tr.transformHavingNoFieldsMatching
-		} else {
+		default:
 			lib.InternalCodingErrorIf(true)
 		}
 	}

--- a/pkg/transformers/head.go
+++ b/pkg/transformers/head.go
@@ -59,25 +59,26 @@ func transformerHeadParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerHeadUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			n, err := cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			headCount = n
 
-		} else if opt == "-g" {
+		case "-g":
 			names, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			groupByFieldNames = names
 
-		} else {
+		default:
 			transformerHeadUsage(os.Stderr)
 			return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verb, opt)
 		}

--- a/pkg/transformers/histogram.go
+++ b/pkg/transformers/histogram.go
@@ -70,44 +70,45 @@ func transformerHistogramParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerHistogramUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			valueFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--lo" {
+		case "--lo":
 			lo, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--nbins" {
+		case "--nbins":
 			nbins, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--hi" {
+		case "--hi":
 			hi, err = cli.VerbGetFloatArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--auto" {
+		case "--auto":
 			doAuto = true
 
-		} else if opt == "-o" {
+		case "-o":
 			outputPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/join.go
+++ b/pkg/transformers/join.go
@@ -162,82 +162,83 @@ func transformerJoinParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerJoinUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "--prepipe" {
+		case "--prepipe":
 			opts.prepipe, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			opts.prepipeIsRaw = false
 
-		} else if opt == "--prepipex" {
+		case "--prepipex":
 			opts.prepipe, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			opts.prepipeIsRaw = true
 
-		} else if opt == "-f" {
+		case "-f":
 			opts.leftFileName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-j" {
+		case "-j":
 			opts.outputJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-l" {
+		case "-l":
 			opts.leftJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--lk" || opt == "--left-keep-field-names" {
+		case "--lk", "--left-keep-field-names":
 			opts.leftKeepFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-r" {
+		case "-r":
 			opts.rightJoinFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--lp" {
+		case "--lp":
 			opts.leftPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--rp" {
+		case "--rp":
 			opts.rightPrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--np" {
+		case "--np":
 			opts.emitPairables = false
 
-		} else if opt == "--ul" {
+		case "--ul":
 			opts.emitLeftUnpairables = true
 
-		} else if opt == "--ur" {
+		case "--ur":
 			opts.emitRightUnpairables = true
 
-		} else if opt == "-u" {
+		case "-u":
 			opts.allowUnsortedInput = true
 
-		} else if opt == "--sorted-input" || opt == "-s" {
+		case "--sorted-input", "-s":
 			opts.allowUnsortedInput = false
 
-		} else {
+		default:
 			// This is inelegant. For error-proofing we advance argi already in our
 			// loop (so individual if-statements don't need to). However,
 			// cli.Parse expects it unadvanced.

--- a/pkg/transformers/json_parse.go
+++ b/pkg/transformers/json_parse.go
@@ -61,20 +61,21 @@ func transformerJSONParseParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerJSONParseUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-k" {
+		case "-k":
 			keepFailed = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/json_stringify.go
+++ b/pkg/transformers/json_stringify.go
@@ -61,23 +61,24 @@ func transformerJSONStringifyParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerJSONStringifyUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--jvstack" {
+		case "--jvstack":
 			jvStack = true
 
-		} else if opt == "--no-jvstack" {
+		case "--no-jvstack":
 			jvStack = false
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/merge_fields.go
+++ b/pkg/transformers/merge_fields.go
@@ -100,56 +100,54 @@ func transformerMergeFieldsParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerMergeFieldsUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-a" {
+		case "-a":
 			accumulatorNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doWhich = e_MERGE_BY_NAME_LIST
 
-		} else if opt == "-r" {
+		case "-r":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doWhich = e_MERGE_BY_NAME_REGEX
 
-		} else if opt == "-c" {
+		case "-c":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doWhich = e_MERGE_BY_COLLAPSING
 
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldBasename, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-k" {
+		case "-k":
 			keepInputFields = true
 
-		} else if opt == "-i" {
+		case "-i":
 			doInterpolatedPercentiles = true
 
-		} else if opt == "-S" {
+		case "-S", "-F":
 			// No-op pass-through for backward compatibility with Miller 5
 
-		} else if opt == "-F" {
-			// No-op pass-through for backward compatibility with Miller 5
-
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -301,13 +299,14 @@ func NewTransformerMergeFields(
 		tr.namedAccumulators.Put(accumulatorName, accumulator)
 	}
 
-	if doWhich == e_MERGE_BY_NAME_LIST {
+	switch doWhich {
+	case e_MERGE_BY_NAME_LIST:
 		tr.recordTransformerFunc = tr.transformByNameList
-	} else if doWhich == e_MERGE_BY_NAME_REGEX {
+	case e_MERGE_BY_NAME_REGEX:
 		tr.recordTransformerFunc = tr.transformByNameRegex
-	} else if doWhich == e_MERGE_BY_COLLAPSING {
+	case e_MERGE_BY_COLLAPSING:
 		tr.recordTransformerFunc = tr.transformByCollapsing
-	} else {
+	default:
 		lib.InternalCodingErrorIf(true)
 	}
 

--- a/pkg/transformers/most_or_least_frequent.go
+++ b/pkg/transformers/most_or_least_frequent.go
@@ -115,32 +115,33 @@ func transformerMostOrLeastFrequentParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			usageFunc(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-n" {
+		case "-n":
 			maxOutputLength, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-b" {
+		case "-b":
 			showCounts = false
 
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/nest.go
+++ b/pkg/transformers/nest.go
@@ -125,18 +125,19 @@ func transformerNestParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerNestUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			fieldName = s
 
-		} else if opt == "-r" {
+		case "-r":
 			doRegexes = true
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -144,41 +145,41 @@ func transformerNestParseCLI(
 			}
 			fieldName = s
 
-		} else if opt == "--explode" || opt == "-e" {
+		case "--explode", "-e":
 			doExplode = true
 			doExplodeSpecified = true
-		} else if opt == "--implode" || opt == "-i" {
+		case "--implode", "-i":
 			doExplode = false
 			doExplodeSpecified = true
 
-		} else if opt == "--values" || opt == "-v" {
+		case "--values", "-v":
 			doPairs = false
 			doPairsSpecified = true
-		} else if opt == "--pairs" || opt == "-p" {
+		case "--pairs", "-p":
 			doPairs = true
 			doPairsSpecified = true
 
-		} else if opt == "--across-fields" || opt == "-F" {
+		case "--across-fields", "-F":
 			doAcrossFields = true
 			doAcrossFieldsSpecified = true
-		} else if opt == "--across-records" || opt == "-R" {
+		case "--across-records", "-R":
 			doAcrossFields = false
 			doAcrossFieldsSpecified = true
 
-		} else if opt == "--nested-fs" || opt == "-S" {
+		case "--nested-fs", "-S":
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			nestedFS = s
-		} else if opt == "--nested-ps" || opt == "-P" {
+		case "--nested-ps", "-P":
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			nestedPS = s
 
-		} else if opt == "--evar" {
+		case "--evar":
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -191,7 +192,7 @@ func transformerNestParseCLI(
 			doAcrossFields = false
 			doAcrossFieldsSpecified = true
 
-		} else if opt == "--ivar" {
+		case "--ivar":
 			s, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -204,7 +205,7 @@ func transformerNestParseCLI(
 			doAcrossFields = false
 			doAcrossFieldsSpecified = true
 
-		} else {
+		default:
 			transformerNestUsage(os.Stderr)
 			return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verb, opt)
 		}

--- a/pkg/transformers/put_or_filter.go
+++ b/pkg/transformers/put_or_filter.go
@@ -49,9 +49,10 @@ func transformerPutOrFilterUsage(
 	verb string,
 ) {
 	fmt.Fprintf(o, "Usage: %s %s [options] {DSL expression}\n", "mlr", verb)
-	if verb == "put" {
+	switch verb {
+	case "put":
 		fmt.Fprintf(o, "Lets you use a domain-specific language to programmatically alter stream records.\n")
-	} else if verb == "filter" {
+	case "filter":
 		fmt.Fprintf(o, "Lets you use a domain-specific language to programmatically filter which\n")
 		fmt.Fprintf(o, "stream records will be output.\n")
 	}
@@ -234,11 +235,12 @@ func transformerPutOrFilterParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerPutOrFilterUsage(os.Stdout, verb)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			// Get a DSL string from the user-specified filename
 			filename, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -266,7 +268,7 @@ func transformerPutOrFilterParseCLI(
 			}
 			haveDSLStringsHere = true
 
-		} else if opt == "-e" {
+		case "-e":
 			dslString, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -274,7 +276,7 @@ func transformerPutOrFilterParseCLI(
 			dslStrings = append(dslStrings, dslString)
 			haveDSLStringsHere = true
 
-		} else if opt == "-s" {
+		case "-s":
 			// E.g.
 			//   mlr put -s sum=0
 			// is like
@@ -285,45 +287,45 @@ func transformerPutOrFilterParseCLI(
 			}
 			presets = append(presets, preset)
 
-		} else if opt == "-x" {
+		case "-x":
 			invertFilter = true
-		} else if opt == "-q" {
+		case "-q":
 			suppressOutputRecord = true
 
-		} else if opt == "-E" {
+		case "-E":
 			echoDSLString = true
-		} else if opt == "-p" {
+		case "-p":
 			printASTAsTree = true
-		} else if opt == "-v" {
+		case "-v":
 			echoDSLString = true
 			printASTAsTree = true
-		} else if opt == "-d" {
+		case "-d":
 			printASTMultiLine = true
-		} else if opt == "-D" {
+		case "-D":
 			printASTSingleLine = true
-		} else if opt == "-X" {
+		case "-X":
 			exitAfterParse = true
-		} else if opt == "-w" {
+		case "-w":
 			doWarnings = true
 			warningsAreFatal = false
-		} else if opt == "-z" {
+		case "-z":
 			// TODO: perhaps doWarnings and warningsAreFatal as well.
 			// But first I want to see what can be caught at runtime
 			// without static analysis.
 			strictMode = true
-		} else if opt == "-W" {
+		case "-W":
 			doWarnings = true
 			warningsAreFatal = true
 
-		} else if opt == "-S" {
+		case "-S":
 			// TODO: this is a no-op in Miller 6 and above.
 			// Comment this in more detail.
 
-		} else if opt == "-F" {
+		case "-F":
 			// TODO: this is a no-op in Miller 6 and above.
 			// Comment this in more detail.
 
-		} else {
+		default:
 			// This is inelegant. For error-proofing we advance argi already in our
 			// loop (so individual if-statements don't need to). However,
 			// ParseWriterOptions expects it unadvanced.

--- a/pkg/transformers/rename.go
+++ b/pkg/transformers/rename.go
@@ -74,17 +74,18 @@ func transformerRenameParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerRenameUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-r" {
+		case "-r":
 			doRegexes = true
 
-		} else if opt == "-g" {
+		case "-g":
 			doGsub = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verbNameRename, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/reorder.go
+++ b/pkg/transformers/reorder.go
@@ -80,43 +80,44 @@ func transformerReorderParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerReorderUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doRegexes = false
 
-		} else if opt == "-r" {
+		case "-r":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doRegexes = true
 
-		} else if opt == "-b" {
+		case "-b":
 			centerFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			putAfter = false
 
-		} else if opt == "-a" {
+		case "-a":
 			centerFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			putAfter = true
 
-		} else if opt == "-e" {
+		case "-e":
 			putAfter = true
 			centerFieldName = ""
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/repeat.go
+++ b/pkg/transformers/repeat.go
@@ -85,25 +85,26 @@ func transformerRepeatParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerRepeatUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			repeatCount, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			repeatCountSource = repeatCountFromInt
 
-		} else if opt == "-f" {
+		case "-f":
 			repeatCountFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			repeatCountSource = repeatCountFromFieldName
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/reshape.go
+++ b/pkg/transformers/reshape.go
@@ -144,16 +144,17 @@ func transformerReshapeParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerReshapeUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-i" {
+		case "-i":
 			inputFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-r" {
+		case "-r":
 			inputFieldRegexString, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -162,18 +163,18 @@ func transformerReshapeParseCLI(
 				inputFieldRegexStrings = []string{}
 			}
 			inputFieldRegexStrings = append(inputFieldRegexStrings, inputFieldRegexString)
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-s" {
+		case "-s":
 			splitOutFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/sample.go
+++ b/pkg/transformers/sample.go
@@ -60,23 +60,24 @@ func transformerSampleParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSampleUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-k" {
+		case "-k":
 			sampleCount, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/sec2gmt.go
+++ b/pkg/transformers/sec2gmt.go
@@ -62,37 +62,38 @@ func transformerSec2GMTParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSec2GMTUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-1" {
+		case "-1":
 			numDecimalPlaces = 1
-		} else if opt == "-2" {
+		case "-2":
 			numDecimalPlaces = 2
-		} else if opt == "-3" {
+		case "-3":
 			numDecimalPlaces = 3
-		} else if opt == "-4" {
+		case "-4":
 			numDecimalPlaces = 4
-		} else if opt == "-5" {
+		case "-5":
 			numDecimalPlaces = 5
-		} else if opt == "-6" {
+		case "-6":
 			numDecimalPlaces = 6
-		} else if opt == "-7" {
+		case "-7":
 			numDecimalPlaces = 7
-		} else if opt == "-8" {
+		case "-8":
 			numDecimalPlaces = 8
-		} else if opt == "-9" {
+		case "-9":
 			numDecimalPlaces = 9
 
-		} else if opt == "--millis" {
+		case "--millis":
 			preDivide = 1.0e3
-		} else if opt == "--micros" {
+		case "--micros":
 			preDivide = 1.0e6
-		} else if opt == "--nanos" {
+		case "--nanos":
 			preDivide = 1.0e9
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verbNameSec2GMT, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/seqgen.go
+++ b/pkg/transformers/seqgen.go
@@ -69,35 +69,36 @@ func transformerSeqgenParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSeqgenUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--start" {
+		case "--start":
 			startString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--stop" {
+		case "--stop":
 			stopString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--step" {
+		case "--step":
 			stepString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/sort.go
+++ b/pkg/transformers/sort.go
@@ -116,11 +116,12 @@ func transformerSortParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSortUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			subList, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -130,7 +131,7 @@ func transformerSortParseCLI(
 				comparatorFuncs = append(comparatorFuncs, mlrval.LexicalAscendingComparator)
 			}
 
-		} else if opt == "-c" {
+		case "-c":
 			// See comments over "-n" -- similar hack.
 			if args[argi] == "-r" {
 				// Treat like "-cr"
@@ -158,7 +159,7 @@ func transformerSortParseCLI(
 				}
 			}
 
-		} else if opt == "-t" {
+		case "-t":
 			// See comments over "-n" -- similar hack.
 			if err := cli.VerbCheckArgCount(verb, opt, args, argi, argc, 1); err != nil {
 				return nil, err
@@ -188,7 +189,7 @@ func transformerSortParseCLI(
 				}
 			}
 
-		} else if opt == "-r" {
+		case "-r":
 			// See comments over "-n" -- similar hack.
 			if err := cli.VerbCheckArgCount(verb, opt, args, argi, argc, 1); err != nil {
 				return nil, err
@@ -218,7 +219,7 @@ func transformerSortParseCLI(
 				}
 			}
 
-		} else if opt == "-n" {
+		case "-n":
 			// This is a bit of a hack.
 			//
 			// As of Miller 6 we have a getoptish feature wherein "-xyz" is
@@ -245,7 +246,8 @@ func transformerSortParseCLI(
 				return nil, err
 			}
 
-			if args[argi] == "-f" {
+			switch args[argi] {
+			case "-f":
 				// Treat like "-nf"
 				argi++
 				subList, err := cli.VerbGetStringArrayArg(verb, "-nf", args, &argi, argc)
@@ -257,7 +259,7 @@ func transformerSortParseCLI(
 					comparatorFuncs = append(comparatorFuncs, mlrval.NumericAscendingComparator)
 				}
 
-			} else if args[argi] == "-r" {
+			case "-r":
 				// Treat like "-nr"
 				argi++
 				subList, err := cli.VerbGetStringArrayArg(verb, "-nr", args, &argi, argc)
@@ -269,7 +271,7 @@ func transformerSortParseCLI(
 					comparatorFuncs = append(comparatorFuncs, mlrval.NumericDescendingComparator)
 				}
 
-			} else {
+			default:
 				// Treat like "-n"
 				subList, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 				if err != nil {
@@ -281,7 +283,7 @@ func transformerSortParseCLI(
 				}
 			}
 
-		} else if opt == "-nf" {
+		case "-nf":
 			subList, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -291,7 +293,7 @@ func transformerSortParseCLI(
 				comparatorFuncs = append(comparatorFuncs, mlrval.NumericAscendingComparator)
 			}
 
-		} else if opt == "-nr" {
+		case "-nr":
 			subList, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -301,10 +303,10 @@ func transformerSortParseCLI(
 				comparatorFuncs = append(comparatorFuncs, mlrval.NumericDescendingComparator)
 			}
 
-		} else if opt == "-b" {
+		case "-b":
 			doMoveToHead = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/sort_within_records.go
+++ b/pkg/transformers/sort_within_records.go
@@ -66,11 +66,12 @@ func transformerSortWithinRecordsParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSortWithinRecordsUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-r" {
+		case "-r":
 			// If the next token exists and isn't another flag, consume it as
 			// the regex pattern. Otherwise -r is arity-0: combined with a
 			// preceding -f it means regex mode; standalone it means recursive.
@@ -84,17 +85,17 @@ func transformerSortWithinRecordsParseCLI(
 				doRecurse = true
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			names, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			fieldNames = names
 
-		} else if opt == "-n" {
+		case "-n":
 			doNatural = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verbNameSortWithinRecords, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/sparsify.go
+++ b/pkg/transformers/sparsify.go
@@ -67,23 +67,24 @@ func transformerSparsifyParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSparsifyUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-s" {
+		case "-s":
 			fillerString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			specifiedFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/split.go
+++ b/pkg/transformers/split.go
@@ -118,65 +118,66 @@ func transformerSplitParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSplitUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			n, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doSize = true
 
-		} else if opt == "-m" {
+		case "-m":
 			n, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doMod = true
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--prefix" {
+		case "--prefix":
 			outputFileNamePrefix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--suffix" {
+		case "--suffix":
 			outputFileNameSuffix, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			haveOutputFileNameSuffix = true
 
-		} else if opt == "--folder" {
+		case "--folder":
 			outputFolder, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-a" {
+		case "-a":
 			doAppend = true
 
-		} else if opt == "-v" {
+		case "-v":
 			emitDownstream = true
 
-		} else if opt == "-e" {
+		case "-e":
 			escapeFileNameCharacters = false
 
-		} else if opt == "-j" {
+		case "-j":
 			fileNamePartJoiner, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			// This is inelegant. For error-proofing we advance argi already in our
 			// loop (so individual if-statements don't need to). However,
 			// ParseWriterOptions expects it unadvanced.

--- a/pkg/transformers/stats1.go
+++ b/pkg/transformers/stats1.go
@@ -123,49 +123,50 @@ func transformerStats1ParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerStats1Usage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-a" {
+		case "-a":
 			accumulatorNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "--fr" {
+		case "--fr":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doRegexValueFieldNames = true
 
-		} else if opt == "--fx" {
+		case "--fx":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doRegexValueFieldNames = true
 			invertRegexValueFieldNames = true
-		} else if opt == "--gr" {
+		case "--gr":
 			groupByFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doRegexGroupByFieldNames = true
-		} else if opt == "--gx" {
+		case "--gx":
 			groupByFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -173,7 +174,7 @@ func transformerStats1ParseCLI(
 			doRegexGroupByFieldNames = true
 			invertRegexGroupByFieldNames = true
 
-		} else if opt == "--grfx" {
+		case "--grfx":
 			doRegexValueFieldNames = true
 			doRegexGroupByFieldNames = true
 			invertRegexValueFieldNames = true
@@ -183,19 +184,16 @@ func transformerStats1ParseCLI(
 			}
 			groupByFieldNameList = slices.Clone(valueFieldNameList)
 
-		} else if opt == "-i" {
+		case "-i":
 			doInterpolatedPercentiles = true
 
-		} else if opt == "-s" {
+		case "-s":
 			doIterativeStats = true
 
-		} else if opt == "-S" {
+		case "-S", "-F":
 			// No-op pass-through for backward compatibility with Miller 5
 
-		} else if opt == "-F" {
-			// No-op pass-through for backward compatibility with Miller 5
-
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verbNameStats1, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/stats2.go
+++ b/pkg/transformers/stats2.go
@@ -87,47 +87,48 @@ func transformerStats2ParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerStats2Usage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-a" {
+		case "-a":
 			accumulatorNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			valueFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNameList, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-v" {
+		case "-v":
 			doVerbose = true
 
-		} else if opt == "-s" {
+		case "-s":
 			doIterativeStats = true
 
-		} else if opt == "--fit" {
+		case "--fit":
 			doHoldAndFit = true
 
-		} else if opt == "-S" {
+		case "-S":
 			// No-op pass-through for backward compatibility with Miller 5
 
-		} else if opt == "-F" {
+		case "-F":
 			// The -F flag isn't used for stats2: all arithmetic here is
 			// floating-point. Yet it is supported for step and stats1 for all
 			// applicable stats1/step accumulators, so we accept here as well
 			// for all applicable stats2 accumulators (i.e. none of them).
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/step.go
+++ b/pkg/transformers/step.go
@@ -166,11 +166,12 @@ func transformerStepParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerStepUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-a" {
+		case "-a":
 			// Let them do '-a delta -a rsum' or '-a delta,rsum'
 			stepperNames, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -185,7 +186,7 @@ func transformerStepParseCLI(
 				stepperInputs = append(stepperInputs, stepperInput)
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			// Let them do '-f x -f y' or '-f x,y'
 			arr, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -193,7 +194,7 @@ func transformerStepParseCLI(
 			}
 			valueFieldNames = append(valueFieldNames, arr...)
 
-		} else if opt == "-g" {
+		case "-g":
 			// Let them do '-g a -g b' or '-g a,b'
 			arr, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -201,7 +202,7 @@ func transformerStepParseCLI(
 			}
 			groupByFieldNames = append(groupByFieldNames, arr...)
 
-		} else if opt == "-d" {
+		case "-d":
 			// Let them do '-d 0.8 -d 0.9' or '-d 0.8,0.9'
 			arr, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -209,7 +210,7 @@ func transformerStepParseCLI(
 			}
 			stringAlphas = append(stringAlphas, arr...)
 
-		} else if opt == "-o" {
+		case "-o":
 			// Let them do '-o fast -o slow' or '-o fast,slow'
 			arr, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
@@ -217,11 +218,11 @@ func transformerStepParseCLI(
 			}
 			ewmaSuffixes = append(ewmaSuffixes, arr...)
 
-		} else if opt == "-F" {
+		case "-F":
 			// As of Miller 6 this happens automatically, but the flag is accepted
 			// as a no-op for backward compatibility with Miller 5 and below.
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/subs.go
+++ b/pkg/transformers/subs.go
@@ -165,25 +165,26 @@ func transformerSubsParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			usageFunc(os.Stdout)
 			os.Exit(0)
 
-		} else if opt == "-a" {
+		case "-a":
 			doAllFieldNames = true
 			doRegexes = false
 			fieldNames = nil
 
-		} else if opt == "-r" {
+		case "-r":
 			doRegexes = true
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			doAllFieldNames = false
-		} else {
+		default:
 			usageFunc(os.Stderr)
 			os.Exit(1)
 		}

--- a/pkg/transformers/summary.go
+++ b/pkg/transformers/summary.go
@@ -146,14 +146,15 @@ func transformerSummaryParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSummaryUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "--all" {
+		case "--all":
 			summarizerNames = allSummarizerNamesList
 
-		} else if opt == "-a" {
+		case "-a":
 			summarizerNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -164,7 +165,7 @@ func transformerSummaryParseCLI(
 				}
 			}
 
-		} else if opt == "-x" {
+		case "-x":
 			excludeSummarizerNames, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -187,10 +188,10 @@ func transformerSummaryParseCLI(
 				}
 			}
 
-		} else if opt == "--transpose" {
+		case "--transpose":
 			transposeOutput = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -363,11 +364,12 @@ func (tr *TransformerSummary) emit(
 		}
 
 		for _, info := range allSummarizerInfos {
-			if info.stype == stAccumulator {
+			switch info.stype {
+			case stAccumulator:
 				if tr.summarizerNames[info.name] {
 					newrec.PutCopy(info.name, fieldSummary.accumulators[info.name].Emit())
 				}
-			} else if info.stype == stPercentile {
+			case stPercentile:
 				if tr.summarizerNames[info.name] {
 					newrec.PutCopy(info.name, fieldSummary.percentileKeeper.EmitNamed(info.name))
 				}
@@ -405,9 +407,10 @@ func (tr *TransformerSummary) emitTransposed(
 	}
 
 	for _, info := range allSummarizerInfos {
-		if info.stype == stAccumulator {
+		switch info.stype {
+		case stAccumulator:
 			tr.maybeEmitAccumulatorTransposed(oracs, octx, info.name)
-		} else if info.stype == stPercentile {
+		case stPercentile:
 			tr.maybeEmitPercentileNameTransposed(oracs, octx, info.name)
 		}
 	}

--- a/pkg/transformers/surv.go
+++ b/pkg/transformers/surv.go
@@ -46,30 +46,32 @@ func transformerSurvParseCLI(
 
 	var durationField, statusField string
 
+loop:
 	for argi < argc {
 		opt := args[argi]
 		if !strings.HasPrefix(opt, "-") {
 			break
 		}
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerSurvUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
-		} else if opt == "-d" {
+		case "-d":
 			if argi+1 >= argc {
 				return nil, cli.VerbErrorf(verb, "-d requires an argument")
 			}
 			argi++
 			durationField = args[argi]
 			argi++
-		} else if opt == "-s" {
+		case "-s":
 			if argi+1 >= argc {
 				return nil, cli.VerbErrorf(verb, "-s requires an argument")
 			}
 			argi++
 			statusField = args[argi]
 			argi++
-		} else {
-			break
+		default:
+			break loop
 		}
 	}
 	*pargi = argi

--- a/pkg/transformers/tail.go
+++ b/pkg/transformers/tail.go
@@ -61,11 +61,12 @@ func transformerTailParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerTailUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			if argi < argc && strings.HasPrefix(args[argi], "+") {
 				fromStart = true
 			}
@@ -75,14 +76,14 @@ func transformerTailParseCLI(
 			}
 			tailCount = n
 
-		} else if opt == "-g" {
+		case "-g":
 			names, err := cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			groupByFieldNames = names
 
-		} else {
+		default:
 			transformerTailUsage(os.Stderr)
 			return nil, fmt.Errorf("%s %s: option \"%s\" not recognized", "mlr", verb, opt)
 		}

--- a/pkg/transformers/tee.go
+++ b/pkg/transformers/tee.go
@@ -70,19 +70,20 @@ func transformerTeeParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerTeeUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-a" {
+		case "-a":
 			appending = true
 			piping = false
 
-		} else if opt == "-p" {
+		case "-p":
 			appending = false
 			piping = true
 
-		} else {
+		default:
 			// This is inelegant. For error-proofing we advance argi already in our
 			// loop (so individual if-statements don't need to). However,
 			// ParseWriterOptions expects it unadvanced.

--- a/pkg/transformers/template.go
+++ b/pkg/transformers/template.go
@@ -65,17 +65,18 @@ func transformerTemplateParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerTemplateUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-t" {
+		case "-t":
 			templateFileName, err := cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
@@ -86,13 +87,13 @@ func transformerTemplateParseCLI(
 			}
 			fieldNames = temp
 
-		} else if opt == "--fill-with" {
+		case "--fill-with":
 			fillWith, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/top.go
+++ b/pkg/transformers/top.go
@@ -78,40 +78,41 @@ func transformerTopParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerTopUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-n" {
+		case "-n":
 			topCount, err = cli.VerbGetIntArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-f" {
+		case "-f":
 			valueFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-g" {
+		case "-g":
 			groupByFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt == "-a" {
+		case "-a":
 			showFullRecords = true
-		} else if opt == "--max" {
+		case "--max":
 			doMax = true
-		} else if opt == "--min" {
+		case "--min":
 			doMax = false
-		} else if opt == "-F" {
+		case "-F":
 			// Ignored in Miller 6; allowed for command-line backward compatibility
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/unflatten.go
+++ b/pkg/transformers/unflatten.go
@@ -60,23 +60,24 @@ func transformerUnflattenParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerUnflattenUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-s" {
+		case "-s":
 			oFlatSep, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/uniq.go
+++ b/pkg/transformers/uniq.go
@@ -82,36 +82,37 @@ func transformerCountDistinctParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerCountDistinctUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-g" || opt == "-f" {
+		case "-g", "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-x" {
+		case "-x":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			invertFieldNames = true
 
-		} else if opt == "-n" {
+		case "-n":
 			showNumDistinctOnly = true
 
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-u" {
+		case "-u":
 			doLashed = false
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -200,39 +201,40 @@ func transformerUniqParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerUniqUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-g" || opt == "-f" {
+		case "-g", "-f":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-x" {
+		case "-x":
 			fieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 			invertFieldNames = true
 
-		} else if opt == "-c" {
+		case "-c":
 			showCounts = true
 
-		} else if opt == "-n" {
+		case "-n":
 			showNumDistinctOnly = true
 
-		} else if opt == "-o" {
+		case "-o":
 			outputFieldName, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-a" {
+		case "-a":
 			uniqifyEntireRecords = true
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/unspace.go
+++ b/pkg/transformers/unspace.go
@@ -58,23 +58,24 @@ func transformerUnspaceParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerUnspaceUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "-f" {
+		case "-f":
 			filler, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-k" {
+		case "-k":
 			which = "keys_only"
 
-		} else if opt == "-v" {
+		case "-v":
 			which = "values_only"
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}
@@ -102,11 +103,12 @@ func NewTransformerUnspace(
 	which string,
 ) (*TransformerUnspace, error) {
 	tr := &TransformerUnspace{filler: filler}
-	if which == "keys_only" {
+	switch which {
+	case "keys_only":
 		tr.recordTransformerFunc = tr.transformKeysOnly
-	} else if which == "values_only" {
+	case "values_only":
 		tr.recordTransformerFunc = tr.transformValuesOnly
-	} else {
+	default:
 		tr.recordTransformerFunc = tr.transformKeysAndValues
 	}
 	return tr, nil

--- a/pkg/transformers/unsparsify.go
+++ b/pkg/transformers/unsparsify.go
@@ -71,23 +71,24 @@ func transformerUnsparsifyParseCLI(
 		}
 		argi++
 
-		if opt == "-h" || opt == "--help" {
+		switch opt {
+		case "-h", "--help":
 			transformerUnsparsifyUsage(os.Stdout)
 			return nil, cli.ErrHelpRequested
 
-		} else if opt == "--fill-with" {
+		case "--fill-with":
 			fillerString, err = cli.VerbGetStringArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else if opt == "-f" {
+		case "-f":
 			specifiedFieldNames, err = cli.VerbGetStringArrayArg(verb, opt, args, &argi, argc)
 			if err != nil {
 				return nil, err
 			}
 
-		} else {
+		default:
 			return nil, cli.VerbErrorf(verb, "option \"%s\" not recognized", opt)
 		}
 	}

--- a/pkg/transformers/utils/percentile_keeper.go
+++ b/pkg/transformers/utils/percentile_keeper.go
@@ -84,18 +84,19 @@ func (keeper *PercentileKeeper) EmitLinearlyInterpolated(percentile float64) *ml
 
 // TODO: COMMENT
 func (keeper *PercentileKeeper) EmitNamed(name string) *mlrval.Mlrval {
-	if name == "min" {
+	switch name {
+	case "min":
 		return keeper.EmitNonInterpolated(0.0)
-	} else if name == "p25" {
+	case "p25":
 		return keeper.EmitNonInterpolated(25.0)
-	} else if name == "median" {
+	case "median":
 		return keeper.EmitNonInterpolated(50.0)
-	} else if name == "p75" {
+	case "p75":
 		return keeper.EmitNonInterpolated(75.0)
-	} else if name == "max" {
+	case "max":
 		return keeper.EmitNonInterpolated(100.0)
 
-	} else if name == "iqr" {
+	case "iqr":
 		p25 := keeper.EmitNonInterpolated(25.0)
 		p75 := keeper.EmitNonInterpolated(75.0)
 		if p25.IsNumeric() && p75.IsNumeric() {
@@ -103,7 +104,7 @@ func (keeper *PercentileKeeper) EmitNamed(name string) *mlrval.Mlrval {
 		}
 		return mlrval.VOID
 
-	} else if name == "lof" {
+	case "lof":
 		p25 := keeper.EmitNonInterpolated(25.0)
 		iqr := keeper.EmitNamed("iqr")
 		if p25.IsNumeric() && iqr.IsNumeric() {
@@ -111,7 +112,7 @@ func (keeper *PercentileKeeper) EmitNamed(name string) *mlrval.Mlrval {
 		}
 		return mlrval.VOID
 
-	} else if name == "lif" {
+	case "lif":
 		p25 := keeper.EmitNonInterpolated(25.0)
 		iqr := keeper.EmitNamed("iqr")
 		if p25.IsNumeric() && iqr.IsNumeric() {
@@ -119,7 +120,7 @@ func (keeper *PercentileKeeper) EmitNamed(name string) *mlrval.Mlrval {
 		}
 		return mlrval.VOID
 
-	} else if name == "uif" {
+	case "uif":
 		p75 := keeper.EmitNonInterpolated(75.0)
 		iqr := keeper.EmitNamed("iqr")
 		if p75.IsNumeric() && iqr.IsNumeric() {
@@ -127,7 +128,7 @@ func (keeper *PercentileKeeper) EmitNamed(name string) *mlrval.Mlrval {
 		}
 		return mlrval.VOID
 
-	} else if name == "uof" {
+	case "uof":
 		p75 := keeper.EmitNonInterpolated(75.0)
 		iqr := keeper.EmitNamed("iqr")
 		if p75.IsNumeric() && iqr.IsNumeric() {

--- a/pkg/transformers/utils/stats2_accumulators.go
+++ b/pkg/transformers/utils/stats2_accumulators.go
@@ -482,7 +482,8 @@ func (acc *Stats2CorrCovAccumulator) Populate(
 	outrec *mlrval.Mlrmap,
 ) {
 
-	if acc.doWhich == DO_COVX {
+	switch acc.doWhich {
+	case DO_COVX:
 		key00 := acc.covx00OutputFieldName
 		key01 := acc.covx01OutputFieldName
 		key10 := acc.covx10OutputFieldName
@@ -507,7 +508,7 @@ func (acc *Stats2CorrCovAccumulator) Populate(
 			outrec.PutReference(key11, mlrval.FromFloat(Q[1][1]))
 		}
 
-	} else if acc.doWhich == DO_LINREG_PCA {
+	case DO_LINREG_PCA:
 		keym := acc.pca_mOutputFieldName
 		keyb := acc.pca_bOutputFieldName
 		keyn := acc.pca_nOutputFieldName
@@ -565,7 +566,7 @@ func (acc *Stats2CorrCovAccumulator) Populate(
 				outrec.PutReference(keyv22, mlrval.FromFloat(v2[1]))
 			}
 		}
-	} else {
+	default:
 		key := acc.corrOutputFieldName
 		if acc.doWhich == DO_COV {
 			key = acc.covOutputFieldName


### PR DESCRIPTION
Context: #2109

## Summary

- Replaces 100+ `if/else-if` chains on a single variable with tagged `switch` statements across 72 files
- The bulk are transformer option-parsing loops (`switch opt { case "-f": ... }`), plus value-dispatch sites in `mlrval`, `dsl/cst`, `repl`, `lib`, `auxents`, and `bifs`
- One case (`surv.go`) required a labeled `break loop` to preserve the loop-exit behavior of the original `else { break }`
- Fixes all `staticcheck QF1003` findings; build clean, unit tests pass

## Test plan

- [x] `make build` succeeds
- [x] `make unit-test` all pass
- [x] `golangci-lint run ./cmd/mlr ./pkg/...` reports zero QF1003 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)