### PR TITLE
Document meaning of hyphenated field-type values in `mlr summary`

### DIFF
--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -2311,7 +2311,7 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        Show summary statistics about the input data.
 
        All summarizers:
-         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
          count           +1 for every instance of the field across all records in the input record stream
          null_count      count of field values either empty string or JSON null
          distinct_count  count of distinct values for the field
@@ -2341,6 +2341,8 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        * min, p25, median, p75, and max work for strings as well as numbers
        * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
        * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+       * A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+         all types encountered are printed, hyphen-joined, in the order first encountered.
 
        Options:
        -a {mean,sum,etc.} Use only the specified summarizers.
@@ -4040,5 +4042,5 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)
 </pre>

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -2290,7 +2290,7 @@
        Show summary statistics about the input data.
 
        All summarizers:
-         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
          count           +1 for every instance of the field across all records in the input record stream
          null_count      count of field values either empty string or JSON null
          distinct_count  count of distinct values for the field
@@ -2320,6 +2320,8 @@
        * min, p25, median, p75, and max work for strings as well as numbers
        * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
        * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+       * A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+         all types encountered are printed, hyphen-joined, in the order first encountered.
 
        Options:
        -a {mean,sum,etc.} Use only the specified summarizers.
@@ -4019,4 +4021,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)

--- a/docs/src/reference-verbs.md
+++ b/docs/src/reference-verbs.md
@@ -4044,7 +4044,7 @@ Usage: mlr summary [options]
 Show summary statistics about the input data.
 
 All summarizers:
-  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
   count           +1 for every instance of the field across all records in the input record stream
   null_count      count of field values either empty string or JSON null
   distinct_count  count of distinct values for the field
@@ -4074,6 +4074,8 @@ Notes:
 * min, p25, median, p75, and max work for strings as well as numbers
 * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
 * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+* A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+  all types encountered are printed, hyphen-joined, in the order first encountered.
 
 Options:
 -a {mean,sum,etc.} Use only the specified summarizers.

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -2290,7 +2290,7 @@
        Show summary statistics about the input data.
 
        All summarizers:
-         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+         field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
          count           +1 for every instance of the field across all records in the input record stream
          null_count      count of field values either empty string or JSON null
          distinct_count  count of distinct values for the field
@@ -2320,6 +2320,8 @@
        * min, p25, median, p75, and max work for strings as well as numbers
        * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
        * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+       * A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+         all types encountered are printed, hyphen-joined, in the order first encountered.
 
        Options:
        -a {mean,sum,etc.} Use only the specified summarizers.
@@ -4019,4 +4021,4 @@
        MIME Type for Comma-Separated Values (CSV) Files, the Miller docsite
        https://miller.readthedocs.io
 
-                                  2026-07-04                         4mMILLER24m(1)
+                                  2026-07-05                         4mMILLER24m(1)

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -2,12 +2,12 @@
 .\"     Title: mlr
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: ./mkman.rb
-.\"      Date: 2026-07-04
+.\"      Date: 2026-07-05
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MILLER" "1" "2026-07-04" "\ \&" "\ \&"
+.TH "MILLER" "1" "2026-07-05" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Portability definitions
 .\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2838,7 +2838,7 @@ Usage: mlr summary [options]
 Show summary statistics about the input data.
 
 All summarizers:
-  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
   count           +1 for every instance of the field across all records in the input record stream
   null_count      count of field values either empty string or JSON null
   distinct_count  count of distinct values for the field
@@ -2868,6 +2868,8 @@ Notes:
 * min, p25, median, p75, and max work for strings as well as numbers
 * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
 * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+* A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+  all types encountered are printed, hyphen-joined, in the order first encountered.
 
 Options:
 -a {mean,sum,etc.} Use only the specified summarizers.

--- a/pkg/transformers/summary.go
+++ b/pkg/transformers/summary.go
@@ -29,7 +29,7 @@ type tSummarizerInfo struct {
 }
 
 var allSummarizerInfos = []tSummarizerInfo{
-	{"field_type", "string, int, etc. -- if a column has mixed types, all encountered types are printed", stFieldType},
+	{"field_type", "string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)", stFieldType},
 
 	{"count", "+1 for every instance of the field across all records in the input record stream", stAccumulator},
 	{"null_count", "count of field values either empty string or JSON null", stAccumulator},
@@ -107,6 +107,8 @@ func transformerSummaryUsage(
 	fmt.Fprintf(o, "* min, p25, median, p75, and max work for strings as well as numbers\n")
 	fmt.Fprintf(o, "* Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.\n")
 	fmt.Fprintf(o, "* If the mode is not unique in the input data, the first-encountered value is reported as the mode.\n")
+	fmt.Fprintf(o, "* A field_type of \"int-string\", \"empty-string\", etc. means the column contains values of mixed types --\n")
+	fmt.Fprintf(o, "  all types encountered are printed, hyphen-joined, in the order first encountered.\n")
 	fmt.Fprintf(o, "\n")
 	WriteVerbOptions(o, summaryOptions)
 }

--- a/test/cases/cli-help/0001/expout
+++ b/test/cases/cli-help/0001/expout
@@ -1366,7 +1366,7 @@ Usage: mlr summary [options]
 Show summary statistics about the input data.
 
 All summarizers:
-  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed
+  field_type      string, int, etc. -- if a column has mixed types, all encountered types are printed (see notes below)
   count           +1 for every instance of the field across all records in the input record stream
   null_count      count of field values either empty string or JSON null
   distinct_count  count of distinct values for the field
@@ -1396,6 +1396,8 @@ Notes:
 * min, p25, median, p75, and max work for strings as well as numbers
 * Distinct-counts are computed on string representations -- so 4.1 and 4.10 are counted as distinct here.
 * If the mode is not unique in the input data, the first-encountered value is reported as the mode.
+* A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types --
+  all types encountered are printed, hyphen-joined, in the order first encountered.
 
 Options:
 -a {mean,sum,etc.} Use only the specified summarizers.


### PR DESCRIPTION
https://github.com/johnkerl/miller/issues/1082

The `summary` verb's `field_type` column can show values like `string-int` or `empty-string`, and issue #1082 asked what these mean. As explained in the issue thread, they indicate a column with values of mixed inferred types: the summarizer tracks every type encountered for the column across all records, and prints them hyphen-joined, in the order first encountered (e.g. a column whose first value infers as string and which later contains ints shows `string-int`; the same data with an int first shows `int-string`).

This PR documents that in the verb's help text:

* The `field_type` summarizer description now points to the notes section.
* A new note reads: `A field_type of "int-string", "empty-string", etc. means the column contains values of mixed types -- all types encountered are printed, hyphen-joined, in the order first encountered.`

Regenerated artifacts: `man/mlr.1`, `man/manpage.txt`, `docs/src/manpage.md`, `docs/src/manpage.txt`, `docs/src/reference-verbs.md`, and `test/cases/cli-help/0001/expout`.

Verified with `make check` (4697 cases pass) and empirically:

```
$ printf 'code,name,note\n01,alpha,\n2,beta,x\n03,gamma,\n' | mlr --icsv --opprint summary -a field_type,count,null_count
field_name field_type   count null_count
code       string-int   3     0
name       string       3     0
note       empty-string 3     2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)