### PR TITLE
Identify LICENSE.txt as BSD-2-Clause for GitHub licensee

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,7 @@
+BSD 2-Clause License
+
+SPDX-License-Identifier: BSD-2-Clause
+
 Copyright (c) 2015- John Kerl
 
 All rights reserved.


### PR DESCRIPTION
Fixes #2240

Adds a `BSD 2-Clause License` title and `SPDX-License-Identifier: BSD-2-Clause` so GitHub's licensee can classify the repo. Redistribution terms, disclaimer, and the personal-vs-employer note are unchanged.

John asked for this one-file PR on the issue.