### PR TITLE
Add workflow to auto-publish releases to WinGet (#1459)

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,79 @@
+# Automatically publishes new Miller releases to the Windows Package Manager
+# (WinGet) community repository, updating the existing Miller.Miller package:
+# https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Miller/Miller
+#
+# See https://github.com/johnkerl/miller/issues/1459.
+#
+# One-time setup required before this workflow can succeed:
+#
+# 1. Fork https://github.com/microsoft/winget-pkgs under the same account as
+#    this repository (i.e. github.com/johnkerl/winget-pkgs). The action pushes
+#    manifest branches to that fork and opens PRs against microsoft/winget-pkgs
+#    from it.
+#
+# 2. Create a *classic* GitHub Personal Access Token with the `public_repo`
+#    scope (fine-grained PATs are not supported by the action; see
+#    https://github.com/vedantmgoyal9/winget-releaser/issues/172), and add it
+#    to this repository as an Actions secret named WINGET_GH_TOKEN.
+#
+# Triggers:
+#
+# * release/published: fires when a release is published by a user or by a
+#   workflow authenticated with a PAT. NOTE: releases created with the default
+#   GITHUB_TOKEN (as release.yml/goreleaser does today) do NOT emit events
+#   that trigger other workflows, so this trigger alone would never fire for
+#   Miller's current release process -- hence the workflow_run trigger below.
+# * workflow_run: fires when the "Release for GitHub" workflow (release.yml)
+#   completes successfully on a v* tag. This is what makes publishing
+#   automatic with the current goreleaser setup. If release.yml is ever
+#   changed to create releases with a PAT, remove this trigger to avoid
+#   double-publishing.
+# * workflow_dispatch: manual runs, e.g. to backfill an already-published
+#   release by tag.
+#
+# Under the hood the winget-releaser action uses komac
+# (https://github.com/russellbanks/Komac) to generate the version/installer/
+# locale manifests from the release's Windows zip assets and submit the PR.
+
+name: Publish to WinGet
+on:
+  release:
+    types: [published]
+  workflow_run:
+    workflows: ["Release for GitHub"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to publish to WinGet (e.g. v6.20.2)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # For workflow_run events, only proceed if the release workflow succeeded
+    # and actually ran on a version tag (release.yml can also be run manually
+    # on a branch, in which case head_branch is the branch name).
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    steps:
+      - name: Publish Miller.Miller to WinGet
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Miller.Miller
+          # Matches the Windows zip assets produced by .goreleaser.yml, e.g.
+          # miller-6.20.2-windows-386.zip / -amd64.zip / -arm64.zip.
+          # Note: existing Miller.Miller manifests cover x86 and x64 only;
+          # komac detects arm64 from the asset URL and adds it as a new
+          # architecture. If that ever causes trouble, narrow this regex to
+          # '-windows-(386|amd64)\.zip$'.
+          installers-regex: '-windows-(386|amd64|arm64)\.zip$'
+          # The tag comes from whichever event fired: the dispatch input, the
+          # published release's tag, or the tag the release workflow ran on.
+          # The package version is derived from the tag with the leading "v"
+          # stripped (v6.20.2 -> 6.20.2).
+          release-tag: ${{ github.event.inputs.release-tag || github.event.release.tag_name || github.event.workflow_run.head_branch }}
+          token: ${{ secrets.WINGET_GH_TOKEN }}


### PR DESCRIPTION
https://github.com/johnkerl/miller/issues/1459

Adds `.github/workflows/winget-publish.yml`, which automatically submits a version-update PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) for the existing [`Miller.Miller`](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Miller/Miller) package after each Miller release, using [vedantmgoyal9/winget-releaser](https://github.com/vedantmgoyal9/winget-releaser)`@v2` (which drives [komac](https://github.com/russellbanks/Komac) under the hood). WinGet currently lags well behind: the newest `Miller.Miller` manifest in winget-pkgs is 6.13.0 vs. the current 6.20.2 release.

## Required one-time setup (repo owner)

The workflow cannot succeed until these two things exist — this is the part only you can do, per the issue ("since this requires a token to be set up this isn't really something which can be easily contributed"):

1. **Fork microsoft/winget-pkgs** under your account, i.e. create `johnkerl/winget-pkgs` (no fork exists there today). The action pushes manifest branches to that fork and opens PRs against `microsoft/winget-pkgs` from it.
2. **Create a _classic_ PAT with the `public_repo` scope** (fine-grained PATs are not supported by the action — [winget-releaser#172](https://github.com/vedantmgoyal9/winget-releaser/issues/172)) and add it as an Actions secret named **`WINGET_GH_TOKEN`**: repo Settings → Secrets and variables → Actions → New repository secret.

## Design notes

- **Triggers.** `release: [published]` plus a `workflow_run` trigger on successful completion of the existing "Release for GitHub" workflow on `v*` tags, plus `workflow_dispatch` (tag input) for manual/backfill runs. The `workflow_run` trigger is load-bearing: `release.yml` creates releases via goreleaser using the default `GITHUB_TOKEN`, and events generated by the default token [do not trigger other workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), so `release: published` alone would never fire with the current release process. (If `release.yml` ever switches to a PAT, the `workflow_run` trigger should be removed to avoid double-publishing.)
- **Assets.** `installers-regex: '-windows-(386|amd64|arm64)\.zip$'` matches the goreleaser-produced Windows zips (verified against the v6.20.2 release assets: `miller-6.20.2-windows-{386,amd64,arm64}.zip`) and nothing else. Existing winget manifests cover x86/x64 only; komac detects arm64 from the new asset and adds it as a new architecture. If that misbehaves, the regex can be narrowed to `(386|amd64)` — noted in a comment in the workflow.
- **Versioning.** The action derives `PackageVersion` from the tag with the leading `v` stripped (`v6.20.2` → `6.20.2`), matching existing manifests.
- **Alternative:** goreleaser has [native winget support](https://goreleaser.com/customization/winget/) (a `winget:` section in `.goreleaser.yml`), which would also work and keeps everything in one tool; it likewise needs a PAT + fork. I implemented the dedicated-action route since it's the one proposed in the issue and doesn't touch the existing goreleaser config, but happy to switch if you prefer.

## What is and isn't verified

- Verified: YAML parses; the installers regex matched exactly the three Windows zips (and no other assets) of the v6.20.2 release; action name/major version (`vedantmgoyal9/winget-releaser@v2` — note the account rename from `vedantmgoyal2009`) and its input names checked against the action's `action.yml` at tag `v2`; `Miller.Miller` is the correct package identifier in winget-pkgs.
- Not verified: an end-to-end run. A release-triggered workflow can't be exercised from a PR branch, and it will fail until the fork + `WINGET_GH_TOKEN` secret exist. After merging and completing setup, it can be smoke-tested via the Actions tab → "Publish to WinGet" → Run workflow with `v6.20.2` to backfill winget to the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
