### PR TITLE
Add how-to-lint rules to `README-dev.md` and `CLAUDE.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,24 @@ staticcheck -version
 
 If this works, you can use `make staticcheck` without any further setup.
 
+### Setting Up golangci-lint
+
+CI runs `golangci-lint` (config in `.golangci.yml`) on every push and PR via
+`.github/workflows/golangci-lint.yml`. To run it locally, install the version
+matching CI (currently v2.12.2) per the
+[official instructions](https://golangci-lint.run/welcome/install/#local-installation), e.g.:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+```
+
+This also installs to `~/go/bin/`, so the same `PATH` addition above covers it.
+
+**Verify the installation:**
+```bash
+golangci-lint --version
+```
+
 ## Build & Test
 
 ### Building
@@ -48,7 +66,13 @@ make bench          # Run benchmarks
 ```bash
 make fmt            # Format code with go fmt
 make staticcheck    # Run static analysis (see Initial Setup section above)
+make lint           # Run golangci-lint, same invocation as CI (see Initial Setup section above)
 ```
+
+`make lint` runs `golangci-lint run ./cmd/mlr ./pkg/...`, matching
+`.github/workflows/golangci-lint.yml` exactly, so a clean local run means CI's
+lint job will pass too. It is not part of `make check` or `make dev`, so run
+it explicitly before pushing.
 
 ### Full Developer Workflow
 ```bash
@@ -125,9 +149,10 @@ Documentation is built from `.md.in` template files that contain live code sampl
 Always run:
 ```bash
 make dev
+make lint
 ```
 
-This ensures code formatting, builds successfully, passes all tests, and documentation is up to date.
+`make dev` ensures code formatting, builds successfully, passes all tests, and documentation is up to date. `make lint` is separate (not part of `make dev`/`make check`) and mirrors the CI lint job.
 
 ## Additional Resources
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ fmt format:
 staticcheck:
 	staticcheck ./pkg/... ./cmd/mlr/...
 
+# Needs first: https://golangci-lint.run/welcome/install/#local-installation
+# Config lives in .golangci.yml; same invocation as .github/workflows/golangci-lint.yml
+lint:
+	golangci-lint run ./cmd/mlr ./pkg/...
+
 # ----------------------------------------------------------------
 # For developers before pushing to GitHub.
 #
@@ -125,4 +130,4 @@ release_tarball release-tarball: build check
 
 # ================================================================
 # Go does its own dependency management, outside of make.
-.PHONY: build mlr check unit_test regression_test bench fmt staticcheck dev docs man
+.PHONY: build mlr check unit_test regression_test bench fmt staticcheck lint dev docs man

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,6 +1,7 @@
 # Quickstart for developers
 
 * `make`, `make check`, `make docs`, etc: see [Makefile](Makefile) in the repo base directory.
+* Linting: `make lint` runs [golangci-lint](https://golangci-lint.run/) (config in [.golangci.yml](.golangci.yml)) with the same invocation used by [.github/workflows/golangci-lint.yml](.github/workflows/golangci-lint.yml), so a clean local run means CI's lint job will pass too. Install golangci-lint locally per the [official instructions](https://golangci-lint.run/welcome/install/#local-installation) (match the CI version, currently v2.12.2). It's a separate step from `make dev`/`make check` -- run it explicitly before pushing. `make staticcheck` (requires [staticcheck](https://staticcheck.io)) is a second, independent static-analysis pass.
 * Software-testing methodology: see [./test/README.md](./test/README.md).
 * Source-code indexing: please see [https://sourcegraph.com/github.com/johnkerl/miller](https://sourcegraph.com/github.com/johnkerl/miller)
 * Godoc As of September 2021, `godoc` support is minimal: package-level synopses exist; most `func`/`const`/etc content lacks `godoc`-style comments.  To view doc material, you can:


### PR DESCRIPTION
You can now run `make lint` to reproduce CI lint failures.