### PR TITLE
Batch-stream `mlr seqgen` output for head-friendliness

### DIFF
--- a/pkg/transformers/aaa_chain_transformer.go
+++ b/pkg/transformers/aaa_chain_transformer.go
@@ -202,6 +202,16 @@ func runSingleTransformer(
 	options *cli.TOptions,
 ) {
 
+	if streamingProducer, ok := recordTransformer.(StreamingProducer); ok {
+		// e.g. seqgen: drain the single upstream batch (the lone
+		// end-of-stream marker sent by the NoInput reader) so the reader
+		// goroutine isn't blocked, then let the producer generate and flush
+		// its own output directly. See StreamingProducer.
+		<-inputRecordChannel
+		streamingProducer.ProduceStream(outputRecordChannel, inputDownstreamDoneChannel, outputDownstreamDoneChannel)
+		return
+	}
+
 	done := false
 	for !done {
 		recordsAndContexts := <-inputRecordChannel

--- a/pkg/transformers/aaa_record_transformer.go
+++ b/pkg/transformers/aaa_record_transformer.go
@@ -26,6 +26,25 @@ type RecordTransformer interface {
 	) error
 }
 
+// StreamingProducer is implemented by transformers that generate their own
+// output independent of (and potentially unbounded relative to) their input
+// -- currently only seqgen. Ordinary Transform implementations accumulate
+// output in memory and hand it back to the caller for a single channel-send;
+// that works because they're invoked once per input record, with the reader
+// interleaving sends across many batches. seqgen has no such interleaving --
+// with IgnoresInput it's invoked exactly once, with nothing to stop it from
+// building its entire output in memory before anything downstream (e.g. mlr
+// head) ever runs. ProduceStream instead writes directly and repeatedly to
+// outputRecordChannel in bounded batches, checking inputDownstreamDoneChannel
+// between batches, mirroring pseudo_reader_gen.go. See ChainTransformer.
+type StreamingProducer interface {
+	ProduceStream(
+		outputRecordChannel chan<- []*types.RecordAndContext,
+		inputDownstreamDoneChannel <-chan bool,
+		outputDownstreamDoneChannel chan<- bool,
+	)
+}
+
 type RecordTransformerFunc func(
 	inrecAndContext *types.RecordAndContext,
 	outputRecordsAndContexts *[]*types.RecordAndContext, // list of *types.RecordAndContext

--- a/pkg/transformers/seqgen.go
+++ b/pkg/transformers/seqgen.go
@@ -180,6 +180,10 @@ func NewTransformerSeqgen(
 	}, nil
 }
 
+// Transform satisfies RecordTransformer. In normal operation seqgen is
+// driven via ProduceStream (see StreamingProducer) instead, since
+// ChainTransformer special-cases any transformer implementing that
+// interface. This is kept as a correct, if non-streaming, fallback.
 func (tr *TransformerSeqgen) Transform(
 	inrecAndContext *types.RecordAndContext,
 	outputRecordsAndContexts *[]*types.RecordAndContext, // list of *types.RecordAndContext
@@ -195,22 +199,13 @@ func (tr *TransformerSeqgen) Transform(
 	context := types.NewNilContext()
 	context.UpdateForStartOfFile("seqgen")
 
-	keepGoing := true
 	for {
-
-		// See ChainTransformer. If a downstream transformer is discarding all
-		// further input -- e.g. head -n 10 -- and if no interverning
-		// transformer is interested either, then we should break out of our
-		// for loop.  This way 'mlr seqgen --stop 1000000000 then head -n 10'
-		// finishes quickly.
 		select {
 		case b := <-inputDownstreamDoneChannel:
 			outputDownstreamDoneChannel <- b
-			keepGoing = false
+			*outputRecordsAndContexts = append(*outputRecordsAndContexts, types.NewEndOfStreamMarker(context))
+			return nil
 		default:
-		}
-		if !keepGoing {
-			break
 		}
 
 		tr.mdone = tr.doneComparator(counter, tr.stop)
@@ -232,4 +227,65 @@ func (tr *TransformerSeqgen) Transform(
 
 	*outputRecordsAndContexts = append(*outputRecordsAndContexts, types.NewEndOfStreamMarker(context))
 	return nil
+}
+
+// ProduceStream implements StreamingProducer. Unlike Transform, which must
+// return its entire output in one shot -- unusable for a NoInput verb like
+// seqgen, since nothing downstream can run until that single return happens
+// -- this writes bounded batches directly to outputRecordChannel, checking
+// inputDownstreamDoneChannel between batches. This is what lets 'mlr seqgen
+// --stop 1000000000 then head -n 10' finish quickly instead of generating
+// (and OOMing on) the entire sequence before head ever sees a record.
+// Mirrors pkg/input/pseudo_reader_gen.go, which solves the same problem for
+// 'mlr --from gen'.
+func (tr *TransformerSeqgen) ProduceStream(
+	outputRecordChannel chan<- []*types.RecordAndContext,
+	inputDownstreamDoneChannel <-chan bool,
+	outputDownstreamDoneChannel chan<- bool,
+) {
+	counter := tr.start
+	context := types.NewNilContext()
+	context.UpdateForStartOfFile("seqgen")
+
+	recordsPerBatch := int64(cli.DEFAULT_RECORDS_PER_BATCH)
+	batch := make([]*types.RecordAndContext, 0, recordsPerBatch)
+
+	for {
+		tr.mdone = tr.doneComparator(counter, tr.stop)
+		done, _ := tr.mdone.GetBoolValue()
+		if done {
+			break
+		}
+
+		outrec := mlrval.NewMlrmapAsRecord()
+		outrec.PutCopy(tr.fieldName, counter)
+
+		context.UpdateForInputRecord()
+		batch = append(batch, types.NewRecordAndContext(outrec, context))
+
+		counter = bifs.BIF_plus_binary(counter, tr.step)
+
+		if int64(len(batch)) >= recordsPerBatch {
+			outputRecordChannel <- batch
+			batch = make([]*types.RecordAndContext, 0, recordsPerBatch)
+
+			// See if downstream transformers will be ignoring further data
+			// (e.g. mlr head -n 10). If so, stop generating. Checked only
+			// between batches to avoid goroutine-scheduler thrash. Even
+			// though downstream won't use any more real records, it still
+			// needs the end-of-stream marker to know to stop reading and
+			// drain cleanly -- so that's sent below rather than returning
+			// directly from here.
+			select {
+			case b := <-inputDownstreamDoneChannel:
+				outputDownstreamDoneChannel <- b
+				outputRecordChannel <- []*types.RecordAndContext{types.NewEndOfStreamMarker(context)}
+				return
+			default:
+			}
+		}
+	}
+
+	batch = append(batch, types.NewEndOfStreamMarker(context))
+	outputRecordChannel <- batch
 }


### PR DESCRIPTION
## Problem

`mlr seqgen --stop 1000000000 then head` was OOMing instead of finishing in milliseconds, despite `seqgen.go` already containing an early-exit mechanism (and an explanatory comment) intended for exactly this case.

## Root cause

`TransformerSeqgen.Transform()` looped internally and appended every generated record to an in-memory slice, sending it downstream in a *single* channel send only after the whole loop finished (or exhausted `--stop`). The loop polled `inputDownstreamDoneChannel` via a non-blocking `select` on every iteration, but that channel could never have data: `head`'s goroutine can't run — and therefore can't send its "I'm done, stop producing" signal — until it receives its *first* batch from seqgen, which can't happen until seqgen's one and only `Transform()` call returns. It's a chicken-and-egg deadlock on the polling side: seqgen keeps hitting the `default` case forever while it single-mindedly builds a slice toward `--stop` (up to OOM).

This only affects `seqgen` because it's the only verb whose entire output is produced by one uninterrupted `Transform()` call with no batch boundaries (`IgnoresInput: true` means it's fed exactly one upstream batch: a lone end-of-stream marker). Ordinary verbs interleave via the reader's ~500-record batches, giving `head` many chances to run and signal done well before things get out of hand.

## Fix

Added a `StreamingProducer` interface (`pkg/transformers/aaa_record_transformer.go`) that `ChainTransformer` special-cases in `runSingleTransformer` (`pkg/transformers/aaa_chain_transformer.go`): if a transformer implements it, the chain drains the transformer's single upstream batch and then hands it direct, repeated write access to the real output channel, instead of the usual accumulate-then-return-once contract.

`TransformerSeqgen` implements `ProduceStream`, generating and flushing in batches of 500 (`cli.DEFAULT_RECORDS_PER_BATCH`), checking the downstream-done channel between batches — the same pattern already used correctly by `pkg/input/pseudo_reader_gen.go` (the `mlr --from gen` pseudo-reader) to solve the identical problem on the reader side. `Transform()` itself is left in place (now correctly sending an end-of-stream marker on the done-channel-signaled exit path too) as a fallback so `*TransformerSeqgen` still satisfies `RecordTransformer`, even though the chain no longer calls it in practice.

One non-obvious wrinkle caught during testing: on receiving the downstream-done signal mid-generation, `ProduceStream` must still forward an end-of-stream-marker batch before returning — an earlier version of the fix returned immediately after forwarding the done signal, which left `head`'s goroutine blocked forever waiting for a batch that would never arrive (deadlock, not OOM, but still a hang).

## Testing

- `mlr seqgen --stop 1000000000 then head -n 5` now returns instantly instead of OOMing.
- Verified small/finite `seqgen` output (below and exactly at the 500-record batch boundary), negative step, `then cat then head`, and grouped `head -g` (which never signals done, so this only confirms no regression — it's still bounded by `--stop`).
- `make dev` (fmt, build, `go vet`, unit tests, regression tests — 4789 cases including `verb-seqgen`) and `make lint` pass.

## Known gaps

- `StreamingProducer` is currently only implemented by `seqgen`; `head` and `tee` still use their existing special-cased handling within the normal `Transform()`/batch flow, since they don't have the same "single unbounded call" problem.
