### PR TITLE
Update snapcore/action-build to node24 SHA, drop unused matrix

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -9,14 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x]    
 
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - uses: snapcore/action-build@v1
+      - uses: snapcore/action-build@edf78ca622b1eb99b69f09420bb19f77e4f84ac1
         id: build
         
       - uses: diddlesnaps/snapcraft-review-action@v1

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
+      # Context for pin: https://github.com/johnkerl/miller/pull/2119
       - uses: snapcore/action-build@edf78ca622b1eb99b69f09420bb19f77e4f84ac1
         id: build
         


### PR DESCRIPTION
## What and why

snapcore/action-build@v1 targets Node.js 20, which is now deprecated on GitHub Actions runners and produces warnings (runners force Node.js 24). This was surfaced in our CI:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: snapcore/action-build@v1.

See: https://github.com/johnkerl/miller/actions/runs/28449033140

Upstream has an open PR to fix this (https://github.com/snapcore/action-build/pull/1 -- "chore: update to node24"), but it has been stale with no activity. Rather than wait, we pin directly to that PR's HEAD SHA (edf78ca) which uses node24 in its action.yml.

Once upstream merges and cuts a new tag, we can update back to a named version (e.g. @v2 or @v1.4.0).

Also removes the strategy.matrix.node-version: [20.x] block, which was dead config -- there was no actions/setup-node step in the job that would have used it.

## Testing

The snap build CI itself will validate this on the PR.