### PR TITLE
`mlr uniq`: document that `-g`/`-f` output-field order follows the command line

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -2443,7 +2443,9 @@ This is simply a copy of what you should see on running `man mlr` at a command p
    1muniq0m
        Usage: mlr uniq [options]
        Prints distinct values for specified field names. With -c, same as
-       count-distinct. For uniq, -f is a synonym for -g.
+       count-distinct. For uniq, -f is a synonym for -g. Output fields are
+       written in the order in which they are named with -g or -f, not in the
+       order in which they appear in the input records.
 
        Options:
        -g {d,e,f} Group-by field names for uniq counts.
@@ -4040,5 +4042,5 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -2422,7 +2422,9 @@
    1muniq0m
        Usage: mlr uniq [options]
        Prints distinct values for specified field names. With -c, same as
-       count-distinct. For uniq, -f is a synonym for -g.
+       count-distinct. For uniq, -f is a synonym for -g. Output fields are
+       written in the order in which they are named with -g or -f, not in the
+       order in which they appear in the input records.
 
        Options:
        -g {d,e,f} Group-by field names for uniq counts.
@@ -4019,4 +4021,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)

--- a/docs/src/reference-verbs.md
+++ b/docs/src/reference-verbs.md
@@ -4414,7 +4414,9 @@ Options:
 <pre class="pre-non-highlight-in-pair">
 Usage: mlr uniq [options]
 Prints distinct values for specified field names. With -c, same as
-count-distinct. For uniq, -f is a synonym for -g.
+count-distinct. For uniq, -f is a synonym for -g. Output fields are
+written in the order in which they are named with -g or -f, not in the
+order in which they appear in the input records.
 
 Options:
 -g {d,e,f} Group-by field names for uniq counts.

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -2422,7 +2422,9 @@
    1muniq0m
        Usage: mlr uniq [options]
        Prints distinct values for specified field names. With -c, same as
-       count-distinct. For uniq, -f is a synonym for -g.
+       count-distinct. For uniq, -f is a synonym for -g. Output fields are
+       written in the order in which they are named with -g or -f, not in the
+       order in which they appear in the input records.
 
        Options:
        -g {d,e,f} Group-by field names for uniq counts.
@@ -4019,4 +4021,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2026-07-04
+.\"      Date: 2026-07-05
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2026-07-04" "\ \&" "\ \&"
+.TH "MILLER" "1" "2026-07-05" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3024,7 +3024,9 @@ Options:
 .nf
 Usage: mlr uniq [options]
 Prints distinct values for specified field names. With -c, same as
-count-distinct. For uniq, -f is a synonym for -g.
+count-distinct. For uniq, -f is a synonym for -g. Output fields are
+written in the order in which they are named with -g or -f, not in the
+order in which they appear in the input records.
 
 Options:
 -g {d,e,f} Group-by field names for uniq counts.

--- a/pkg/transformers/uniq.go
+++ b/pkg/transformers/uniq.go
@@ -166,7 +166,9 @@ func transformerUniqUsage(
 	verb := verbNameUniq
 	fmt.Fprintf(o, "Usage: %s %s [options]\n", argv0, verb)
 	fmt.Fprintf(o, "Prints distinct values for specified field names. With -c, same as\n")
-	fmt.Fprintf(o, "count-distinct. For uniq, -f is a synonym for -g.\n")
+	fmt.Fprintf(o, "count-distinct. For uniq, -f is a synonym for -g. Output fields are\n")
+	fmt.Fprintf(o, "written in the order in which they are named with -g or -f, not in the\n")
+	fmt.Fprintf(o, "order in which they appear in the input records.\n")
 	fmt.Fprintf(o, "\n")
 	WriteVerbOptions(o, uniqOptions)
 }

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -1507,7 +1507,9 @@ Options:
 uniq
 Usage: mlr uniq [options]
 Prints distinct values for specified field names. With -c, same as
-count-distinct. For uniq, -f is a synonym for -g.
+count-distinct. For uniq, -f is a synonym for -g. Output fields are
+written in the order in which they are named with -g or -f, not in the
+order in which they appear in the input records.
 
 Options:
 -g {d,e,f} Group-by field names for uniq counts.


### PR DESCRIPTION
https://github.com/johnkerl/miller/issues/962

As discussed on the issue, `mlr uniq -g <fields>` writes its group-by fields in the order they are named on the command line, not the order in which they appear in the input records (unlike `cut`, which preserves input order unless `-o` is given). This is long-standing behavior shared by many `-g`-taking verbs, so this PR documents it rather than changing output ordering.

Changes:
- `pkg/transformers/uniq.go`: add a note to the `uniq` verb help text that output fields are written in the order named with `-g`/`-f`.
- Regenerated: `test/cases/cli-help/0001/expout`, `man/mlr.1`, `man/manpage.txt`, `docs/src/manpage.txt`, `docs/src/manpage.md`, `docs/src/reference-verbs.md`.

Verified empirically (`uniq -g c,a` on a CSV with fields `a,b,c` outputs `c,a`, also with `-c`/`-n`; `-x` retains input order and is unaffected). `make check` passes (4697/4697 regression cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
