### PR TITLE
Add scoped make gosec target for security scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,16 @@ staticcheck:
 lint:
 	golangci-lint run ./cmd/mlr ./pkg/...
 
+# Needs first: go install github.com/securego/gosec/v2/cmd/gosec@latest
+# Rules excluded below don't apply to a CLI data-processing tool and are pure
+# noise here; see plans/security.md for the reasoning behind each:
+#   G104 unhandled errors            -- already tuned via errcheck in .golangci.yml
+#   G115 int overflow conversions    -- inherent to Mlrval's numeric-type handling
+#   G301/G302/G306 file permissions  -- 0644/0755 is expected for output data files
+#   G602 slice index out of range    -- gosec can't prove loop bounds; high false-positive rate
+gosec:
+	gosec -exclude=G104,G115,G301,G302,G306,G602 ./pkg/... ./cmd/mlr/...
+
 # ----------------------------------------------------------------
 # For developers before pushing to GitHub.
 #

--- a/pkg/bifs/hashing.go
+++ b/pkg/bifs/hashing.go
@@ -1,8 +1,8 @@
 package bifs
 
 import (
-	"crypto/md5"
-	"crypto/sha1"
+	"crypto/md5"  // #nosec G501 -- used only for the DSL's md5() data-fingerprinting builtin, not security
+	"crypto/sha1" // #nosec G505 -- used only for the DSL's sha1() data-fingerprinting builtin, not security
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -27,7 +27,7 @@ func BIF_md5(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 	if errval != nil {
 		return errval
 	}
-	return mlrval.FromString(fmt.Sprintf("%x", md5.Sum(payload)))
+	return mlrval.FromString(fmt.Sprintf("%x", md5.Sum(payload))) // #nosec G401 -- data-fingerprinting, not security
 }
 
 func BIF_sha1(input1 *mlrval.Mlrval) *mlrval.Mlrval {
@@ -35,7 +35,7 @@ func BIF_sha1(input1 *mlrval.Mlrval) *mlrval.Mlrval {
 	if errval != nil {
 		return errval
 	}
-	return mlrval.FromString(fmt.Sprintf("%x", sha1.Sum(payload)))
+	return mlrval.FromString(fmt.Sprintf("%x", sha1.Sum(payload))) // #nosec G401 -- data-fingerprinting, not security
 }
 
 func BIF_sha256(input1 *mlrval.Mlrval) *mlrval.Mlrval {

--- a/pkg/lib/rand.go
+++ b/pkg/lib/rand.go
@@ -11,13 +11,13 @@ import (
 // By default, Miller random numbers are different on every run.
 var defaultSeed = time.Now().UnixNano() ^ int64(os.Getpid())
 var source = rand.NewSource(defaultSeed)
-var generator = rand.New(source)
+var generator = rand.New(source) // #nosec G404 -- must be seedable for --seed/reproducibility; not used for security
 
 // Users can request specific seeds if they want the same random-number
 // sequence on each run.
 func SeedRandom(seed int64) {
 	source = rand.NewSource(seed)
-	generator = rand.New(source)
+	generator = rand.New(source) // #nosec G404 -- must be seedable for --seed/reproducibility; not used for security
 }
 
 func RandFloat64() float64 {

--- a/plans/security.md
+++ b/plans/security.md
@@ -1,0 +1,67 @@
+# gosec scoping notes
+
+`gosec` (github.com/securego/gosec/v2), run against `./pkg/... ./cmd/mlr/...`
+(same scope as `make lint`/`make staticcheck`, which excludes the stale,
+non-shipped example code under `cmd/experiments/`, `docs/site/`, and
+`docs/src/miller-as-library/`).
+
+Run via `make gosec`. Background: this replaced an earlier attempt at using
+`gokart` (github.com/praetorian-inc/gokart), which is unmaintained/archived
+and can't parse export data from Go 1.24+ toolchains; `gosec` is actively
+maintained and its taint-tracking rules (G702/G703) cover the same ground
+gokart did, plus more.
+
+## Baseline (first run)
+
+- **237 raw issues** before any exclusions or `#nosec` annotations
+- **53 issues** after scoping (see below)
+
+### Rules excluded globally (via `-exclude=` in the `gosec` Makefile target)
+
+These don't represent real risk for a CLI data-processing tool and were the
+overwhelming majority of raw noise; every sampled instance below was
+reviewed before excluding the rule wholesale.
+
+| Rule | Count | Why excluded |
+|------|------:|--------------|
+| G104 | 151 | Unhandled errors -- already tuned precisely via `errcheck.exclude-functions` in `.golangci.yml` (bufio/strings.Builder writes, Fprint family) |
+| G115 | 17 | Integer overflow on numeric conversions -- inherent to `Mlrval`'s int64/uint64/rune/byte representation handling; every sampled site (`mlrval_infer.go`, `lib/util.go`, `bifs/bits.go`, `latin1.go`) is a benign value-representation conversion, not attacker-controlled-length arithmetic |
+| G602 | 5 | "slice index out of range" -- gosec can't prove loop-bound invariants; every sampled site (`emit_emitp.go`, `help/entry.go`) is a loop-bounded index |
+| G301/G302/G306 | 8 | File/dir permissions (wants 0600/0750) -- output data files and directories are meant to be group/world-readable by design (0644/0755); these aren't secrets |
+
+### Rules `#nosec`'d at specific sites (not excluded globally)
+
+Kept enabled everywhere else, so any *new* misuse still gets flagged.
+
+| Rule | Site | Why |
+|------|------|-----|
+| G401/G501/G505 | `pkg/bifs/hashing.go` (`md5()`/`sha1()` DSL builtins) | Exposed to users as data-fingerprinting/checksum functions, never for authentication or integrity-of-secrets purposes |
+| G404 | `pkg/lib/rand.go` (`SeedRandom`, package-level generator) | Must be deterministically seedable for `--seed`/reproducible `urand()` output; `crypto/rand` can't do that by definition |
+
+### Remaining after scoping (53) -- live findings, triage as normal work
+
+| Rule | Count | Category |
+|------|------:|----------|
+| G703 | 22 | Path traversal via taint analysis |
+| G304 | 20 | File path from variable (same sites as G703, mostly) |
+| G204 | 6 | Subprocess launched with tainted args |
+| G702 | 2 | Command injection via taint analysis (same sites as G204) |
+| G107 | 1 | HTTP request with variable URL (`pkg/lib/file_readers.go:74`, the `mlr --from http://...` feature) |
+
+Most of the G304/G703 file-path findings are the expected shape for a CLI
+tool: the "taint source" is `os.Args`/CLI flags, which is Miller's own
+trust boundary -- a user passing `mlr --from ./whatever` is not an attacker.
+The two sites worth a closer look precisely because they're *not* just the
+regtest/REPL harnesses:
+
+- `pkg/bifs/system.go` -- the DSL's `system()` builtin (subprocess from DSL
+  expression, i.e. from data the user's *script* constructs, not just argv)
+- `pkg/terminals/mcp/tools_exec.go:94` -- MCP tool execution; worth
+  double-checking exactly what can reach this before treating it as
+  low-risk by the "it's just argv" argument above
+
+`G107` (`file_readers.go:74`) is the documented `--from http://...` /
+`--from https://...` feature -- also CLI-argv-driven today, but worth
+revisiting if Miller's HTTP-fetch path is ever reachable from anything
+other than the operator's own command line (e.g. if driven by data from a
+record rather than a flag).


### PR DESCRIPTION
## Summary

Context: #813

Adds `make gosec`, running [gosec](https://github.com/securego/gosec) scoped to the same paths as `make lint`/`make staticcheck` (`./pkg/... ./cmd/mlr/...`).

This replaces an earlier attempt at using `gokart`: it's unmaintained (archived by praetorian-inc in 2024, last real commit 2022) and its pinned `golang.org/x/tools v0.1.12` panics (`unsupported version: 2`) trying to read export data from Go 1.24+ toolchains — the compiler's export format was bumped and gokart's dependency was never updated to follow. `gosec` is actively maintained and its taint-tracking rules (subprocess/path-traversal) cover the same ground gokart did, plus more — it independently found gokart's same command-injection/path-traversal sites in `pkg/terminals/regtest/invoker.go` and `cmd/mlr/main.go`, plus two gokart missed entirely: the DSL's `system()` builtin and the MCP tool executor.

## Why the scoping

`gosec`'s defaults are noisy for a CLI data-processing tool: 237 raw findings on this repo, most not real issues. Excluded via `-exclude=` in the Makefile target (each reviewed by sampling actual hits before excluding, not just going by rule description):

- **G104** (unhandled errors) — already tuned precisely via `errcheck.exclude-functions` in `.golangci.yml`
- **G115** (int overflow conversions) — inherent to `Mlrval`'s int64/uint64/rune/byte representation handling, not attacker-controlled-length arithmetic
- **G602** (slice index out of range) — gosec can't prove loop-bound invariants; every sampled site was a loop-bounded index
- **G301/G302/G306** (file/dir permissions) — 0644/0755 is correct for output data files meant to be readable, not secrets

That leaves 51 real findings, tracked in `plans/security.md` for future triage — mostly the expected shape for a CLI tool (file/subprocess taint sourced from CLI args, i.e. the user's own argv, not an attacker), except two sites flagged as worth a closer look precisely because they're not just argv-trust: `pkg/bifs/system.go` (DSL `system()` builtin, driven by script content) and `pkg/terminals/mcp/tools_exec.go:94` (MCP tool execution).

## Non-obvious decisions

- Two intentional "weak crypto" uses are `#nosec`'d at their specific call sites rather than via a blanket rule exclusion, so the rule stays live for any new misuse elsewhere:
  - `pkg/bifs/hashing.go`: the DSL's `md5()`/`sha1()` builtins are user-facing data-fingerprinting/checksum functions, never used for authentication or securing secrets.
  - `pkg/lib/rand.go`: the PRNG backing `--seed`/reproducible `urand()` output must be deterministically seedable, which rules out `crypto/rand` by definition.
- `gosec` (like `lint`/`staticcheck`) is intentionally not wired into `make check`/`make dev` — it exits non-zero while real findings remain, matching how the other static-analysis targets are kept separate per the top of the Makefile's static-analysis section.

## How to test

```
go install github.com/securego/gosec/v2/cmd/gosec@latest
make gosec
```
Expect exit code 1 with 51 findings (not 237) — confirms the exclusions and `#nosec` annotations are taking effect. `go build ./...` and `go test ./pkg/bifs/... ./pkg/lib/...` to confirm the two touched source files are otherwise unchanged (comment-only edits).

## Known gaps

- The 51 remaining findings aren't fixed here, just scoped and documented — real triage (especially the two flagged non-argv sites) is left as follow-up work.
- No CI workflow wiring (e.g. a `golangci-lint`-style GitHub Action) — this PR only adds the local `make gosec` entry point, matching the ask that prompted it.
