### PR TITLE
Remove `os.Exit` callsites below the entrypoint: record final status, defer phase 5, convert stragglers

### DIFF
--- a/pkg/cli/option_parse.go
+++ b/pkg/cli/option_parse.go
@@ -59,7 +59,11 @@ func FinalizeReaderOptions(readerOptions *TReaderOptions) error {
 		// and spaces, that should now be the default for NIDX. But *only* for NIDX format,
 		// and if IFS wasn't specified.
 		if readerOptions.InputFileFormat == "nidx" && !readerOptions.ifsWasSpecified {
-			readerOptions.IFSRegex = lib.CompileMillerRegexOrDie(WHITESPACE_REGEX)
+			regex, err := lib.CompileMillerRegex(WHITESPACE_REGEX)
+			if err != nil {
+				return err
+			}
+			readerOptions.IFSRegex = regex
 		} else {
 			if allowRepeatIFS, ok := defaultAllowRepeatIFSes[readerOptions.InputFileFormat]; ok {
 				readerOptions.AllowRepeatIFS = allowRepeatIFS
@@ -285,7 +289,11 @@ var SeparatorFlagSection = FlagSection{
 				// LF vs CR/LF line endings is handled within Go libraries so
 				// we needn't do anything ourselves.
 				if args[*pargi+1] != "auto" {
-					options.ReaderOptions.IFSRegex = lib.CompileMillerRegexOrDie(SeparatorRegexFromArg(args[*pargi+1]))
+					regex, err := lib.CompileMillerRegex(SeparatorRegexFromArg(args[*pargi+1]))
+					if err != nil {
+						return err
+					}
+					options.ReaderOptions.IFSRegex = regex
 					options.ReaderOptions.ifsWasSpecified = true
 				}
 				*pargi += 2
@@ -316,7 +324,11 @@ var SeparatorFlagSection = FlagSection{
 				if err := CheckArgCount(args, *pargi, argc, 2); err != nil {
 					return err
 				}
-				options.ReaderOptions.IPSRegex = lib.CompileMillerRegexOrDie(SeparatorRegexFromArg(args[*pargi+1]))
+				regex, err := lib.CompileMillerRegex(SeparatorRegexFromArg(args[*pargi+1]))
+				if err != nil {
+					return err
+				}
+				options.ReaderOptions.IPSRegex = regex
 				options.ReaderOptions.ipsWasSpecified = true
 				*pargi += 2
 				return nil

--- a/pkg/dsl/cst/root.go
+++ b/pkg/dsl/cst/root.go
@@ -411,11 +411,12 @@ func (root *RootNode) RegisterOutputHandlerManager(
 	root.outputHandlerManagers = append(root.outputHandlerManagers, outputHandlerManager)
 }
 
-func (root *RootNode) ProcessEndOfStream() {
+func (root *RootNode) ProcessEndOfStream() error {
 	for _, outputHandlerManager := range root.outputHandlerManagers {
 		errs := outputHandlerManager.Close()
 		if len(errs) != 0 {
-			for _, err := range errs {
+			// Print any additional errors here; return the first one.
+			for _, err := range errs[1:] {
 				fmt.Fprintf(
 					os.Stderr,
 					"%s: error on end-of-stream close: %v\n",
@@ -423,9 +424,10 @@ func (root *RootNode) ProcessEndOfStream() {
 					err,
 				)
 			}
-			os.Exit(1)
+			return fmt.Errorf("mlr: error on end-of-stream close: %v", errs[0])
 		}
 	}
+	return nil
 }
 
 func (root *RootNode) ExecuteBeginBlocks(state *runtime.State) error {

--- a/pkg/transformers/put_or_filter.go
+++ b/pkg/transformers/put_or_filter.go
@@ -615,7 +615,9 @@ func (tr *TransformerPut) Transform(
 
 		// Send all registered OutputHandlerManager instances the end-of-stream
 		// indicator.
-		tr.cstRootNode.ProcessEndOfStream()
+		if err := tr.cstRootNode.ProcessEndOfStream(); err != nil {
+			return err
+		}
 
 		*outputRecordsAndContexts = append(*outputRecordsAndContexts, types.NewEndOfStreamMarker(&context))
 	}

--- a/plans/exit.md
+++ b/plans/exit.md
@@ -140,6 +140,52 @@ asserts on both; see also recent exit-code fixes #2171, #2146). `--errors-json`
 categorization must keep working — and gains coverage, since stream-time errors that
 today bypass `EmitStructuredError` will now arrive at the entrypoint as errors.
 
+## Status (2026-07)
+
+- Phase 1: done — #2198.
+- Phase 2: done — #2202.
+- Phase 3: done — #2204. Additionally, the `RecordTransformerFunc` internal
+  dispatch methods were converted along with `Transform`, and the step verb's
+  `tStepperAllocator` table gained an error return.
+- Phase 4: done — #2205. Went one step further than planned: the
+  `auxents`/`terminals` dispatchers themselves now return exit codes instead
+  of calling `os.Exit`, so `entrypoint.Main` is the single exit point below
+  `main`. Also converted in the phase-5 wrap-up PR: `RootNode.ProcessEndOfStream`
+  (a phase-3 leftover on the put/filter Transform path) returns an error.
+- Phase 5: **deferred** — see below.
+
+### Phase 5 deferral rationale
+
+The sketch below (error-Mlrvals via `FromErrorString`) turns out to have costs
+not visible at planning time: 58 regression cases pin the current
+loud-failure behavior (exact stderr message plus exit 1 via `should-fail`),
+and error-Mlrvals display as bare `(error)` — so HOF/UDF misuse would fail
+*silently* with exit 0 unless `--fail-on-data-error` is set, a debugging-UX
+regression. An alternative mechanism (a typed panic recovered at the four
+`Execute*` boundaries, then riding the phase-3 error path) would preserve
+behavior exactly, but introduces panic/recover to a codebase that has none.
+Rather than pick under time pressure, the DSL cluster is deferred to the
+issue-440 strict-mode design, where the fatal-vs-data error taxonomy has to
+be decided anyway. The remaining sites are all in `pkg/dsl/cst`: `hofs.go`
+(14), `udf.go` (8), `evaluable.go` (1), plus `builtin_function_manager.go`'s
+init-time duplicate-name assertion.
+
+### Final keep-list (intentional, documented)
+
+- `pkg/entrypoint/entrypoint.go` `exitOnError` — the sanctioned exit point.
+- `pkg/lib/logger.go` `InternalCodingErrorIf` family — should-never-happen
+  assertions (`MLR_PANIC_ON_INTERNAL_ERROR` gives stack traces).
+- `pkg/bifs/types.go` `assertingCommon` — the `asserting_*` DSL builtins,
+  whose documented contract is abort-on-failure.
+- `pkg/mlrval/mlrval_get.go` (`GetNumericToFloatValueOrDie`,
+  `StrictModeCheck`) and `mlrval_output.go` (`String()` path) — inside
+  `fmt.Stringer` and hot-path value accessors; error returns don't fit the
+  signatures. Candidates for the 440 redesign.
+- `pkg/lib/mlrmath.go` (eigensolver non-convergence), `pkg/lib/regex.go`
+  `CompileMillerRegexOrDie` (remaining callers are `lib`-internal and `bifs`
+  hot paths, both on the `Evaluate`-shaped signatures deferred with phase 5;
+  the `option_parse` callers were converted in the wrap-up PR).
+
 ## Phases (one PR each, each green under `make dev` + `make lint`)
 
 ### Phase 1 — top level + all mechanical swaps (clusters 2, 3a, 5, 7 partial)


### PR DESCRIPTION
## What & why

Wrap-up of the [plans/exit.md](https://github.com/johnkerl/miller/blob/main/plans/exit.md) campaign (follows #2198, #2202, #2204, #2205). This PR **defers phase 5** (the DSL-runtime cluster) with the rationale written into the plan doc, records the final phase-by-phase status and keep-list, and converts two stragglers that belong to earlier phases' patterns.

Net effect of the whole campaign: ~170 `os.Exit` sites down to 41, every remaining one either deferred-with-rationale or on the documented keep-list, with `entrypoint.exitOnError` as the single sanctioned exit point below `main`.

## Why phase 5 is deferred, not done

The plan's sketch was to convert `pkg/dsl/cst` runtime failures (HOF arity/not-found, UDF argument-count/type-gate errors — `hofs.go` 14 sites, `udf.go` 8, `evaluable.go` 1) into in-band error-Mlrvals via `FromErrorString`. Two facts surfaced during implementation that weren't visible at planning time:

1. **58 regression cases pin the current loud-failure behavior** — exact stderr message plus exit 1 via `should-fail` markers (`test/cases/dsl-first-class-functions/{sort,fold,apply,reduce,any,every,select}-errors-*` and UDF cases).
2. **Error-Mlrvals display as bare `(error)`** — so `sort($*, typo_func)` would silently produce `(error)` with exit 0 unless `--fail-on-data-error` is set. That's a debugging-UX regression, not just a semantics change.

The behavior-preserving alternative — a typed panic thrown at the ~23 expression-depth sites and recovered at the four `Execute*` boundaries (which already return `error`), then riding the phase-3 propagation path — keeps messages and exit codes byte-identical with zero test churn, but introduces panic/recover to a codebase that deliberately has none. Either choice is really a decision about Miller's fatal-vs-data error taxonomy, which is exactly what the #440 strict-mode design has to settle. So the cluster is deferred to that work, with both options analyzed in the plan doc.

## What is converted here

Two stragglers squarely within already-merged patterns:

- **`RootNode.ProcessEndOfStream` returns `error`** — a phase-3 leftover: it's called from `put_or_filter.Transform` (error-returning since #2204) and was still printing end-of-stream close errors and exiting. Multi-error handling matches split's convention from phase 3: first error returned (printed once by the entrypoint), any others printed at the site.
- **The three `CompileMillerRegexOrDie` calls in `option_parse.go`** now use `CompileMillerRegex` and return the error — they've been inside error-returning parser closures since #2202. `mlr --ifs-regex '('` prints the identical `mlr: error parsing regexp: ...` and exits 1; the NIDX whitespace-preset compile (a constant that can't fail) propagates through `FinalizeReaderOptions`'s existing error return.

## Final keep-list (documented in plans/exit.md)

`entrypoint.exitOnError` (the sanctioned exit point); `lib.InternalCodingErrorIf` assertions; `asserting_*` DSL builtins (abort is their documented contract); mlrval `Stringer`-path and `...OrDie` accessors (error returns don't fit the signatures; 440-redesign candidates); `mlrmath` non-convergence; `CompileMillerRegexOrDie`'s remaining lib-internal/bifs hot-path callers.

## Testing

All 4779 regression cases pass; `make lint` 0 issues. Hand-checked `mlr --ifs-regex '('` (same message, exit 1) and NIDX default whitespace splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
