### PR TITLE
Document that NF is dynamic within a record (#2192)

### DIFF
--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -550,7 +550,11 @@ mathematic constant
 Stands for _number of fields_. A read-only [built-in
 variable](reference-dsl-variables.md#built-in-variables) in the [Miller
 programming language](miller-programming-language.md) which shows the number of fields
-in the current record.
+in the current record. Note that `NF` is dynamic: it is re-evaluated at each
+reference, so if fields are added to or removed from the current record --
+even within a single `put` or `filter` expression -- the value of `NF` changes
+accordingly. See the [built-in-variables
+section](reference-dsl-variables.md#built-in-variables) for details.
 
 ## NIDX
 

--- a/docs/src/glossary.md.in
+++ b/docs/src/glossary.md.in
@@ -534,7 +534,11 @@ mathematic constant
 Stands for _number of fields_. A read-only [built-in
 variable](reference-dsl-variables.md#built-in-variables) in the [Miller
 programming language](miller-programming-language.md) which shows the number of fields
-in the current record.
+in the current record. Note that `NF` is dynamic: it is re-evaluated at each
+reference, so if fields are added to or removed from the current record --
+even within a single `put` or `filter` expression -- the value of `NF` changes
+accordingly. See the [built-in-variables
+section](reference-dsl-variables.md#built-in-variables) for details.
 
 ## NIDX
 

--- a/docs/src/manpage.md
+++ b/docs/src/manpage.md
@@ -4091,7 +4091,10 @@ This is simply a copy of what you should see on running `man mlr` at a command p
        M_PI: the mathematical constant pi.
 
    1mNF0m
-       NF: evaluates to the number of fields in the current record.
+       NF: evaluates to the number of fields in the current record. Note that NF
+       is dynamic: it is re-evaluated at each reference, so if fields are added to or
+       removed from the current record -- even within a single put/filter expression
+       -- the value of NF changes accordingly.
 
    1mNR0m
        NR: evaluates to the number of the current record over all files

--- a/docs/src/manpage.txt
+++ b/docs/src/manpage.txt
@@ -4070,7 +4070,10 @@
        M_PI: the mathematical constant pi.
 
    1mNF0m
-       NF: evaluates to the number of fields in the current record.
+       NF: evaluates to the number of fields in the current record. Note that NF
+       is dynamic: it is re-evaluated at each reference, so if fields are added to or
+       removed from the current record -- even within a single put/filter expression
+       -- the value of NF changes accordingly.
 
    1mNR0m
        NR: evaluates to the number of the current record over all files

--- a/docs/src/reference-dsl-control-structures.md
+++ b/docs/src/reference-dsl-control-structures.md
@@ -153,6 +153,11 @@ x=1,y=2,3=,4=,5=,6=,7=,8=,9=,10=,foo=bar
 x=1,y=2,3=,4=,5=,foo=bar
 </pre>
 
+Note that these examples rely on the fact that
+[`NF`](reference-dsl-variables.md#built-in-variables) is **dynamic**: it is
+re-evaluated at each reference, so each `$[NF+1] = ""` assignment increments
+`NF`, and the loop makes progress toward its exit condition.
+
 A `break` or `continue` within nested conditional blocks or if-statements will,
 of course, propagate to the innermost loop enclosing them, if any. A `break` or
 `continue` outside a loop is a syntax error that will be flagged as soon as the
@@ -523,6 +528,8 @@ Notes:
 * Miller has no `++` or `--` operators.
 
 * As with all `for`/`if`/`while` statements in Miller, the curly braces are required even if the body is a single statement or empty.
+
+* Since [`NF`](reference-dsl-variables.md#built-in-variables) is **dynamic** -- it is re-evaluated at each reference -- a loop such as `for (i = 1; i <= NF; i += 1)` whose body adds fields to the current record will never terminate, since each added field increments `NF`. To loop over the fields the record had on entry, take a copy first -- e.g. `num n = NF; for (i = 1; i <= n; i += 1) { ... }` -- or use a [key-value for-loop](#key-value-for-loops) such as `for (k, v in $*)`, which iterates over a copy of the record made before the loop began.
 
 ## Begin/end blocks
 

--- a/docs/src/reference-dsl-control-structures.md.in
+++ b/docs/src/reference-dsl-control-structures.md.in
@@ -101,6 +101,11 @@ echo x=1,y=2 | mlr put '
 '
 GENMD-EOF
 
+Note that these examples rely on the fact that
+[`NF`](reference-dsl-variables.md#built-in-variables) is **dynamic**: it is
+re-evaluated at each reference, so each `$[NF+1] = ""` assignment increments
+`NF`, and the loop makes progress toward its exit condition.
+
 A `break` or `continue` within nested conditional blocks or if-statements will,
 of course, propagate to the innermost loop enclosing them, if any. A `break` or
 `continue` outside a loop is a syntax error that will be flagged as soon as the
@@ -340,6 +345,8 @@ Notes:
 * Miller has no `++` or `--` operators.
 
 * As with all `for`/`if`/`while` statements in Miller, the curly braces are required even if the body is a single statement or empty.
+
+* Since [`NF`](reference-dsl-variables.md#built-in-variables) is **dynamic** -- it is re-evaluated at each reference -- a loop such as `for (i = 1; i <= NF; i += 1)` whose body adds fields to the current record will never terminate, since each added field increments `NF`. To loop over the fields the record had on entry, take a copy first -- e.g. `num n = NF; for (i = 1; i <= n; i += 1) { ... }` -- or use a [key-value for-loop](#key-value-for-loops) such as `for (k, v in $*)`, which iterates over a copy of the record made before the loop began.
 
 ## Begin/end blocks
 

--- a/docs/src/reference-dsl-variables.md
+++ b/docs/src/reference-dsl-variables.md
@@ -131,7 +131,7 @@ a=eks,b=wye,i=4,x=NEW,y=0.134188
 a=wye,b=pan,i=5,x=0.573288,y=NEW
 </pre>
 
-Right-hand side accesses to non-existent fields -- i.e., with index less than 1 or greater than `NF` -- return an absent value. Likewise, left-hand side accesses only refer to fields that already exist. For example, if a field has 5 records, then assigning the name or value of the 6th (or 600th) field results in a no-op.
+Right-hand side accesses to non-existent fields -- i.e., with index less than 1 or greater than `NF` -- return an absent value. Likewise, left-hand side accesses only refer to fields that already exist. For example, if a record has 5 fields, then assigning the name or value of the 6th (or 600th) field results in a no-op.
 
 <pre class="pre-highlight-in-pair">
 <b>mlr put '$[[6]] = "NEW"' data/small</b>
@@ -607,6 +607,29 @@ mathematical constants, of course, do not change; `ENV` is populated from the
 system environment variables at the time Miller starts. Any changes made to
 `ENV` by assigning to it will affect any subprocesses, such as using
 [piped tee](reference-dsl-output-statements.md#redirected-output-statements).
+
+Note that, unlike the others, **`NF` is dynamic even within a single record**:
+it is re-evaluated at each reference, tracking the number of fields in the
+current record as of that moment. So if you add or remove fields -- even
+within a single `put` or `filter` expression -- the value of `NF` changes
+accordingly:
+
+<pre class="pre-highlight-in-pair">
+<b>echo 'x=1,y=2,z=3' | mlr put '$nf1 = NF; $u = 4; $nf2 = NF; unset $x, $y; $nf3 = NF'</b>
+</pre>
+<pre class="pre-non-highlight-in-pair">
+z=3,nf1=3,u=4,nf2=5,nf3=4
+</pre>
+
+In particular, be careful with loops whose continuation test involves `NF`,
+when the loop body adds fields to the record. For example,
+`for (i = 1; i <= NF; i += 1) { $["copy_".i] = $[[[i]]] }` is an **infinite
+loop**, since each new field increments `NF`, which is re-tested at each
+iteration. To loop over the fields a record had on entry, either take a copy
+of `NF` before the loop -- e.g. `num n = NF; for (i = 1; i <= n; i += 1) {
+... }` -- or use a [key-value for-loop](reference-dsl-control-structures.md#key-value-for-loops)
+such as `for (k, v in $*) { ... }`, which iterates over a copy of the record
+made before the loop began.
 
 Their **scope is global**: you can refer to them in any `filter` or `put` statement. The input-record reader assigns their values:
 
@@ -1260,7 +1283,10 @@ M_E: the mathematical constant e.
 
 M_PI: the mathematical constant pi.
 
-NF: evaluates to the number of fields in the current record.
+NF: evaluates to the number of fields in the current record. Note that NF
+is dynamic: it is re-evaluated at each reference, so if fields are added to or
+removed from the current record -- even within a single put/filter expression
+-- the value of NF changes accordingly.
 
 NR: evaluates to the number of the current record over all files
 being processed, starting with 1. Does not reset at the start of each file.

--- a/docs/src/reference-dsl-variables.md.in
+++ b/docs/src/reference-dsl-variables.md.in
@@ -70,7 +70,7 @@ GENMD-RUN-COMMAND
 mlr put '$[[[NR]]] = "NEW"' data/small
 GENMD-EOF
 
-Right-hand side accesses to non-existent fields -- i.e., with index less than 1 or greater than `NF` -- return an absent value. Likewise, left-hand side accesses only refer to fields that already exist. For example, if a field has 5 records, then assigning the name or value of the 6th (or 600th) field results in a no-op.
+Right-hand side accesses to non-existent fields -- i.e., with index less than 1 or greater than `NF` -- return an absent value. Likewise, left-hand side accesses only refer to fields that already exist. For example, if a record has 5 fields, then assigning the name or value of the 6th (or 600th) field results in a no-op.
 
 GENMD-RUN-COMMAND
 mlr put '$[[6]] = "NEW"' data/small
@@ -319,6 +319,26 @@ mathematical constants, of course, do not change; `ENV` is populated from the
 system environment variables at the time Miller starts. Any changes made to
 `ENV` by assigning to it will affect any subprocesses, such as using
 [piped tee](reference-dsl-output-statements.md#redirected-output-statements).
+
+Note that, unlike the others, **`NF` is dynamic even within a single record**:
+it is re-evaluated at each reference, tracking the number of fields in the
+current record as of that moment. So if you add or remove fields -- even
+within a single `put` or `filter` expression -- the value of `NF` changes
+accordingly:
+
+GENMD-RUN-COMMAND
+echo 'x=1,y=2,z=3' | mlr put '$nf1 = NF; $u = 4; $nf2 = NF; unset $x, $y; $nf3 = NF'
+GENMD-EOF
+
+In particular, be careful with loops whose continuation test involves `NF`,
+when the loop body adds fields to the record. For example,
+`for (i = 1; i <= NF; i += 1) { $["copy_".i] = $[[[i]]] }` is an **infinite
+loop**, since each new field increments `NF`, which is re-tested at each
+iteration. To loop over the fields a record had on entry, either take a copy
+of `NF` before the loop -- e.g. `num n = NF; for (i = 1; i <= n; i += 1) {
+... }` -- or use a [key-value for-loop](reference-dsl-control-structures.md#key-value-for-loops)
+such as `for (k, v in $*) { ... }`, which iterates over a copy of the record
+made before the loop began.
 
 Their **scope is global**: you can refer to them in any `filter` or `put` statement. The input-record reader assigns their values:
 

--- a/man/manpage.txt
+++ b/man/manpage.txt
@@ -4070,7 +4070,10 @@
        M_PI: the mathematical constant pi.
 
    1mNF0m
-       NF: evaluates to the number of fields in the current record.
+       NF: evaluates to the number of fields in the current record. Note that NF
+       is dynamic: it is re-evaluated at each reference, so if fields are added to or
+       removed from the current record -- even within a single put/filter expression
+       -- the value of NF changes accordingly.
 
    1mNR0m
        NR: evaluates to the number of the current record over all files

--- a/man/mlr.1
+++ b/man/mlr.1
@@ -6596,7 +6596,10 @@ M_PI: the mathematical constant pi.
 .RS 0
 .\}
 .nf
-NF: evaluates to the number of fields in the current record.
+NF: evaluates to the number of fields in the current record. Note that NF
+is dynamic: it is re-evaluated at each reference, so if fields are added to or
+removed from the current record -- even within a single put/filter expression
+-- the value of NF changes accordingly.
 .fi
 .if n \{\
 .RE

--- a/pkg/dsl/cst/keyword_usage.go
+++ b/pkg/dsl/cst/keyword_usage.go
@@ -588,7 +588,11 @@ func M_PIKeywordUsage() {
 }
 
 func NFKeywordUsage() {
-	fmt.Println(`evaluates to the number of fields in the current record.`)
+	fmt.Println(
+		`evaluates to the number of fields in the current record. Note that NF
+is dynamic: it is re-evaluated at each reference, so if fields are added to or
+removed from the current record -- even within a single put/filter expression
+-- the value of NF changes accordingly.`)
 }
 
 func NRKeywordUsage() {


### PR DESCRIPTION
Addresses #2192.

## User's pain points

* The user expected `NF` to be constant for a given record, and hit an inadvertent infinite loop (with memory growth) from `for (i = 1; i <= NF; i += 1) { $["times2_".i] = 2*$i }` -- each new field increments `NF`, which is re-tested on every iteration.
* The docs sentence they quoted -- "Their values of NF, NR, FNR, FILENUM, and FILENAME change from one record to the next" -- implied per-record constancy.

Verified behavior (it's re-evaluated from `state.Inrec.FieldCount` on every reference, `pkg/dsl/cst/leaves.go`):

```
$ echo 'x=1,y=2,z=3' | mlr put '$nf1 = NF; $u = 4; $nf2 = NF; unset $x, $y; $nf3 = NF'
z=3,nf1=3,u=4,nf2=5,nf3=4
```

Per the triage comment on the issue, this is documentation-only: `NF` is intended to track the current field count, so no behavior change is made.

## Audit: where dynamism was already documented vs. not

Already stated:

* `questions-about-then-chaining.md.in` -- "`NF` is dynamically updated," with a live example.
* `miller-programming-language.md.in` -- "if you assign `$newcolumn = some value`, then `NF` will increment."
* `reference-dsl-syntax.md.in` and `reference-dsl-control-structures.md.in` -- `while (NF < 10) { $[NF+1] = "" }` examples exploit the dynamism, but without calling it out.

Not stated (the gaps, now fixed):

* `reference-dsl-variables.md.in` (Built-in variables section) -- the primary reference page, containing the exact sentence the user quoted.
* `glossary.md.in` -- the `NF` entry.
* `mlr help keyword NF` (`pkg/dsl/cst/keyword_usage.go`) -- one line with no dynamism note; this text also flows into the manpage and the usage-keywords section of the variables reference page.
* `reference-dsl-control-structures.md.in` -- the C-style triple-for section (the exact construct that bit the user) had no warning.

## Changes

* `docs/src/reference-dsl-variables.md.in`: after the "change from one record to the next" paragraph, added an explicit "NF is dynamic even within a single record" paragraph with a live GENMD example (`nf1=3 ... nf2=5 ... nf3=4`), a warning that `for (i = 1; i <= NF; i += 1)` with a field-adding body is an infinite loop, and the two idiomatic alternatives: snapshot (`num n = NF`) or a key-value for-loop over `$*` (which iterates over a copy of the record).
* `docs/src/reference-dsl-control-structures.md.in`: noted in the while/do-while section that those examples work *because* `NF` is dynamic; added a bullet in the triple-for notes warning about non-terminating `NF`-bounded loops, cross-linking the alternatives.
* `docs/src/glossary.md.in`: added the dynamism note to the `NF` entry, linking to the built-in-variables section.
* `pkg/dsl/cst/keyword_usage.go`: extended the `mlr help keyword NF` text with the dynamism note.
* Fixed a pre-existing typo in the same page ("if a field has 5 records" -> "if a record has 5 fields").
* Regenerated docs (`make -C docs/src forcebuild`) and man pages (`make -C man build`).

Not touched: `docs/src/mlr.1` is a stale 2021-dated artifact that no Makefile keeps in sync with `man/mlr.1`; left as-is.

## Testing

* `make check`: all unit tests pass; regression suite 4759/4759 cases, 312/312 case-directories PASS.
* `make lint`: 0 issues; `gofmt` clean.
* Manually verified `mlr help keyword NF` output and the rendered examples in the regenerated `.md` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
