### PR TITLE
Fix mid-stream error-loss race (flaky exit codes on transformer errors)

### DIFF
--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -104,6 +104,26 @@ func Stream(
 		}
 	}
 
+	// An error and the done-writing signal can be ready simultaneously, and
+	// select chooses among ready channels at random -- so an error may still
+	// be sitting in a buffer when the loop above exits. Senders guarantee the
+	// error is buffered before the end-of-stream marker that lets the writer
+	// finish, so a final non-blocking drain is sufficient to pick it up.
+	if retval == nil {
+		select {
+		case ierr := <-inputErrorChannel:
+			retval = ierr
+		default:
+		}
+	}
+	if retval == nil {
+		select {
+		case derr := <-dataProcessingErrorChannel:
+			retval = derr
+		default:
+		}
+	}
+
 	if err := bufferedOutputStream.Flush(); err != nil && retval == nil {
 		retval = err
 	}

--- a/pkg/transformers/aaa_chain_transformer.go
+++ b/pkg/transformers/aaa_chain_transformer.go
@@ -213,24 +213,21 @@ func runSingleTransformer(
 			outputRecordChannel,
 			inputDownstreamDoneChannel,
 			outputDownstreamDoneChannel,
+			dataProcessingErrorChannel,
 			options,
 		)
 		if err != nil {
-			// Surface the error to stream.Stream's select loop. Non-blocking
-			// send: if another goroutine errored first, that error wins.
-			select {
-			case dataProcessingErrorChannel <- err:
-			default:
-			}
+			// runSingleTransformerBatch has already sent the error to
+			// dataProcessingErrorChannel and then forwarded an end-of-stream
+			// marker downstream, so the record-writer drains and finishes,
+			// upon which stream.Stream returns the error.
+			//
 			// Tell upstream (transformers and ultimately the record-reader,
 			// via the mlr-head mechanism) that we'll ignore further input.
 			select {
 			case outputDownstreamDoneChannel <- true:
 			default:
 			}
-			// runSingleTransformerBatch has already forwarded an end-of-stream
-			// marker downstream, so the record-writer drains and finishes,
-			// upon which stream.Stream returns the error we sent above.
 			return
 		}
 	}
@@ -238,10 +235,10 @@ func runSingleTransformer(
 
 // runSingleTransformerBatch passes one batch of records through the
 // transformer. The boolean return is true on end of record stream. A non-nil
-// error is a mid-stream transformer failure: any output produced before the
-// failure, plus an end-of-stream marker, has already been forwarded
-// downstream so the rest of the chain and the record-writer can drain and
-// finish cleanly.
+// error is a mid-stream transformer failure: the error has already been sent
+// to dataProcessingErrorChannel, and any output produced before the failure,
+// plus an end-of-stream marker, has already been forwarded downstream so the
+// rest of the chain and the record-writer can drain and finish cleanly.
 func runSingleTransformerBatch(
 	inputRecordsAndContexts []*types.RecordAndContext, // list of types.RecordAndContext
 	recordTransformer RecordTransformer,
@@ -249,6 +246,7 @@ func runSingleTransformerBatch(
 	outputRecordChannel chan<- []*types.RecordAndContext, // list of *types.RecordAndContext
 	inputDownstreamDoneChannel <-chan bool,
 	outputDownstreamDoneChannel chan<- bool,
+	dataProcessingErrorChannel chan<- error,
 	options *cli.TOptions,
 ) (bool, error) {
 	outputRecordsAndContexts := make([]*types.RecordAndContext, 0, len(inputRecordsAndContexts))
@@ -292,6 +290,17 @@ func runSingleTransformerBatch(
 				outputDownstreamDoneChannel,
 			)
 			if err != nil {
+				// Surface the error to stream.Stream's select loop.
+				// Non-blocking send: if another goroutine errored first, that
+				// error wins. This must happen before the end-of-stream
+				// marker is forwarded below: the marker lets the
+				// record-writer finish and signal done-writing, and the error
+				// must already be buffered by then or stream.Stream could
+				// return nil, losing the nonzero exit code.
+				select {
+				case dataProcessingErrorChannel <- err:
+				default:
+				}
 				// Forward what was produced before the failure, plus an
 				// end-of-stream marker so downstream drains and finishes.
 				outputRecordsAndContexts = append(outputRecordsAndContexts,


### PR DESCRIPTION
## Problem

The Windows CI job on #2209 failed in `test/cases/verb-join/left-file-malformed-sorted` — then the harness's automatic rerun of the same case **passed** within the same job. The PR only touched a markdown file, so this was a flake in the error path itself, introduced by the recent `os.Exit`-removal refactor (plans/exit.md, #2204/#2205).

## Root cause

When a transformer fails mid-stream (e.g. `join -s` whose left file is malformed CSV), two independent races could each cause the error — and hence the nonzero exit code and stderr message — to be silently lost:

1. **Send ordering.** `runSingleTransformerBatch` forwarded the end-of-stream marker downstream *before* `runSingleTransformer` sent the error to `dataProcessingErrorChannel`. If the transformer goroutine was descheduled in that window, the record-writer drained, signaled done-writing, and `stream.Stream` returned `nil` before the error was ever sent.
2. **Select fairness.** Even with the error safely buffered, `stream.Stream`'s select loop chooses among simultaneously-ready channels at random. Picking `doneWritingChannel` exited the loop with the error still sitting in the buffer.

Either way: exit 0, empty stderr, and (for this test) a diff against the expected `mlr: CSV header/data length mismatch ...` message.

## Fix

- `pkg/transformers/aaa_chain_transformer.go`: send the error to `dataProcessingErrorChannel` **before** forwarding the end-of-stream marker. This establishes a happens-before chain: error buffered → marker reaches writer → writer signals done. The same ordering already holds for the record-reader (`inputErrorChannel` before its end-of-stream marker) and for `ChannelWriter` (error before `doneChannel`).
- `pkg/stream/stream.go`: after the select loop exits on done-writing, do a final non-blocking drain of both error channels. Given the ordering guarantee above, this is sufficient to pick up any error that lost the select race.

## Verification

- Could not reproduce the flake with 1,500 plain runs on macOS (the window is a few instructions wide). Instead, widened the window with a temporary `time.Sleep` between the end-of-stream forward and the error send: **5/5 runs reproduced** the CI failure exactly (exit 0, empty stderr).
- With the fix, re-injected adversarial 10 ms sleeps on **both** sides of the end-of-stream forward: **0/200 failures**.
- Temporary sleeps removed; `make check` passes (4789 cases, 0 failed), `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)