### PR TITLE
Guard against release tag cut before version-bump commit lands

### DIFF
--- a/docs/src/how-to-release.md.in
+++ b/docs/src/how-to-release.md.in
@@ -14,7 +14,11 @@ Much of the mechanical work below is automated by `tools/release.sh`, which has 
 
 `rpmbuild` is mandatory for `pre-release` (the SRPM is a required release artifact); `rpmlint` is optional and is run only if installed. The ReadTheDocs admin steps and the flip from pre-release to public remain manual. Each subcommand is idempotent, so a partial run can be re-invoked safely.
 
+**If you are running `pre-release`, do not also do the version-bump / tarball / SRPM / GitHub-release-and-tag steps below by hand first.** `pre-release` does all of that itself, in the order that makes the tag land correctly (version bump commit pushed *before* the tag is cut). Manually creating the GitHub release/tag before the version-bump commit is pushed reproduces the exact bug called out under "Create the GitHub release tag" below -- the tag gets pinned to whatever commit `main` was at that moment, forever, even though it looks like `--target main`. Worse, `pre-release`'s idempotency check only confirms *a* release exists for the tag; it does not verify the tagged commit actually contains the version bump, so a subsequent `pre-release` run will not notice or fix a bad tag -- it will just keep uploading assets to it. If this happens, the only fix is to delete the GitHub release and the tag (`git push --delete origin vX.Y.Z`, plus the local tag) and recreate it pointing at the correct commit.
+
 ## Manual steps
+
+These are the individual steps `pre-release`/`docs`/`afterwork` automate, kept here as a reference for what each phase actually does (and as a fallback if you need to run a step by hand). Do not run these separately from the script for a release the script is also handling.
 
 * Update version found in `mlr --version` and `man mlr`:
 
@@ -38,6 +42,7 @@ Much of the mechanical work below is automated by `tools/release.sh`, which has 
 
 * Create the GitHub release tag:
 
+    * If `pre-release` is handling this release, skip this step -- do not create the release/tag by hand first. See the warning above.
     * Don't forget the `v` in `v6.3.0`
     * Write the release notes -- save as a pre-release until below
         * Be sure the commit being used is the (non-`main`) PR commit containing the new version, or, `main` after that PR is merged back to `main`. (Otherwise, the release will be tagging the commit _before_ the changes, and `mlr version` will not show the new release number.)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -127,6 +127,32 @@ push_if_needed() {
   run_cmd git push "$@" origin "$branch"
 }
 
+# verify_release_tag_commit guards against the classic ordering bug: a
+# release/tag for $TAG created (by hand, or by anything other than this
+# script's own Phase 4) BEFORE the version-bump commit was pushed. Git tags
+# don't retroactively follow branch movement, so once cut against the wrong
+# commit they stay wrong -- and a same-tag `gh release view` success on a
+# resumed run looks identical whether the tag is right or wrong. This checks
+# the actual tagged commit's pkg/version/version.go, not just tag existence.
+verify_release_tag_commit() {
+  local tag="$1"
+  # Read-only (fetch/rev-parse/show), so this runs even under --dry-run --
+  # skipping it there would hide exactly the bug it exists to catch.
+  git fetch --tags origin >/dev/null 2>&1 || true
+  if ! git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+    # Not fetchable yet (e.g. propagation lag right after creation); nothing
+    # to check against.
+    return 0
+  fi
+  local tagged_version
+  tagged_version="$(git show "${tag}:pkg/version/version.go" 2>/dev/null \
+    | awk -F'"' '/^var[[:space:]]+STRING/ { print $2; exit }')"
+  if [ "$tagged_version" != "$VERSION" ]; then
+    die "tag '$tag' points at a commit where pkg/version/version.go reports '$tagged_version', not '$VERSION' -- it was likely created before the version-bump commit landed (see docs/src/how-to-release.md.in's warning on tag ordering). Delete the release and the tag (locally and on origin) and recreate it pointing at the correct commit before continuing."
+  fi
+  note "verified tag '$tag' points at a commit with version.go == '$VERSION'"
+}
+
 # ============================================================================
 # Argument parsing
 # ============================================================================
