### PR TITLE
Docs: NIDX/DKVP split on separators regardless of double quotes (#369)

### DIFF
--- a/docs/src/data/semicolon-quoted.txt
+++ b/docs/src/data/semicolon-quoted.txt
@@ -1,0 +1,2 @@
+a;b
+"text; text";"more text"

--- a/docs/src/file-formats.md
+++ b/docs/src/file-formats.md
@@ -836,6 +836,41 @@ the dawn's
 light
 </pre>
 
+Note that NIDX and DKVP split each line on the field separator without regard to double quotes: a separator inside a double-quoted string still starts a new field.
+
+<pre class="pre-highlight-in-pair">
+<b>cat data/semicolon-quoted.txt</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+a;b
+"text; text";"more text"
+</pre>
+
+<pre class="pre-highlight-in-pair">
+<b>mlr --inidx --ifs semicolon --oxtab cat data/semicolon-quoted.txt</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+1 a
+2 b
+
+1 "text
+2  text"
+3 "more text"
+</pre>
+
+If your data uses RFC-4180-style double-quoting to protect separators inside field values, use CSV format with `--ifs` set to your separator -- along with `--implicit-csv-header` if the file has no header line:
+
+<pre class="pre-highlight-in-pair">
+<b>mlr --icsv --ifs semicolon --implicit-csv-header --oxtab cat data/semicolon-quoted.txt</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+1 a
+2 b
+
+1 text; text
+2 more text
+</pre>
+
 ## DCF (Debian control file)
 
 <pre class="pre-highlight-in-pair">

--- a/docs/src/file-formats.md.in
+++ b/docs/src/file-formats.md.in
@@ -409,6 +409,22 @@ GENMD-RUN-COMMAND
 mlr --nidx --fs ' ' --repifs cut -f 2,3 data/mydata.txt
 GENMD-EOF
 
+Note that NIDX and DKVP split each line on the field separator without regard to double quotes: a separator inside a double-quoted string still starts a new field.
+
+GENMD-RUN-COMMAND
+cat data/semicolon-quoted.txt
+GENMD-EOF
+
+GENMD-RUN-COMMAND
+mlr --inidx --ifs semicolon --oxtab cat data/semicolon-quoted.txt
+GENMD-EOF
+
+If your data uses RFC-4180-style double-quoting to protect separators inside field values, use CSV format with `--ifs` set to your separator -- along with `--implicit-csv-header` if the file has no header line:
+
+GENMD-RUN-COMMAND
+mlr --icsv --ifs semicolon --implicit-csv-header --oxtab cat data/semicolon-quoted.txt
+GENMD-EOF
+
 ## DCF (Debian control file)
 
 GENMD-RUN-COMMAND


### PR DESCRIPTION
https://github.com/johnkerl/miller/issues/369

The issue reported that `mlr --inidx --fs semicolon` treats a semicolon inside a double-quoted field as a field separator. That is by design for NIDX/DKVP, which split lines naively on the separator; the issue was left open (labeled needs-documentation) pending an FAQ-style writeup.

Verified with current Go Miller:

- `--inidx --ifs semicolon` still splits inside quotes, as in the original report (expected for this format).
- The recommended approach works correctly: `mlr --icsv --ifs semicolon --implicit-csv-header` respects RFC-4180 quoting with a custom separator, yielding `text; text` / `more text` as single fields.

This PR adds a short note with a worked example to the NIDX section of the file-formats page: NIDX/DKVP do not respect double quotes, and quoted data with a non-comma separator should be read as CSV with `--ifs`, plus `--implicit-csv-header` for headerless files. Includes a small sample data file `docs/src/data/semicolon-quoted.txt` and regenerated `file-formats.md`.

Docs only; no code changes. `make check` passes (4730 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)