### PR TITLE
Docs: a thousands-separator recipe for the DSL (#382)

### DIFF
--- a/docs/src/reference-main-number-formatting.md
+++ b/docs/src/reference-main-number-formatting.md
@@ -84,3 +84,42 @@ x=0xffff,y=0xff,z=16711425
 <pre class="pre-non-highlight-in-pair">
 x=0xffff,y=0xff,z=0xfeff01
 </pre>
+
+## Thousands separators
+
+Some tools accept a `printf`-style apostrophe flag, e.g. `%'d`, to insert
+locale-dependent thousands separators, formatting `12345` as `12,345`. Since
+Miller's number formatting uses Go's [fmt](https://pkg.go.dev/fmt) package,
+which doesn't support that flag, formats like `--ofmt "%'d"`,
+`fmtnum($x, "%'d")`, and `format-values -i "%'d"` won't work. Likewise, the
+well-known `sed`/`perl` recipe for inserting separators relies on regular-expression
+lookaheads such as `(?=...)`, which [Go's regular-expression engine](reference-main-regular-expressions.md)
+doesn't support.
+
+You can, however, insert thousands separators with a small user-defined
+[DSL function](reference-dsl-user-defined-functions.md) which applies
+[`sub`](reference-dsl-builtin-functions.md#sub) until there's nothing left to
+do. Digits are grouped from the left, so the decimal part (if any) is
+untouched, and non-numeric values pass through unchanged:
+
+<pre class="pre-highlight-in-pair">
+<b>echo 'x=12345,y=1234567.8901,z=-987654321,s=hello' | mlr --opprint put '</b>
+<b>  func commify(n) {</b>
+<b>    s = string(n);</b>
+<b>    while (s =~ "^(-?[0-9]+)([0-9]{3})") {</b>
+<b>      s = sub(s, "^(-?[0-9]+)([0-9]{3})", "\1,\2");</b>
+<b>    }</b>
+<b>    return s;</b>
+<b>  }</b>
+<b>  for (k, v in $*) {</b>
+<b>    $[k] = commify(v);</b>
+<b>  }</b>
+<b>'</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+x      y              z            s
+12,345 1,234,567.8901 -987,654,321 hello
+</pre>
+
+To use a separator other than comma -- say, a space or a period -- simply
+change the `,` in the `"\1,\2"` replacement string.

--- a/docs/src/reference-main-number-formatting.md.in
+++ b/docs/src/reference-main-number-formatting.md.in
@@ -50,3 +50,38 @@ GENMD-EOF
 GENMD-RUN-COMMAND
 echo 'x=0xffff,y=0xff' | mlr put '$z=hexfmt($x*$y)'
 GENMD-EOF
+
+## Thousands separators
+
+Some tools accept a `printf`-style apostrophe flag, e.g. `%'d`, to insert
+locale-dependent thousands separators, formatting `12345` as `12,345`. Since
+Miller's number formatting uses Go's [fmt](https://pkg.go.dev/fmt) package,
+which doesn't support that flag, formats like `--ofmt "%'d"`,
+`fmtnum($x, "%'d")`, and `format-values -i "%'d"` won't work. Likewise, the
+well-known `sed`/`perl` recipe for inserting separators relies on regular-expression
+lookaheads such as `(?=...)`, which [Go's regular-expression engine](reference-main-regular-expressions.md)
+doesn't support.
+
+You can, however, insert thousands separators with a small user-defined
+[DSL function](reference-dsl-user-defined-functions.md) which applies
+[`sub`](reference-dsl-builtin-functions.md#sub) until there's nothing left to
+do. Digits are grouped from the left, so the decimal part (if any) is
+untouched, and non-numeric values pass through unchanged:
+
+GENMD-RUN-COMMAND
+echo 'x=12345,y=1234567.8901,z=-987654321,s=hello' | mlr --opprint put '
+  func commify(n) {
+    s = string(n);
+    while (s =~ "^(-?[0-9]+)([0-9]{3})") {
+      s = sub(s, "^(-?[0-9]+)([0-9]{3})", "\1,\2");
+    }
+    return s;
+  }
+  for (k, v in $*) {
+    $[k] = commify(v);
+  }
+'
+GENMD-EOF
+
+To use a separator other than comma -- say, a space or a period -- simply
+change the `,` in the `"\1,\2"` replacement string.


### PR DESCRIPTION
https://github.com/johnkerl/miller/issues/382

## What

Adds a "Thousands separators" section to the [Number formatting](https://miller.readthedocs.io/en/latest/reference-main-number-formatting/) reference page, documenting:

- Why `%'d`-style formats don't work in Miller: number formatting goes through Go's `fmt` package, which doesn't support the printf apostrophe (grouping) flag — so `--ofmt "%'d"`, `fmtnum($x, "%'d")`, and `format-values -i "%'d"` all fail, as reported in the issue.
- Why the well-known `sed`/`perl` one-liner also can't be ported directly: it relies on regex lookaheads (`(?=...)`), which Go's RE2 engine rejects (`invalid or unsupported Perl syntax`).
- A working recipe: a small user-defined DSL `commify` function which applies `sub()` in a loop, grouping digits from the left. It handles negatives and decimal parts, and passes non-numeric values through unchanged:

```
func commify(n) {
  s = string(n);
  while (s =~ "^(-?[0-9]+)([0-9]{3})") {
    s = sub(s, "^(-?[0-9]+)([0-9]{3})", "\1,\2");
  }
  return s;
}
```

Verified on `12345`, `1234567.8901`, `-987654321`, `0.123456`, `123`, and non-numeric strings. The doc example is a live GENMD sample, so its output is generated by actually running it.

## Testing

- `cd docs/src && ./genmds reference-main-number-formatting.md.in` — regenerated `.md` committed alongside the `.md.in`
- `make check` — all 4730 cases pass

## Notes

This is a docs-only change. A built-in `commify`/`format_thousands` DSL function (possibly with a configurable separator) would be a possible follow-up if the recipe feels too clunky, but the UDF approach keeps the surface area small and is copy-pasteable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