@@ -558,6 +584,8 @@ phase_4_github_release() {
       --title "Miller $VERSION" \
       --notes-file "$NOTES_FILE"
   fi
+
+  verify_release_tag_commit "$TAG"
 
   banner "PHASE 4: upload assets"
   # --clobber so that a resumed run can re-upload a replaced artifact.


### PR DESCRIPTION
## Summary

While debugging why a downloaded `v6.20.0` pre-release binary reported `mlr version 6.19.0-dev`, traced it to a real, currently-live bug: the `v6.20.0` git tag is pinned to commit `a9de5824b` (the commit immediately before `9a1c49be7 "Prepare 6.20.0 release"` landed). Confirmed via:

```
git rev-parse v6.20.0                              -> a9de5824b
git show v6.20.0:pkg/version/version.go             -> STRING = "6.19.0-dev"
gh release view v6.20.0 --json createdAt            -> 2026-07-04T00:31:20Z
git log -1 --format=%cI a9de5824b                   -> 2026-07-03T20:31:20-04:00 (same instant)
git log -1 --format=%cI 9a1c49be7 "Prepare 6.20.0"  -> 2026-07-03T20:39:31-04:00 (8 min later)
```

The release/tag was created at the exact instant `a9de5824b` landed on `main` -- 8 minutes *before* the version-bump commit was even made, let alone pushed. `targetCommitish: "main"` in the release metadata is misleading: GitHub cuts the actual tag against whatever `main` points to *at creation time*; it does not track the branch forward afterward. Once cut, the tag is permanent.

`docs/src/how-to-release.md.in` already has a warning about this exact failure mode under "Create the GitHub release tag", but:
1. It presents the manual tag-creation step as parallel/optional reading alongside `tools/release.sh`, without saying "skip this entirely if you're using `pre-release`" -- so it's easy to do it by hand (or via some other automation) right after a PR merges, before the version bump ever runs.
2. Once a mis-tagged release exists, `tools/release.sh` Phase 4 treats `gh release view $TAG` succeeding as fully idempotent ("already exists, just upload assets") -- it never checks that the tagged commit actually contains the version bump. So a `pre-release` re-run can't detect or fix this; it just keeps uploading a tarball to a release permanently pinned to the wrong commit, which is what I was about to do while helping debug the earlier rpmbuild issue.

## Changes

- `docs/src/how-to-release.md.in`: explicit warning that running `pre-release` means skipping the manual version-bump/tarball/SRPM/tag-creation steps entirely, with a pointer to why (this exact bug) and how to recover if it happens anyway.
- `tools/release.sh`: new `verify_release_tag_commit()`, called in Phase 4 after the create-or-reuse branch (both paths, not just resume) -- reads the actual tagged commit's `pkg/version/version.go` and dies loudly if it doesn't match `$VERSION`, instead of silently treating tag-existence as tag-correctness. Runs even under `--dry-run` since it's read-only (fetch/rev-parse/show) -- skipping it there would hide the exact bug it exists to catch.

## Test plan
- [x] `bash -n tools/release.sh` -- syntax check
- [x] Isolated test of `verify_release_tag_commit` against the real, currently-broken `v6.20.0` tag: correctly dies with `tagged=6.19.0-dev expected=6.20.0`
- [x] Isolated test with the correct expected version (`6.19.0-dev`): passes
- [x] Full `pre-release --dry-run` run against this repo (with `--branch` matching the working branch): correctly stops the run at Phase 4 with the exact diagnosis, reproducing the real bug end to end

## Note
This does not fix the already-broken `v6.20.0` release -- that requires deleting and recreating the tag/release against the correct commit, which is being handled separately with explicit confirmation since it's a destructive, shared-state operation against the live GitHub repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)